### PR TITLE
Fix comment for getting the latest unprocessed priority transaction

### DIFF
--- a/ethereum/contracts/zksync/facets/Getters.sol
+++ b/ethereum/contracts/zksync/facets/Getters.sol
@@ -57,8 +57,10 @@ contract GettersFacet is Base, IGetters, ILegacyGetters {
         return s.priorityQueue.getTotalPriorityTxs();
     }
 
-    /// @notice Returns zero if and only if no operations were processed from the queue
-    /// @notice Reverts if there are no unprocessed priority transactions
+    /// @notice The function that returns the first unprocessed priority transaction.
+    /// @dev Returns zero if and only if no operations were processed from the queue.
+    /// @dev If all the transactions were processed, it will return the last processed index, so
+    /// in case exactly *unprocessed* transactions are needed, one should check that getPriorityQueueSize() is greater than 0.
     /// @return Index of the oldest priority operation that wasn't processed yet
     function getFirstUnprocessedPriorityTx() external view returns (uint256) {
         return s.priorityQueue.getFirstUnprocessedPriorityTx();


### PR DESCRIPTION
# What ❔

Fixing the comment about retrieving the latest unprocessed priority transaction

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
