### PR TITLE
support for convenient bridging

### DIFF
--- a/l2-contracts/contracts/bridge/L2ERC20Bridge.sol
+++ b/l2-contracts/contracts/bridge/L2ERC20Bridge.sol
@@ -31,6 +31,9 @@ contract L2ERC20Bridge is IL2Bridge, Initializable {
     /// @dev A mapping l2 token address => l1 token address
     mapping(address => address) public override l1TokenAddress;
 
+    /// @dev Address of the exchange smart contract. Any funds deposited to L2 will be transferred to the user main account under in this smart contract
+    address public exchangeAddress;
+
     /// @dev Contract is expected to be used as proxy implementation.
     /// @dev Disable the initialization to prevent Parity hack.
     constructor() {
@@ -48,6 +51,13 @@ contract L2ERC20Bridge is IL2Bridge, Initializable {
         address l2StandardToken = address(new L2StandardERC20{salt: bytes32(0)}());
         l2TokenBeacon = new UpgradeableBeacon{salt: bytes32(0)}(l2StandardToken);
         l2TokenBeacon.transferOwnership(_governor);
+    }
+
+    /// @notice Set the address of GRVT smart contracts that can move the funds from user EOA to their exchange account. This can only be called once after the bridge is deployed
+    /// TODO: make this contract ownable, only allow the owner to call this function
+    function setExchangeAddress(address _exchangeAddress) external {
+        require(_exchangeAddress != address(0), "grvt@");
+        exchangeAddress = _exchangeAddress;
     }
 
     /// @notice Finalize the deposit and mint funds
@@ -85,10 +95,11 @@ contract L2ERC20Bridge is IL2Bridge, Initializable {
 
     /// @dev Deploy and initialize the L2 token for the L1 counterpart
     function _deployL2Token(address _l1Token, bytes calldata _data) internal returns (address) {
+                require(exchangeAddress != address(0), "grvt@");
         bytes32 salt = _getCreate2Salt(_l1Token);
 
         BeaconProxy l2Token = _deployBeaconProxy(salt);
-        L2StandardERC20(address(l2Token)).bridgeInitialize(_l1Token, _data);
+        L2StandardERC20(address(l2Token)).bridgeInitialize(_l1Token, _data, exchangeAddress);
 
         return address(l2Token);
     }

--- a/l2-contracts/contracts/bridge/L2StandardERC20.sol
+++ b/l2-contracts/contracts/bridge/L2StandardERC20.sol
@@ -32,6 +32,10 @@ contract L2StandardERC20 is ERC20PermitUpgradeable, IL2StandardToken {
     /// @dev Address of the L1 token that can be deposited to mint this L2 token
     address public override l1Address;
 
+    // Up to 3 parameters can be indexed.
+    // Indexed parameters helps you filter the logs by the indexed parameter
+    event FundExchangeAccount(address indexed account, uint256 amount);
+
     /// @dev Contract is expected to be used as proxy implementation.
     constructor() {
         // Disable initialization to prevent Parity hack.
@@ -43,11 +47,13 @@ contract L2StandardERC20 is ERC20PermitUpgradeable, IL2StandardToken {
     /// @param _l1Address Address of the L1 token that can be deposited to mint this L2 token
     /// @param _data The additional data that the L1 bridge provide for initialization.
     /// In this case, it is packed `name`/`symbol`/`decimals` of the L1 token.
-    function bridgeInitialize(address _l1Address, bytes memory _data) external initializer {
+    function bridgeInitialize(address _l1Address, bytes memory _data, address _exchangeAddress) external initializer {
         require(_l1Address != address(0), "in6"); // Should be non-zero address
         l1Address = _l1Address;
 
         l2Bridge = msg.sender;
+
+        exchangeAddress = _exchangeAddress;
 
         // We parse the data exactly as they were created on the L1 bridge
         (bytes memory nameBytes, bytes memory symbolBytes, bytes memory decimalsBytes) = abi.decode(
@@ -109,6 +115,16 @@ contract L2StandardERC20 is ERC20PermitUpgradeable, IL2StandardToken {
     function bridgeMint(address _to, uint256 _amount) external override onlyBridge {
         _mint(_to, _amount);
         emit BridgeMint(_to, _amount);
+    }
+
+    /// @dev Move the user's fund to their main account under the exchange contract
+    /// @dev We don't directly move the fund in bridgeMint as we want GRVT's backend to be notified of the deposit first. Only after our risk engine has approved the deposit, we move the fund to the user's exchange account by calling this function. This way, we can prevent a state divergent where user balance is updated on chain before it is updated off chain.
+    // TODO: add a record of how much balance we can moved from user's EOA to exchange account
+    function fundExchangeAccount(address _from, uint256 _amount) external {
+        require(_from != exchangeAddress, "invalid address");
+        require(exchangeAddress != address(0), "invalid grvt address");
+        _transfer(_from, exchangeAddress, _amount);
+        emit FundExchangeAccount(_from, _amount);
     }
 
     /// @dev Burn tokens from a given account.


### PR DESCRIPTION
# What ❔
Amend the L2 bridge to allow moving funds to exchange contract account

## Why ❔
As an exchange, GRVT wants users to be able to funds their account to trade as soon as possible.
Currently, the stock L2 ERC20 bridge and ERC20 Token contracts only allow user to bridge funds from L1 to L2 EOA.
And thus, we will need user to initiate a transaction to send their funds in L2 EOA to GRVT Exchange contract

This is not ideal since every extra step in the funding process is another hurdle that turns user away. This PR propose a change in the 2 contracts below that allows user's funds to be moved to their exchange contract's account
- L2StandardERC20
- L2ERC20Bridge

This PR is a draft that demonstrates how this could be done. Further consideration about security and upgradability needs to be taken care of in future PRs

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
