### PR TITLE
Fix: replaced hardhat run with ts-node

### DIFF
--- a/zksync/package.json
+++ b/zksync/package.json
@@ -34,8 +34,8 @@
     "build": "hardhat compile",
     "clean": "hardhat clean",
     "verify": "hardhat run src/verify.ts",
-    "deploy-testnet-paymaster": "hardhat run src/deployTestnetPaymaster.ts",
-    "deploy-force-deploy-upgrader": "hardhat run src/deployForceDeployUpgrader.ts",
+    "deploy-testnet-paymaster": "ts-node src/deployTestnetPaymaster.ts",
+    "deploy-force-deploy-upgrader": "ts-node src/deployForceDeployUpgrader.ts",
     "publish-bridge-preimages": "hardhat run src/publish-bridge-preimages.ts",
     "deploy-l2-weth": "ts-node src/deployL2Weth.ts",
     "upgrade-l2-erc20-contract": "ts-node src/upgradeL2BridgeImpl.ts"

--- a/zksync/package.json
+++ b/zksync/package.json
@@ -36,7 +36,7 @@
     "verify": "hardhat run src/verify.ts",
     "deploy-testnet-paymaster": "ts-node src/deployTestnetPaymaster.ts",
     "deploy-force-deploy-upgrader": "ts-node src/deployForceDeployUpgrader.ts",
-    "publish-bridge-preimages": "hardhat run src/publish-bridge-preimages.ts",
+    "publish-bridge-preimages": "ts-node src/publish-bridge-preimages.ts",
     "deploy-l2-weth": "ts-node src/deployL2Weth.ts",
     "upgrade-l2-erc20-contract": "ts-node src/upgradeL2BridgeImpl.ts"
   },


### PR DESCRIPTION
The scripts are created as 'commander' commands, and if executed with hardhat run won't accept the parameters and will throw an error. Changing to 'ts-node' executes them properly.

Merging to main - as the PR is only touching the scripts and not the contracts.