### PR TITLE
fix: add payable for forceDeploy

### DIFF
--- a/zksync/contracts/ForceDeployUpgrader.sol
+++ b/zksync/contracts/ForceDeployUpgrader.sol
@@ -11,6 +11,6 @@ contract ForceDeployUpgrader {
     /// @notice A function that performs force deploy
     /// @param _forceDeployments The force deployments to perform.
     function forceDeploy(IContractDeployer.ForceDeployment[] calldata _forceDeployments) external payable {
-        IContractDeployer(DEPLOYER_SYSTEM_CONTRACT).forceDeployOnAddresses(_forceDeployments);
+        IContractDeployer(DEPLOYER_SYSTEM_CONTRACT).forceDeployOnAddresses{value: msg.value}(_forceDeployments);
     }
 }

--- a/zksync/contracts/ForceDeployUpgrader.sol
+++ b/zksync/contracts/ForceDeployUpgrader.sol
@@ -10,7 +10,7 @@ import {IContractDeployer, DEPLOYER_SYSTEM_CONTRACT} from "./L2ContractHelper.so
 contract ForceDeployUpgrader {
     /// @notice A function that performs force deploy
     /// @param _forceDeployments The force deployments to perform.
-    function forceDeploy(IContractDeployer.ForceDeployment[] calldata _forceDeployments) external {
+    function forceDeploy(IContractDeployer.ForceDeployment[] calldata _forceDeployments) external payable {
         IContractDeployer(DEPLOYER_SYSTEM_CONTRACT).forceDeployOnAddresses(_forceDeployments);
     }
 }

--- a/zksync/contracts/L2ContractHelper.sol
+++ b/zksync/contracts/L2ContractHelper.sol
@@ -44,7 +44,7 @@ interface IContractDeployer {
 
     /// @notice This method is to be used only during an upgrade to set bytecodes on specific addresses.
     /// @param _deployParams A set of parameters describing force deployment.
-    function forceDeployOnAddresses(ForceDeployment[] calldata _deployParams) external;
+    function forceDeployOnAddresses(ForceDeployment[] calldata _deployParams) external payable;
 
     /// @notice Creates a new contract at a determined address using the `CREATE2` salt on L2
     /// @param _salt a unique value to create the deterministic address of the new contract
@@ -54,7 +54,7 @@ interface IContractDeployer {
         bytes32 _salt,
         bytes32 _bytecodeHash,
         bytes calldata _input
-    ) external;
+    ) external payable returns (address);
 }
 
 /**


### PR DESCRIPTION
# What ❔
* updated the IContractDeployer interface: made the create2 and forceDeployOnAddresses payable
* made the forceDeploy function payable

## Why ❔
In the era-system-contracts the ContractDeployer's create2 and forceDeployOnAddresses functions are payable (https://github.com/matter-labs/era-system-contracts/blob/dev/contracts/ContractDeployer.sol), therefore updated the interface and made the forceDeploy function payable.

## Checklist
- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] ~Tests for the changes have been added / updated.~
- [x] ~Documentation comments have been added / updated.~
- [x] ~Code has been formatted via `zk fmt` and `zk lint`.~
