### PR TITLE
feat: add event for setDepositLimit

### DIFF
--- a/ethereum/contracts/common/AllowList.sol
+++ b/ethereum/contracts/common/AllowList.sol
@@ -129,6 +129,7 @@ contract AllowList is IAllowList, Ownable2Step {
     function setDepositLimit(address _l1Token, bool _depositLimitation, uint256 _depositCap) external onlyOwner {
         tokenDeposit[_l1Token].depositLimitation = _depositLimitation;
         tokenDeposit[_l1Token].depositCap = _depositCap;
+        emit UpdateDepositLimit(_l1Token, _depositLimitation, _depositCap);
     }
 
     /// @dev Get deposit limit data of a token

--- a/ethereum/contracts/common/interfaces/IAllowList.sol
+++ b/ethereum/contracts/common/interfaces/IAllowList.sol
@@ -13,6 +13,9 @@ interface IAllowList {
     /// @notice Permission to call is changed
     event UpdateCallPermission(address indexed caller, address indexed target, bytes4 indexed functionSig, bool status);
 
+    /// @notice Deposit limit of a token is changed
+    event UpdateDepositLimit(address indexed l1Token, bool depositLimitation, uint256 depositCap);
+
     /// @notice Type of access to a specific contract includes three different modes
     /// @param Closed No one has access to the contract
     /// @param SpecialAccessOnly Any address with granted special access can interact with a contract (see `hasSpecialAccessToCall`)

--- a/ethereum/test/foundry/unit/concrete/AllowList/AccessMode/DepositLimit.t.sol
+++ b/ethereum/test/foundry/unit/concrete/AllowList/AccessMode/DepositLimit.t.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.8.17;
 
+import {Vm} from "forge-std/Test.sol";
 import {AccessModeTest} from "./_AccessMode_Shared.t.sol";
 import {IAllowList} from "../../../../../../cache/solpp-generated-contracts/common/interfaces/IAllowList.sol";
 
@@ -30,5 +31,31 @@ contract DepositLimitTest is AccessModeTest {
 
         assertEq(deposit.depositLimitation, false, "depositLimitation should be false");
         assertEq(deposit.depositCap, 0, "depositCap should be 0");
+    }
+
+    function test_UpdateDepositLimitEvent() public {
+        vm.startPrank(owner);
+
+        vm.recordLogs();
+        allowList.setDepositLimit(l1token, true, 1000);
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        assertEq(entries.length, 1);
+        assertEq(entries[0].topics.length, 2);
+        assertEq(
+            entries[0].topics[0],
+            keccak256("UpdateDepositLimit(address,bool,uint256)"),
+            "received event should be correct"
+        );
+        assertEq(
+            entries[0].topics[1],
+            bytes32(uint256(uint160(l1token))),
+            "received l1Token address should be correct"
+        );
+        assertEq(
+            entries[0].data,
+            abi.encode(true, 1000),
+            "received depositLimitation and depositCap should be correct"
+        );
     }
 }


### PR DESCRIPTION
# What ❔
Created the `UpdateDepositLimit` event and emitting it at the end of the `setDepositLimit` function.

## Why ❔
To make deposit limit changes trackable for off-chain clients.

## Checklist
- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] ~Documentation comments have been added / updated.~
- [x] Code has been formatted and linted via `yarn prettier:write` and `yarn lint:fix`.
