### PR TITLE
Fix block verification

### DIFF
--- a/ethereum/contracts/zksync/facets/Executor.sol
+++ b/ethereum/contracts/zksync/facets/Executor.sol
@@ -364,7 +364,7 @@ contract ExecutorFacet is Base, IExecutor {
 
     function _verifyProof(uint256[] memory proofPublicInput, ProofInput calldata _proof) internal view {
         // We can only process 1 batch proof at a time.
-        require(_proof.serializedProof.length == 1, "t4");
+        require(proofPublicInput.length == 1, "t4");
 
         bool successVerifyProof = s.verifier.verify(
             proofPublicInput,


### PR DESCRIPTION
# What ❔

Ensure that `proofPublicInput` is equal to 1, not the proof's length itself

## Why ❔

For correctness of the execution

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
