### PR TITLE
Fix README.md lint

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,3 +1,3 @@
-## Tool for generating `Verifier.sol` using json Verification key
+# Tool for generating `Verifier.sol` using json Verification key
 
 `cargo run --bin zksync_verifier_contract_generator --release -- --input_path /path/to/scheduler_verification_key.json --output_path /path/to/Verifier.sol`


### PR DESCRIPTION
First line should always be a top-level heading.