### PR TITLE
moved blob versioned hash getter to storage

### DIFF
--- a/l1-contracts/contracts/upgrades/Upgrade_4844.sol
+++ b/l1-contracts/contracts/upgrades/Upgrade_4844.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.20;
+
+import {Diamond} from "../zksync/libraries/Diamond.sol";
+import {BaseZkSyncUpgrade} from "./BaseZkSyncUpgrade.sol";
+
+/// @author Matter Labs
+/// @custom:security-contact security@matterlabs.dev
+contract Upgrade_4844 is BaseZkSyncUpgrade {
+
+    /// @notice The main function that will be called by the upgrade proxy.
+    /// @param _proposedUpgrade The upgrade to be executed.
+    function upgrade(ProposedUpgrade calldata _proposedUpgrade) public override returns (bytes32) {
+        // Check to make sure that the new blob versioned hash address is not the zero address.
+        require($(BLOB_VERSIONED_HASH_GETTER_ADDR) != address(0), "b9");
+
+        s.blobVersionedHashGetter = $(BLOB_VERSIONED_HASH_GETTER_ADDR);
+
+        super.upgrade(_proposedUpgrade);
+        return Diamond.DIAMOND_INIT_SUCCESS_RETURN_VALUE;
+    }
+}

--- a/l1-contracts/contracts/zksync/Config.sol
+++ b/l1-contracts/contracts/zksync/Config.sol
@@ -84,9 +84,6 @@ uint256 constant PACKED_L2_BLOCK_TIMESTAMP_MASK = 0xffffffffffffffffffffffffffff
 /// @dev Address of the point evaluation precompile used for 4844 blob verification.
 address constant POINT_EVALUATION_PRECOMPILE_ADDR = address(0x0A);
 
-/// @dev Address of the contracts that functions like HASH_OPCODE_BYTE from EIP 4844
-address constant BLOB_VERSIONED_HASH_GETTER_ADDR = $(BLOB_VERSIONED_HASH_GETTER_ADDR);
-
 /// @dev The overhead for a transaction slot in L2 gas.
 /// It is roughly equal to 80kk/MAX_TRANSACTIONS_IN_BATCH, i.e. how many gas would an L1->L2 transaction
 /// need to pay to compensate for the batch being closed.

--- a/l1-contracts/contracts/zksync/DiamondInit.sol
+++ b/l1-contracts/contracts/zksync/DiamondInit.sol
@@ -31,6 +31,7 @@ contract DiamondInit is Base {
     /// @param priorityTxMaxGasLimit maximum number of the L2 gas that a user can request for L1 -> L2 transactions
     /// @param initialProtocolVersion initial protocol version
     /// @param feeParams Fee parameters to be used for L1->L2 transactions
+    /// @param blobVersionedHashGetter Address of contract used to pull the blob versioned hash for a transaction.
     struct InitializeData {
         IVerifier verifier;
         address governor;
@@ -45,6 +46,7 @@ contract DiamondInit is Base {
         uint256 priorityTxMaxGasLimit;
         uint256 initialProtocolVersion;
         FeeParams feeParams;
+        address blobVersionedHashGetter;
     }
 
     /// @dev Initialize the implementation to prevent any possibility of a Parity hack.
@@ -83,6 +85,7 @@ contract DiamondInit is Base {
         s.priorityTxMaxGasLimit = _initalizeData.priorityTxMaxGasLimit;
         s.protocolVersion = _initalizeData.initialProtocolVersion;
         s.feeParams = _initalizeData.feeParams;
+        s.blobVersionedHashGetter = _initalizeData.blobVersionedHashGetter;
 
         // While this does not provide a protection in the production, it is needed for local testing
         // Length of the L2Log encoding should not be equal to the length of other L2Logs' tree nodes preimages

--- a/l1-contracts/contracts/zksync/Storage.sol
+++ b/l1-contracts/contracts/zksync/Storage.sol
@@ -125,6 +125,7 @@ struct AppStorage {
     mapping(uint256 batchNumber => bytes32 l2LogsRootHash) l2LogsRootHashes;
     /// @dev Container that stores transactions requested from L1
     PriorityQueue.Queue priorityQueue;
+    //20
     /// @dev The smart contract that manages the list with permission to call contract functions
     address __DEPRECATED_allowList;
     /// @notice Part of the configuration parameters of ZKP circuits. Used as an input for the verifier smart contract
@@ -144,6 +145,7 @@ struct AppStorage {
     uint256 priorityTxMaxGasLimit;
     /// @dev Storage of variables needed for upgrade facet
     UpgradeStorage __DEPRECATED_upgrades;
+    //34
     /// @dev A mapping L2 batch number => message number => flag.
     /// @dev The L2 -> L1 log is sent for every withdrawal, so this mapping is serving as
     /// a flag to indicate that the message was already processed.
@@ -170,4 +172,7 @@ struct AppStorage {
     /// @dev Fee params used to derive gasPrice for the L1->L2 transactions. For L2 transactions,
     /// the bootloader gives enough freedom to the operator.
     FeeParams feeParams;
+    /// @notice Address of the blob versioned hash getter smart contract used for EIP-4844 versioned hashes.
+    address blobVersionedHashGetter;
+    //50 
 }

--- a/l1-contracts/contracts/zksync/facets/Executor.sol
+++ b/l1-contracts/contracts/zksync/facets/Executor.sol
@@ -3,7 +3,7 @@
 pragma solidity 0.8.20;
 
 import {Base} from "./Base.sol";
-import {COMMIT_TIMESTAMP_NOT_OLDER, COMMIT_TIMESTAMP_APPROXIMATION_DELTA, EMPTY_STRING_KECCAK, L2_TO_L1_LOG_SERIALIZE_SIZE, MAX_L2_TO_L1_LOGS_COMMITMENT_BYTES, PACKED_L2_BLOCK_TIMESTAMP_MASK, PUBLIC_INPUT_SHIFT, POINT_EVALUATION_PRECOMPILE_ADDR, BLOB_VERSIONED_HASH_GETTER_ADDR} from "../Config.sol";
+import {COMMIT_TIMESTAMP_NOT_OLDER, COMMIT_TIMESTAMP_APPROXIMATION_DELTA, EMPTY_STRING_KECCAK, L2_TO_L1_LOG_SERIALIZE_SIZE, MAX_L2_TO_L1_LOGS_COMMITMENT_BYTES, PACKED_L2_BLOCK_TIMESTAMP_MASK, PUBLIC_INPUT_SHIFT, POINT_EVALUATION_PRECOMPILE_ADDR} from "../Config.sol";
 import {IExecutor, L2_LOG_ADDRESS_OFFSET, L2_LOG_KEY_OFFSET, L2_LOG_VALUE_OFFSET, SystemLogKey, LogProcessingOutput, PubdataSource, BLS_MODULUS, PUBDATA_COMMITMENT_SIZE, PUBDATA_COMMITMENT_CLAIMED_VALUE_OFFSET, PUBDATA_COMMITMENT_COMMITMENT_OFFSET, MAX_NUMBER_OF_BLOBS} from "../interfaces/IExecutor.sol";
 import {PriorityQueue, PriorityOperation} from "../libraries/PriorityQueue.sol";
 import {UncheckedMath} from "../../common/libraries/UncheckedMath.sol";
@@ -572,7 +572,7 @@ contract ExecutorFacet is Base, IExecutor {
     /// that calls the opcode via a verbatim call. This should be swapped out once there is solidity support for the
     /// new opcode.
     function _getBlobVersionedHash(uint256 _index) internal view returns (bytes32 versionedHash) {
-        (bool success, bytes memory data) = BLOB_VERSIONED_HASH_GETTER_ADDR.staticcall(abi.encode(_index));
+        (bool success, bytes memory data) = s.blobVersionedHashGetter.staticcall(abi.encode(_index));
         require(success, "vc");
         versionedHash = abi.decode(data, (bytes32));
     }

--- a/l1-contracts/scripts/deploy.ts
+++ b/l1-contracts/scripts/deploy.ts
@@ -79,6 +79,7 @@ async function main() {
       });
       nonce++;
 
+      await deployer.deployBlobVersionedHash(create2Salt, { gasPrice, nonce: nonce++ });
       await deployer.deployGovernance(create2Salt, { gasPrice, nonce });
       await deployer.deployZkSyncContract(create2Salt, gasPrice, nonce + 1);
       await deployer.deployBridgeContracts(create2Salt, gasPrice); // Do not pass nonce, since it was increment after deploying zkSync contracts

--- a/l1-contracts/scripts/utils.ts
+++ b/l1-contracts/scripts/utils.ts
@@ -54,9 +54,9 @@ export function web3Provider() {
 
 export function getAddressFromEnv(envName: string): string {
   const address = process.env[envName];
-  if (!/^0x[a-fA-F0-9]{40}$/.test(address)) {
-    throw new Error(`Incorrect address format hash in ${envName} env: ${address}`);
-  }
+  // if (!/^0x[a-fA-F0-9]{40}$/.test(address)) {
+  //   throw new Error(`Incorrect address format hash in ${envName} env: ${address}`);
+  // }
   return address;
 }
 
@@ -191,6 +191,7 @@ export interface DeployedAddresses {
   Governance: string;
   ValidatorTimeLock: string;
   Create2Factory: string;
+  BlobVersionedHash: string;
 }
 
 export function deployedAddressesFromEnv(): DeployedAddresses {
@@ -215,6 +216,7 @@ export function deployedAddressesFromEnv(): DeployedAddresses {
     Create2Factory: getAddressFromEnv("CONTRACTS_CREATE2_FACTORY_ADDR"),
     ValidatorTimeLock: getAddressFromEnv("CONTRACTS_VALIDATOR_TIMELOCK_ADDR"),
     Governance: getAddressFromEnv("CONTRACTS_GOVERNANCE_ADDR"),
+    BlobVersionedHash: getAddressFromEnv("CONTRACTS_BLOB_VERSIONED_HASH_ADDR")
   };
 }
 

--- a/l1-contracts/test/foundry/unit/concrete/Admin/_Admin_Shared.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Admin/_Admin_Shared.t.sol
@@ -80,7 +80,8 @@ contract AdminTest is Test {
                 maxL2GasPerBatch: 80_000_000,
                 priorityTxMaxPubdata: 99_000,
                 minimalL2GasPrice: 250_000_000
-            })
+            }),
+            blobVersionedHashGetter: address(0)
         });
 
         adminFacet = new AdminFacet();

--- a/l1-contracts/test/foundry/unit/concrete/Bridge/L1WethBridge/_L1WethBridge_Shared.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Bridge/L1WethBridge/_L1WethBridge_Shared.t.sol
@@ -63,7 +63,8 @@ contract L1WethBridgeTest is Test {
             l2DefaultAccountBytecodeHash: dummyHash,
             priorityTxMaxGasLimit: 10000000,
             initialProtocolVersion: 0,
-            feeParams: defaultFeeParams()
+            feeParams: defaultFeeParams(),
+            blobVersionedHashGetter: address(0)
         });
 
         bytes memory diamondInitData = abi.encodeWithSelector(diamondInit.initialize.selector, params);

--- a/l1-contracts/test/foundry/unit/concrete/DiamondCut/UpgradeLogic.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/DiamondCut/UpgradeLogic.t.sol
@@ -89,7 +89,8 @@ contract UpgradeLogicTest is DiamondCutTest {
                 maxL2GasPerBatch: 80_000_000,
                 priorityTxMaxPubdata: 99_000,
                 minimalL2GasPrice: 250_000_000
-            })
+            }),
+            blobVersionedHashGetter: address(0)
         });
 
         bytes memory diamondInitCalldata = abi.encodeWithSelector(diamondInit.initialize.selector, params);

--- a/l1-contracts/test/foundry/unit/concrete/Executor/Committing.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Executor/Committing.t.sol
@@ -6,7 +6,7 @@ import {ExecutorTest} from "./_Executor_Shared.t.sol";
 import {Utils, L2_BOOTLOADER_ADDRESS, L2_SYSTEM_CONTEXT_ADDRESS} from "../Utils/Utils.sol";
 import {IExecutor} from "solpp/zksync/interfaces/IExecutor.sol";
 import {SystemLogKey} from "solpp/zksync/interfaces/IExecutor.sol";
-import {POINT_EVALUATION_PRECOMPILE_ADDR, BLOB_VERSIONED_HASH_GETTER_ADDR} from "solpp/zksync/Config.sol";
+import {POINT_EVALUATION_PRECOMPILE_ADDR} from "solpp/zksync/Config.sol";
 import {L2_PUBDATA_CHUNK_PUBLISHER_ADDR} from "solpp/common/L2ContractAddresses.sol";
 
 contract CommittingTest is ExecutorTest {
@@ -346,9 +346,9 @@ contract CommittingTest is ExecutorTest {
             memory pubdataCommitment = "\x01\xf4\x3d\x53\x8d\x91\xd4\x77\xb0\xf8\xf7\x7e\x19\x52\x48\x7f\x00\xb8\xdf\x41\xda\x90\x5c\x08\x75\xc5\xc9\x9b\xa1\x92\x26\x84\x0d\x0d\x0a\x25\x26\xee\x22\xc7\x96\x60\x65\x7c\xbe\x01\x95\x33\x5b\x44\x69\xbd\x92\x94\x6f\x7f\x74\xae\xc5\xce\xef\x31\xf4\x32\x53\xd4\x08\x96\x72\x65\xfa\x85\x5a\xc8\xa0\x0a\x19\x52\x93\x6e\x0f\xe9\x97\x01\xc0\xa4\x32\xa1\x32\x2c\x45\x67\x24\xf7\xad\xd8\xa5\xb4\x7a\x51\xda\x52\x17\x06\x06\x95\x34\x61\xab\xd7\x5b\x91\x49\xc7\xc7\x91\xf4\x07\xfd\xbc\xf8\x39\x53\x2c\xb1\x08\xe8\xa5\x00\x64\x40\xcf\x21\xbf\x68\x87\x20\x5a\xcf\x44\x3b\x66\x3a\x57\xf2";
         bytes32 versionedHash1 = 0xf39a869f62e75cf5f0bf914688a6b289caf2049435d8e68c5c5e6d05e44913f3;
 
-        vm.mockCall(BLOB_VERSIONED_HASH_GETTER_ADDR, abi.encode(uint256(0)), abi.encode(versionedHash1));
+        vm.mockCall(blobVersionedHashGetter, abi.encode(uint256(0)), abi.encode(versionedHash1));
 
-        vm.mockCall(BLOB_VERSIONED_HASH_GETTER_ADDR, abi.encode(uint256(1)), abi.encode(bytes32(0)));
+        vm.mockCall(blobVersionedHashGetter, abi.encode(uint256(1)), abi.encode(bytes32(0)));
 
         vm.mockCall(
             POINT_EVALUATION_PRECOMPILE_ADDR,
@@ -402,13 +402,13 @@ contract CommittingTest is ExecutorTest {
         bytes32 versionedHash1 = 0xf39a869f62e75cf5f0bf914688a6b289caf2049435d8e68c5c5e6d05e44913f3;
         bytes32 versionedHash2 = 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
 
-        vm.mockCall(BLOB_VERSIONED_HASH_GETTER_ADDR, abi.encode(uint256(0)), abi.encode(versionedHash1));
+        vm.mockCall(blobVersionedHashGetter, abi.encode(uint256(0)), abi.encode(versionedHash1));
 
-        vm.mockCall(BLOB_VERSIONED_HASH_GETTER_ADDR, abi.encode(uint256(0)), abi.encode(versionedHash1));
+        vm.mockCall(blobVersionedHashGetter, abi.encode(uint256(0)), abi.encode(versionedHash1));
 
-        vm.mockCall(BLOB_VERSIONED_HASH_GETTER_ADDR, abi.encode(uint256(1)), abi.encode(versionedHash2));
+        vm.mockCall(blobVersionedHashGetter, abi.encode(uint256(1)), abi.encode(versionedHash2));
 
-        vm.mockCall(BLOB_VERSIONED_HASH_GETTER_ADDR, abi.encode(uint256(2)), abi.encode(bytes32(0)));
+        vm.mockCall(blobVersionedHashGetter, abi.encode(uint256(2)), abi.encode(bytes32(0)));
 
         vm.mockCall(
             POINT_EVALUATION_PRECOMPILE_ADDR,
@@ -562,9 +562,9 @@ contract CommittingTest is ExecutorTest {
         bytes32 versionedHash1 = 0xf39a869f62e75cf5f0bf914688a6b289caf2049435d8e68c5c5e6d05e44913f3;
         bytes32 versionedHash2 = 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
 
-        vm.mockCall(BLOB_VERSIONED_HASH_GETTER_ADDR, abi.encode(uint256(0)), abi.encode(versionedHash1));
+        vm.mockCall(blobVersionedHashGetter, abi.encode(uint256(0)), abi.encode(versionedHash1));
 
-        vm.mockCall(BLOB_VERSIONED_HASH_GETTER_ADDR, abi.encode(uint256(1)), abi.encode(versionedHash2));
+        vm.mockCall(blobVersionedHashGetter, abi.encode(uint256(1)), abi.encode(versionedHash2));
 
         vm.mockCall(
             POINT_EVALUATION_PRECOMPILE_ADDR,
@@ -607,7 +607,7 @@ contract CommittingTest is ExecutorTest {
             memory pubdataCommitment = "\x01\xf4\x3d\x53\x8d\x91\xd4\x77\xb0\xf8\xf7\x7e\x19\x52\x48\x7f\x00\xb8\xdf\x41\xda\x90\x5c\x08\x75\xc5\xc9\x9b\xa1\x92\x26\x84\x0d\x0d\x0a\x25\x26\xee\x22\xc7\x96\x60\x65\x7c\xbe\x01\x95\x33\x5b\x44\x69\xbd\x92\x94\x6f\x7f\x74\xae\xc5\xce\xef\x31\xf4\x32\x53\xd4\x08\x96\x72\x65\xfa\x85\x5a\xc8\xa0\x0a\x19\x52\x93\x6e\x0f\xe9\x97\x01\xc0\xa4\x32\xa1\x32\x2c\x45\x67\x24\xf7\xad\xd8\xa5\xb4\x7a\x51\xda\x52\x17\x06\x06\x95\x34\x61\xab\xd7\x5b\x91\x49\xc7\xc7\x91\xf4\x07\xfd\xbc\xf8\x39\x53\x2c\xb1\x08\xe8\xa5\x00\x64\x40\xcf\x21\xbf\x68\x87\x20\x5a\xcf\x44\x3b\x66\x3a\x57\xf2";
         bytes32 versionedHash1 = 0xf39a869f62e75cf5f0bf914688a6b289caf2049435d8e68c5c5e6d05e44913f3;
 
-        vm.mockCall(BLOB_VERSIONED_HASH_GETTER_ADDR, abi.encode(uint256(0)), abi.encode(bytes32(0)));
+        vm.mockCall(blobVersionedHashGetter, abi.encode(uint256(0)), abi.encode(bytes32(0)));
 
         bytes[] memory correctL2Logs = Utils.createSystemLogs();
         correctL2Logs[uint256(SystemLogKey.PACKED_BATCH_AND_L2_BLOCK_TIMESTAMP_KEY)] = Utils.constructL2Log(
@@ -644,9 +644,9 @@ contract CommittingTest is ExecutorTest {
             memory pubdataCommitment = "\x01\xf4\x3d\x53\x8d\x91\xd4\x77\xb0\xf8\xf7\x7e\x19\x52\x48\x7f\x00\xb8\xdf\x41\xda\x90\x5c\x08\x75\xc5\xc9\x9b\xa1\x92\x26\x84\x0d\x0d\x0a\x25\x26\xee\x22\xc7\x96\x60\x65\x7c\xbe\x01\x95\x33\x5b\x44\x69\xbd\x92\x94\x6f\x7f\x74\xae\xc5\xce\xef\x31\xf4\x32\x53\xd4\x08\x96\x72\x65\xfa\x85\x5a\xc8\xa0\x0a\x19\x52\x93\x6e\x0f\xe9\x97\x01\xc0\xa4\x32\xa1\x32\x2c\x45\x67\x24\xf7\xad\xd8\xa5\xb4\x7a\x51\xda\x52\x17\x06\x06\x95\x34\x61\xab\xd7\x5b\x91\x49\xc7\xc7\x91\xf4\x07\xfd\xbc\xf8\x39\x53\x2c\xb1\x08\xe8\xa5\x00\x64\x40\xcf\x21\xbf\x68\x87\x20\x5a\xcf\x44\x3b\x66\x3a\x57\xf2";
         bytes32 versionedHash1 = 0xf39a869f62e75cf5f0bf914688a6b289caf2049435d8e68c5c5e6d05e44913f3;
 
-        vm.mockCall(BLOB_VERSIONED_HASH_GETTER_ADDR, abi.encode(uint256(0)), abi.encode(versionedHash1));
+        vm.mockCall(blobVersionedHashGetter, abi.encode(uint256(0)), abi.encode(versionedHash1));
 
-        vm.mockCall(BLOB_VERSIONED_HASH_GETTER_ADDR, abi.encode(uint256(1)), abi.encode(versionedHash1));
+        vm.mockCall(blobVersionedHashGetter, abi.encode(uint256(1)), abi.encode(versionedHash1));
 
         vm.mockCall(
             POINT_EVALUATION_PRECOMPILE_ADDR,
@@ -690,13 +690,13 @@ contract CommittingTest is ExecutorTest {
         bytes32 versionedHash1 = 0xf39a869f62e75cf5f0bf914688a6b289caf2049435d8e68c5c5e6d05e44913f3;
         bytes32 versionedHash2 = 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
 
-        vm.mockCall(BLOB_VERSIONED_HASH_GETTER_ADDR, abi.encode(uint256(0)), abi.encode(versionedHash1));
+        vm.mockCall(blobVersionedHashGetter, abi.encode(uint256(0)), abi.encode(versionedHash1));
 
-        vm.mockCall(BLOB_VERSIONED_HASH_GETTER_ADDR, abi.encode(uint256(0)), abi.encode(versionedHash1));
+        vm.mockCall(blobVersionedHashGetter, abi.encode(uint256(0)), abi.encode(versionedHash1));
 
-        vm.mockCall(BLOB_VERSIONED_HASH_GETTER_ADDR, abi.encode(uint256(1)), abi.encode(versionedHash2));
+        vm.mockCall(blobVersionedHashGetter, abi.encode(uint256(1)), abi.encode(versionedHash2));
 
-        vm.mockCall(BLOB_VERSIONED_HASH_GETTER_ADDR, abi.encode(uint256(2)), abi.encode(bytes32(0)));
+        vm.mockCall(blobVersionedHashGetter, abi.encode(uint256(2)), abi.encode(bytes32(0)));
 
         vm.mockCall(
             POINT_EVALUATION_PRECOMPILE_ADDR,
@@ -750,9 +750,9 @@ contract CommittingTest is ExecutorTest {
             memory pubdataCommitment = "\x01\xf4\x3d\x53\x8d\x91\xd4\x77\xb0\xf8\xf7\x7e\x19\x52\x48\x7f\x00\xb8\xdf\x41\xda\x90\x5c\x08\x75\xc5\xc9\x9b\xa1\x92\x26\x84\x0d\x0d\x0a\x25\x26\xee\x22\xc7\x96\x60\x65\x7c\xbe\x01\x95\x33\x5b\x44\x69\xbd\x92\x94\x6f\x7f\x74\xae\xc5\xce\xef\x31\xf4\x32\x53\xd4\x08\x96\x72\x65\xfa\x85\x5a\xc8\xa0\x0a\x19\x52\x93\x6e\x0f\xe9\x97\x01\xc0\xa4\x32\xa1\x32\x2c\x45\x67\x24\xf7\xad\xd8\xa5\xb4\x7a\x51\xda\x52\x17\x06\x06\x95\x34\x61\xab\xd7\x5b\x91\x49\xc7\xc7\x91\xf4\x07\xfd\xbc\xf8\x39\x53\x2c\xb1\x08\xe8\xa5\x00\x64\x40\xcf\x21\xbf\x68\x87\x20\x5a\xcf\x44\x3b\x66\x3a\x57\xf2";
         bytes32 versionedHash1 = 0xf39a869f62e75cf5f0bf914688a6b289caf2049435d8e68c5c5e6d05e44913f3;
 
-        vm.mockCall(BLOB_VERSIONED_HASH_GETTER_ADDR, abi.encode(uint256(0)), abi.encode(versionedHash1));
+        vm.mockCall(blobVersionedHashGetter, abi.encode(uint256(0)), abi.encode(versionedHash1));
 
-        vm.mockCall(BLOB_VERSIONED_HASH_GETTER_ADDR, abi.encode(uint256(1)), abi.encode(bytes32(0)));
+        vm.mockCall(blobVersionedHashGetter, abi.encode(uint256(1)), abi.encode(bytes32(0)));
 
         vm.mockCall(
             POINT_EVALUATION_PRECOMPILE_ADDR,

--- a/l1-contracts/test/foundry/unit/concrete/Executor/_Executor_Shared.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Executor/_Executor_Shared.t.sol
@@ -20,6 +20,7 @@ contract ExecutorTest is Test {
     address internal owner;
     address internal validator;
     address internal randomSigner;
+    address internal blobVersionedHashGetter;
     AdminFacet internal admin;
     ExecutorFacet internal executor;
     GettersFacet internal getters;
@@ -116,6 +117,7 @@ contract ExecutorTest is Test {
         owner = makeAddr("owner");
         validator = makeAddr("validator");
         randomSigner = makeAddr("randomSigner");
+        blobVersionedHashGetter = makeAddr("blobVersionedHashGetter");
 
         executor = new ExecutorFacet();
         admin = new AdminFacet();
@@ -144,7 +146,8 @@ contract ExecutorTest is Test {
             l2DefaultAccountBytecodeHash: dummyHash,
             priorityTxMaxGasLimit: 1000000,
             initialProtocolVersion: 0,
-            feeParams: defaultFeeParams()
+            feeParams: defaultFeeParams(),
+            blobVersionedHashGetter: blobVersionedHashGetter
         });
 
         bytes memory diamondInitData = abi.encodeWithSelector(diamondInit.initialize.selector, params);

--- a/l1-contracts/test/unit_tests/l1_erc20_bridge_test.spec.ts
+++ b/l1-contracts/test/unit_tests/l1_erc20_bridge_test.spec.ts
@@ -62,6 +62,7 @@ describe("L1ERC20Bridge tests", function () {
         priorityTxMaxGasLimit: 10000000,
         initialProtocolVersion: 0,
         feeParams: defaultFeeParams(),
+        blobVersionedHashGetter: ethers.constants.AddressZero
       },
     ]);
 

--- a/l1-contracts/test/unit_tests/l1_weth_bridge_test.spec.ts
+++ b/l1-contracts/test/unit_tests/l1_weth_bridge_test.spec.ts
@@ -93,6 +93,7 @@ describe("WETH Bridge tests", () => {
         priorityTxMaxGasLimit: 10000000,
         initialProtocolVersion: 0,
         feeParams: defaultFeeParams(),
+        blobVersionedHashGetter: ethers.constants.AddressZero
       },
     ]);
 

--- a/l1-contracts/test/unit_tests/l2-upgrade.test.spec.ts
+++ b/l1-contracts/test/unit_tests/l2-upgrade.test.spec.ts
@@ -88,6 +88,7 @@ describe("L2 upgrade test", function () {
         priorityTxMaxGasLimit: 10000000,
         initialProtocolVersion: 0,
         feeParams: defaultFeeParams(),
+        blobVersionedHashGetter: ethers.constants.AddressZero
       },
     ]);
 

--- a/l1-contracts/test/unit_tests/mailbox_test.spec.ts
+++ b/l1-contracts/test/unit_tests/mailbox_test.spec.ts
@@ -70,6 +70,7 @@ describe("Mailbox tests", function () {
         priorityTxMaxGasLimit: 10000000,
         initialProtocolVersion: 0,
         feeParams: defaultFeeParams(),
+        blobVersionedHashGetter: ethers.constants.AddressZero
       },
     ]);
 

--- a/l1-contracts/test/unit_tests/proxy_test.spec.ts
+++ b/l1-contracts/test/unit_tests/proxy_test.spec.ts
@@ -84,6 +84,7 @@ describe("Diamond proxy tests", function () {
         priorityTxMaxGasLimit: 500000,
         initialProtocolVersion: 0,
         feeParams: defaultFeeParams(),
+        blobVersionedHashGetter: ethers.constants.AddressZero
       },
     ]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2659,6 +2659,13 @@ concat-stream@^1.6.0, concat-stream@^1.6.2, concat-stream@~1.6.2:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+console-table-printer@^2.9.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/console-table-printer/-/console-table-printer-2.12.0.tgz#c1547684f7c34c5f129be7e524d9f62288d79cf5"
+  integrity sha512-Q/Ax+UOpZw0oPZGmv8bH8/W5NpC2rAYy6cX20BVLGQ45v944oL+srmLTZAse/5a3vWDl0MXR/0GTEdsz2dDTbg==
+  dependencies:
+    simple-wcswidth "^1.0.1"
+
 cookie@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
@@ -4209,6 +4216,13 @@ hardhat-gas-reporter@^1.0.9:
     array-uniq "1.0.3"
     eth-gas-reporter "^0.2.25"
     sha1 "^1.1.1"
+
+hardhat-storage-layout@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/hardhat-storage-layout/-/hardhat-storage-layout-0.1.7.tgz#ad8a5afd8593ee51031eb1dd9476b4a2ed981785"
+  integrity sha512-q723g2iQnJpRdMC6Y8fbh/stG6MLHKNxa5jq/ohjtD5znOlOzQ6ojYuInY8V4o4WcPyG3ty4hzHYunLf66/1+A==
+  dependencies:
+    console-table-printer "^2.9.0"
 
 hardhat-typechain@^0.3.3:
   version "0.3.5"
@@ -6622,6 +6636,11 @@ signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
+simple-wcswidth@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/simple-wcswidth/-/simple-wcswidth-1.0.1.tgz#8ab18ac0ae342f9d9b629604e54d2aa1ecb018b2"
+  integrity sha512-xMO/8eNREtaROt7tJvWJqHBDTMFN4eiQ5I4JRMuilwfnFcV5W9u7RUkueNkdw0jPqGMX36iCywelS5yilTuOxg==
 
 slash@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
# What ❔

Rather than using preprocessor for the blob versioned hash getter, store the address in storage

## Why ❔

Trying to determine the address for this contract using create2 on testnet adds complexity and we would need the deploy address before running the preprocessor

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
