### PR TITLE
Use local provider for tests

### DIFF
--- a/ethereum/test/unit_tests/executor_test.spec.ts
+++ b/ethereum/test/unit_tests/executor_test.spec.ts
@@ -167,7 +167,7 @@ describe(`Executor tests`, function () {
 
     describe(`Commiting functionality`, async function () {
         before(async () => {
-            currentTimestamp = (await hardhat.ethers.providers.getDefaultProvider().getBlock(`latest`)).timestamp;
+            currentTimestamp = (await owner.provider.getBlock(`latest`)).timestamp;
             newCommitBlockInfo = {
                 blockNumber: 1,
                 timestamp: currentTimestamp,


### PR DESCRIPTION
# What ❔

Use the hardhat provider instead of the default provider by ethers.

## Why ❔

The default provider by ethers queries information about an external chain.

## Checklist

- [+] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [+] Tests for the changes have been added / updated.
- [+] Documentation comments have been added / updated.
- [+] Code has been formatted via `zk fmt` and `zk lint`.
