### PR TITLE
Remove test script indirection

### DIFF
--- a/ethereum/package.json
+++ b/ethereum/package.json
@@ -49,7 +49,7 @@
   "scripts": {
     "build": "hardhat compile",
     "clean": "hardhat clean",
-    "test": "CONTRACT_TESTS=1 yarn hardhat test test/unit_tests/*.spec.ts --network hardhat",
+    "test": "CONTRACT_TESTS=1 hardhat test test/unit_tests/*.spec.ts --network hardhat",
     "test:foundry": "hardhat solpp && forge test",
     "test:fork": "CONTRACT_TESTS=1 TEST_CONTRACTS_FORK=1 yarn run hardhat test test/unit_tests/*.fork.ts --network hardhat",
     "coverage:foundry": "hardhat solpp && forge coverage",


### PR DESCRIPTION
# What ❔

Removes a `test` script indirection to call hardhat directly

## Why ❔

Otherwise `zk test l2-contracts` run from `zksync-era` fails with 

```
HardhatError: HH12: Trying to use a non-local installation of Hardhat, which is not supported.
Please install Hardhat locally using npm or Yarn, and try again.
```

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
