### PR TITLE
Fix: early exit in `onlyVerifier` branch

### DIFF
--- a/l1-contracts/scripts/deploy.ts
+++ b/l1-contracts/scripts/deploy.ts
@@ -49,6 +49,11 @@ async function main() {
         verbose: true,
       });
 
+      if (cmd.onlyVerifier) {
+        await deployer.deployVerifier(create2Salt, { gasPrice, nonce });
+        return;
+      }
+
       // Create2 factory already deployed on the public networks, only deploy it on local node
       if (process.env.CHAIN_ETH_NETWORK === "localhost") {
         await deployer.deployCreate2Factory({ gasPrice, nonce });
@@ -56,11 +61,6 @@ async function main() {
 
         await deployer.deployMulticall3(create2Salt, { gasPrice, nonce });
         nonce++;
-      }
-
-      if (cmd.onlyVerifier) {
-        await deployer.deployVerifier(create2Salt, { gasPrice, nonce });
-        return;
       }
 
       // Deploy diamond upgrade init contract if needed


### PR DESCRIPTION
Right now `--only-verifier` still deploys CREATE2 Factory and Multicall3.
In other words, every `zk init` run deploys two copies of the same contracts.
This commit fixes the issue.