### PR TITLE
mirror to both 5ff1252 and 77ef3c5

### DIFF
--- a/ethereum/contracts/zksync/Config.sol
+++ b/ethereum/contracts/zksync/Config.sol
@@ -121,3 +121,7 @@ uint256 constant MAX_NEW_FACTORY_DEPS = $(MAX_NEW_FACTORY_DEPS);
 
 /// @dev The L2 gasPricePerPubdata required to be used in bridges.
 uint256 constant REQUIRED_L2_GAS_PRICE_PER_PUBDATA = $(REQUIRED_L2_GAS_PRICE_PER_PUBDATA);
+
+/// @dev The mask which should be applied to the packed batch and L2 block timestamp in order
+/// to obtain the L2 block timestamp. Applying this mask is equivalent to calculating modulo 2**128
+uint256 constant PACKED_L2_BLOCK_TIMESTAMP_MASK = 0xffffffffffffffffffffffffffffffff;

--- a/ethereum/scripts/deploy-erc20.ts
+++ b/ethereum/scripts/deploy-erc20.ts
@@ -43,6 +43,7 @@ async function deployToken(token: TokenDescription, wallet: Wallet): Promise<Tok
             await erc20.mint(testWallet.address, parseEther('3000000000'));
         }
     }
+
     token.address = erc20.address;
 
     // Remove the unneeded field

--- a/ethereum/scripts/utils.ts
+++ b/ethereum/scripts/utils.ts
@@ -76,7 +76,7 @@ export function applyL1ToL2Alias(address: string): string {
 
 export function readBlockBootloaderBytecode() {
     const bootloaderPath = path.join(process.env.ZKSYNC_HOME as string, `etc/system-contracts/bootloader`);
-    return fs.readFileSync(`${bootloaderPath}/build/artifacts/proved_block.yul/proved_block.yul.zbin`);
+    return fs.readFileSync(`${bootloaderPath}/build/artifacts/proved_batch.yul/proved_batch.yul.zbin`);
 }
 
 export function readSystemContractsBytecode(fileName: string) {

--- a/ethereum/test/unit_tests/l2-upgrade.test.spec.ts
+++ b/ethereum/test/unit_tests/l2-upgrade.test.spec.ts
@@ -23,7 +23,8 @@ import {
     StoredBlockInfo,
     CommitBlockInfo,
     L2_SYSTEM_CONTEXT_ADDRESS,
-    L2_BOOTLOADER_ADDRESS
+    L2_BOOTLOADER_ADDRESS,
+    packBatchTimestampAndBlockTimestamp
 } from './utils';
 import * as ethers from 'ethers';
 import { BigNumber, BigNumberish, BytesLike } from 'ethers';
@@ -640,10 +641,10 @@ interface L2ToL1Log {
     value: string;
 }
 
-function contextLog(timestamp: BigNumberish, prevBlockHash: BytesLike): L2ToL1Log {
+function contextLog(timestamp: number, prevBlockHash: BytesLike): L2ToL1Log {
     return {
         sender: L2_SYSTEM_CONTEXT_ADDRESS,
-        key: ethers.utils.hexlify(timestamp),
+        key: packBatchTimestampAndBlockTimestamp(timestamp, timestamp),
         value: ethers.utils.hexlify(prevBlockHash)
     };
 }

--- a/ethereum/test/unit_tests/utils.ts
+++ b/ethereum/test/unit_tests/utils.ts
@@ -87,6 +87,13 @@ export function genesisStoredBlockInfo(): StoredBlockInfo {
     };
 }
 
+// Packs the batch timestamp and block timestamp and returns the 32-byte hex string
+// which should be used for the "key" field of the L2->L1 system context log.
+export function packBatchTimestampAndBlockTimestamp(batchTimestamp: number, blockTimestamp: number): string {
+    const packedNum = BigNumber.from(batchTimestamp).shl(128).or(BigNumber.from(blockTimestamp));
+    return ethers.utils.hexZeroPad(ethers.utils.hexlify(packedNum), 32);
+}
+
 export interface StoredBlockInfo {
     blockNumber: BigNumberish;
     blockHash: BytesLike;
@@ -100,7 +107,7 @@ export interface StoredBlockInfo {
 
 export interface CommitBlockInfo {
     blockNumber: BigNumberish;
-    timestamp: BigNumberish;
+    timestamp: number;
     indexRepeatedStorageChanges: BigNumberish;
     newStateRoot: BytesLike;
     numberOfLayer1Txs: BigNumberish;


### PR DESCRIPTION
Mirror to the most recent version:
77ef3c5583772d0431836f19cd9367d365991d72

(it is also equivalent to 5ff1252d35b95113bc1478fe966d23f1bb4b6a33 - that was a non-squashed commit on private repo).