### PR TITLE
fix(scripts): moved hardhat to be the first import

### DIFF
--- a/l1-contracts/scripts/deploy-erc20.ts
+++ b/l1-contracts/scripts/deploy-erc20.ts
@@ -1,4 +1,6 @@
+// hardhat import should be the first import in the file
 import * as hardhat from "hardhat";
+
 import "@nomiclabs/hardhat-ethers";
 import { Command } from "commander";
 import { Wallet } from "ethers";

--- a/l1-contracts/scripts/deploy-testkit.ts
+++ b/l1-contracts/scripts/deploy-testkit.ts
@@ -1,4 +1,6 @@
+// hardhat import should be the first import in the file
 import * as hardhat from "hardhat";
+
 import "@nomiclabs/hardhat-ethers";
 import { Command } from "commander";
 import { ethers, Wallet } from "ethers";

--- a/l1-contracts/scripts/deploy-testnet-token.ts
+++ b/l1-contracts/scripts/deploy-testnet-token.ts
@@ -1,8 +1,10 @@
+// hardhat import should be the first import in the file
+import * as hardhat from "hardhat";
+
 import "@nomiclabs/hardhat-ethers";
 import { ArgumentParser } from "argparse";
 import { Wallet } from "ethers";
 import * as fs from "fs";
-import * as hardhat from "hardhat";
 import * as path from "path";
 import { web3Provider } from "./utils";
 

--- a/l1-contracts/scripts/deploy-withdrawal-helpers.ts
+++ b/l1-contracts/scripts/deploy-withdrawal-helpers.ts
@@ -1,7 +1,9 @@
 // This script deploys the contracts required both for production and
 // for testing of the contracts required for the `withdrawal-helpers` library
 
+// hardhat import should be the first import in the file
 import * as hardhat from "hardhat";
+
 import "@nomiclabs/hardhat-ethers";
 import { ethers } from "ethers";
 import * as fs from "fs";

--- a/l1-contracts/scripts/migrate-governance.ts
+++ b/l1-contracts/scripts/migrate-governance.ts
@@ -1,10 +1,12 @@
 /// Temporary script that generated the needed calldata for the migration of the governance.
 
+// hardhat import should be the first import in the file
+import * as hre from "hardhat";
+
 import { Command } from "commander";
 import { BigNumber, ethers, Wallet } from "ethers";
 import { formatUnits, parseUnits } from "ethers/lib/utils";
 import * as fs from "fs";
-import * as hre from "hardhat";
 import { Deployer } from "../src.ts/deploy";
 import { applyL1ToL2Alias, getAddressFromEnv, getNumberFromEnv, web3Provider } from "./utils";
 

--- a/l1-contracts/scripts/read-variable.ts
+++ b/l1-contracts/scripts/read-variable.ts
@@ -1,6 +1,8 @@
+// hardhat import should be the first import in the file
+import * as hre from "hardhat";
+
 import { Command } from "commander";
 import { BigNumber, ethers } from "ethers";
-import * as hre from "hardhat";
 import { web3Provider } from "./utils";
 
 const provider = web3Provider();

--- a/l1-contracts/scripts/revert-reason.ts
+++ b/l1-contracts/scripts/revert-reason.ts
@@ -1,7 +1,9 @@
+// hardhat import should be the first import in the file
+import * as hardhat from "hardhat";
+
 import * as chalk from "chalk";
 import { ethers } from "ethers";
 import { Interface } from "ethers/lib/utils";
-import * as hardhat from "hardhat";
 import { web3Url } from "./utils";
 
 const erc20BridgeInterface = new Interface(hardhat.artifacts.readArtifactSync("L1ERC20Bridge").abi);

--- a/l1-contracts/scripts/verify.ts
+++ b/l1-contracts/scripts/verify.ts
@@ -1,4 +1,6 @@
+// hardhat import should be the first import in the file
 import * as hardhat from "hardhat";
+
 import { deployedAddressesFromEnv } from "../scripts/utils";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/l2-contracts/src/deployForceDeployUpgrader.ts
+++ b/l2-contracts/src/deployForceDeployUpgrader.ts
@@ -1,10 +1,12 @@
+// hardhat import should be the first import in the file
+import * as hre from "hardhat";
+
 import { Command } from "commander";
 import { ethers, Wallet } from "ethers";
 import { computeL2Create2Address, create2DeployFromL1, getNumberFromEnv } from "./utils";
 import { web3Provider } from "../../l1-contracts/scripts/utils";
 import * as fs from "fs";
 import * as path from "path";
-import * as hre from "hardhat";
 
 const provider = web3Provider();
 const testConfigPath = path.join(process.env.ZKSYNC_HOME as string, "etc/test_config/constant");

--- a/l2-contracts/src/deployTestnetPaymaster.ts
+++ b/l2-contracts/src/deployTestnetPaymaster.ts
@@ -1,10 +1,12 @@
+// hardhat import should be the first import in the file
+import * as hre from "hardhat";
+
 import { Command } from "commander";
 import { ethers, Wallet } from "ethers";
 import { computeL2Create2Address, create2DeployFromL1, getNumberFromEnv } from "./utils";
 import { web3Provider } from "../../l1-contracts/scripts/utils";
 import * as fs from "fs";
 import * as path from "path";
-import * as hre from "hardhat";
 
 const provider = web3Provider();
 const testConfigPath = path.join(process.env.ZKSYNC_HOME as string, "etc/test_config/constant");

--- a/l2-contracts/src/publish-bridge-preimages.ts
+++ b/l2-contracts/src/publish-bridge-preimages.ts
@@ -1,10 +1,12 @@
+// hardhat import should be the first import in the file
+import * as hre from "hardhat";
+
 import { Command } from "commander";
 import { Wallet, ethers } from "ethers";
 import * as fs from "fs";
 import { Deployer } from "../../l1-contracts/src.ts/deploy";
 import * as path from "path";
 import { getNumberFromEnv, web3Provider } from "../../l1-contracts/scripts/utils";
-import * as hre from "hardhat";
 import { REQUIRED_L2_GAS_PRICE_PER_PUBDATA } from "./utils";
 
 const PRIORITY_TX_MAX_GAS_LIMIT = getNumberFromEnv("CONTRACTS_PRIORITY_TX_MAX_GAS_LIMIT");

--- a/l2-contracts/src/upgradeBridgeImpl.ts
+++ b/l2-contracts/src/upgradeBridgeImpl.ts
@@ -1,8 +1,10 @@
+// hardhat import should be the first import in the file
+import * as hre from "hardhat";
+
 import "@nomiclabs/hardhat-ethers";
 import { Command } from "commander";
 import { Wallet, ethers, BigNumber } from "ethers";
 import * as fs from "fs";
-import * as hre from "hardhat";
 import * as path from "path";
 import { Provider } from "zksync-web3";
 import { REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT } from "zksync-web3/build/src/utils";

--- a/l2-contracts/src/verify.ts
+++ b/l2-contracts/src/verify.ts
@@ -1,3 +1,4 @@
+// hardhat import should be the first import in the file
 import * as hardhat from "hardhat";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/system-contracts/scripts/deploy-preimages.ts
+++ b/system-contracts/scripts/deploy-preimages.ts
@@ -1,3 +1,4 @@
+// hardhat import should be the first import in the file
 import * as hre from "hardhat";
 
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";

--- a/system-contracts/scripts/preprocess-bootloader.ts
+++ b/system-contracts/scripts/preprocess-bootloader.ts
@@ -1,3 +1,4 @@
+// hardhat import should be the first import in the file
 import * as hre from "hardhat";
 
 import { ethers } from "ethers";
@@ -126,7 +127,7 @@ function createTestFramework(tests: string[]): string {
   let testFramework = `
     let test_id:= mload(0)
 
-    switch test_id 
+    switch test_id
     case 0 {
         testing_totalTests(${tests.length})
     }

--- a/system-contracts/scripts/preprocess-bootloader.ts
+++ b/system-contracts/scripts/preprocess-bootloader.ts
@@ -127,7 +127,7 @@ function createTestFramework(tests: string[]): string {
   let testFramework = `
     let test_id:= mload(0)
 
-    switch test_id
+    switch test_id 
     case 0 {
         testing_totalTests(${tests.length})
     }

--- a/system-contracts/scripts/utils.ts
+++ b/system-contracts/scripts/utils.ts
@@ -1,3 +1,4 @@
+// hardhat import should be the first import in the file
 import * as hre from "hardhat";
 
 import type { Deployer } from "@matterlabs/hardhat-zksync-deploy";


### PR DESCRIPTION
# What ❔
Moved the hardhat import to the top of the imports in scripts.

## Why ❔
When it was imported later, it caused some of the scripts to fail.

## Checklist
- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] ~~Tests for the changes have been added / updated.~~
- [ ] ~~Documentation comments have been added / updated.~~
