### PR TITLE
fix: outdated link to foundry config docs

### DIFF
--- a/l1-contracts/foundry.toml
+++ b/l1-contracts/foundry.toml
@@ -5,4 +5,4 @@ libs = ['node_modules', 'lib']
 cache_path = 'cache-forge'
 test = 'test/foundry'
 
-# See more config options https://github.com/foundry-rs/foundry/tree/master/config
+# See more config options https://github.com/foundry-rs/foundry/tree/master/crates/config


### PR DESCRIPTION
# What ❔

I've found an outdated link pointing to foundry config documentation. This PR replaces the outdated link with a working link.

## Why ❔

To keep external resources approachable.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Documentation comments have been added / updated.
