### PR TITLE
feat: Check the deposit parameter of the L1Bridge contract.

### DIFF
--- a/ethereum/contracts/bridge/L1ERC20Bridge.sol
+++ b/ethereum/contracts/bridge/L1ERC20Bridge.sol
@@ -181,7 +181,6 @@ contract L1ERC20Bridge is IL1Bridge, IL1BridgeLegacy, AllowListed, ReentrancyGua
         uint256 _l2TxGasPerPubdataByte,
         address _refundRecipient
     ) public payable nonReentrant senderCanCallFunction(allowList) returns (bytes32 l2TxHash) {
-        require(l2Bridge != address(0), "L2 bridge is not yet deployed");
         require(_l2Receiver != address(0), "L2 receiver address cannot be zero");
         require(_l2TxGasLimit != 0, "L2 gas limit cannot be zero");
         require(_amount != 0, "2T"); // empty deposit amount

--- a/ethereum/contracts/bridge/L1ERC20Bridge.sol
+++ b/ethereum/contracts/bridge/L1ERC20Bridge.sol
@@ -181,6 +181,9 @@ contract L1ERC20Bridge is IL1Bridge, IL1BridgeLegacy, AllowListed, ReentrancyGua
         uint256 _l2TxGasPerPubdataByte,
         address _refundRecipient
     ) public payable nonReentrant senderCanCallFunction(allowList) returns (bytes32 l2TxHash) {
+        require(l2Bridge != address(0), "L2 bridge is not yet deployed");
+        require(_l2Receiver != address(0), "L2 receiver address cannot be zero");
+        require(_l2TxGasLimit != 0, "L2 gas limit cannot be zero");
         require(_amount != 0, "2T"); // empty deposit amount
         uint256 amount = _depositFunds(msg.sender, IERC20(_l1Token), _amount);
         require(amount == _amount, "1T"); // The token has non-standard transfer logic

--- a/ethereum/contracts/bridge/L1WethBridge.sol
+++ b/ethereum/contracts/bridge/L1WethBridge.sol
@@ -164,7 +164,6 @@ contract L1WethBridge is IL1Bridge, AllowListed, ReentrancyGuard {
         uint256 _l2TxGasPerPubdataByte,
         address _refundRecipient
     ) external payable nonReentrant senderCanCallFunction(allowList) returns (bytes32 txHash) {
-        require(l2Bridge != address(0), "L2 bridge is not yet deployed");
         require(_l2Receiver != address(0), "L2 receiver address cannot be zero");
         require(_l2TxGasLimit != 0, "L2 gas limit cannot be zero");
         require(_l1Token == l1WethAddress, "Invalid L1 token address");

--- a/ethereum/contracts/bridge/L1WethBridge.sol
+++ b/ethereum/contracts/bridge/L1WethBridge.sol
@@ -164,6 +164,9 @@ contract L1WethBridge is IL1Bridge, AllowListed, ReentrancyGuard {
         uint256 _l2TxGasPerPubdataByte,
         address _refundRecipient
     ) external payable nonReentrant senderCanCallFunction(allowList) returns (bytes32 txHash) {
+        require(l2Bridge != address(0), "L2 bridge is not yet deployed");
+        require(_l2Receiver != address(0), "L2 receiver address cannot be zero");
+        require(_l2TxGasLimit != 0, "L2 gas limit cannot be zero");
         require(_l1Token == l1WethAddress, "Invalid L1 token address");
         require(_amount != 0, "Amount cannot be zero");
 

--- a/ethereum/test/unit_tests/l1_erc20_bridge_test.spec.ts
+++ b/ethereum/test/unit_tests/l1_erc20_bridge_test.spec.ts
@@ -138,6 +138,38 @@ describe("L1ERC20Bridge tests", function () {
     expect(revertReason).equal("2T");
   });
 
+  it("Should not allow address(0) receiver", async () => {
+    const revertReason = await getCallRevertReason(
+      l1ERC20Bridge
+        .connect(randomSigner)
+        .deposit(
+          ethers.constants.AddressZero,
+          testnetERC20TokenContract.address,
+          100,
+          1,
+          0,
+          ethers.constants.AddressZero
+        )
+    );
+    expect(revertReason).equal("L2 receiver address cannot be zero");
+  });
+
+  it("Should not allow zero gasLimit", async () => {
+    const revertReason = await getCallRevertReason(
+      l1ERC20Bridge
+        .connect(randomSigner)
+        .deposit(
+          await randomSigner.getAddress(),
+          testnetERC20TokenContract.address,
+          100,
+          0,
+          0,
+          ethers.constants.AddressZero
+        )
+    );
+    expect(revertReason).equal("L2 gas limit cannot be zero");
+  });
+
   it("Should deposit successfully", async () => {
     const depositorAddress = await randomSigner.getAddress();
     await depositERC20(

--- a/ethereum/test/unit_tests/l1_erc20_bridge_test.spec.ts
+++ b/ethereum/test/unit_tests/l1_erc20_bridge_test.spec.ts
@@ -130,7 +130,7 @@ describe("L1ERC20Bridge tests", function () {
           await randomSigner.getAddress(),
           testnetERC20TokenContract.address,
           0,
-          0,
+          1,
           0,
           ethers.constants.AddressZero
         )

--- a/ethereum/test/unit_tests/l1_weth_bridge_test.spec.ts
+++ b/ethereum/test/unit_tests/l1_weth_bridge_test.spec.ts
@@ -162,7 +162,7 @@ describe("WETH Bridge tests", () => {
           await randomSigner.getAddress(),
           await bridgeProxy.l1WethAddress(),
           0,
-          0,
+          1,
           0,
           ethers.constants.AddressZero
         )

--- a/ethereum/test/unit_tests/l1_weth_bridge_test.spec.ts
+++ b/ethereum/test/unit_tests/l1_weth_bridge_test.spec.ts
@@ -171,6 +171,40 @@ describe("WETH Bridge tests", () => {
     expect(revertReason).equal("Amount cannot be zero");
   });
 
+  it("Should not allow address(0) receiver", async () => {
+    const revertReason = await getCallRevertReason(
+      bridgeProxy
+        .connect(randomSigner)
+        .deposit(
+          ethers.constants.AddressZero,
+          await bridgeProxy.l1WethAddress(),
+          100,
+          1,
+          0,
+          ethers.constants.AddressZero
+        )
+    );
+
+    expect(revertReason).equal("L2 receiver address cannot be zero");
+  });
+
+  it("Should not allow zero gasLimit", async () => {
+    const revertReason = await getCallRevertReason(
+      bridgeProxy
+        .connect(randomSigner)
+        .deposit(
+          await randomSigner.getAddress(),
+          await bridgeProxy.l1WethAddress(),
+          100,
+          0,
+          0,
+          ethers.constants.AddressZero
+        )
+    );
+
+    expect(revertReason).equal("L2 gas limit cannot be zero");
+  });
+
   it("Should deposit successfully", async () => {
     await l1Weth.connect(randomSigner).deposit({ value: 100 });
     await (await l1Weth.connect(randomSigner).approve(bridgeProxy.address, 100)).wait();


### PR DESCRIPTION
# What ❔

Check the deposit parameter of the L1Bridge contract:
1. Check whether the receiver address is address(0)
2. Check whether the gasLimit is address(0)

## Why ❔
If the receiver's address is address(0), the transaction is meaningless, and the gasLimit should not be 0. In the original code, the address of the receiver and the number of gasLimit were not checked, so I added this check.


## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
