### PR TITLE
Upgrade zksolc version to 1.3.17

### DIFF
--- a/zksync/hardhat.config.ts
+++ b/zksync/hardhat.config.ts
@@ -13,7 +13,7 @@ if (!process.env.CHAIN_ETH_NETWORK) {
 
 export default {
   zksolc: {
-    version: "1.3.14",
+    version: "1.3.17",
     compilerSource: "binary",
     settings: {
       isSystem: true,


### PR DESCRIPTION
# What ❔

Upgrading zksolc version to 1.3.17

## Why ❔

Prior to 1.13.16, there is no binary available for linux-arm64 which is breaking the `zk init` or `hyperchain init` script 
https://github.com/matter-labs/zksolc-bin/tree/main/linux-arm64

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
