### PR TITLE
Shift public input by 4 bytes

### DIFF
--- a/ethereum/contracts/zksync/Config.sol
+++ b/ethereum/contracts/zksync/Config.sol
@@ -62,7 +62,7 @@ uint256 constant COMMIT_TIMESTAMP_APPROXIMATION_DELTA = $$(
 );
 
 /// @dev Bit mask to apply for verifier public input before verifying.
-uint256 constant INPUT_MASK = $$(~uint256(0) >> 8);
+uint256 constant INPUT_MASK = $$(~uint256(0) >> 32);
 
 /// @dev The maximum number of L2 gas that a user can request for an L2 transaction
 uint256 constant L2_TX_MAX_GAS_LIMIT = $(L2_TX_MAX_GAS_LIMIT);


### PR DESCRIPTION
# What ❔

Shift public input by 4 bytes

## Why ❔

Needed for correct public input generation [here](https://github.com/matter-labs/era-contracts/blob/f06a58360a2b8e7129f64413998767ac169d1efd/ethereum/contracts/zksync/facets/Executor.sol#L396)

## Checklist

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
