### PR TITLE
ERC721 Bridge

### DIFF
--- a/l1-contracts/contracts/bridge/L1ERC721Bridge.sol
+++ b/l1-contracts/contracts/bridge/L1ERC721Bridge.sol
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.20;
+
+import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+import "./interfaces/IL1Bridge.sol";
+import "./interfaces/IL2Bridge.sol";
+import "./interfaces/IL2ERC721Bridge.sol";
+
+import "./libraries/BridgeInitializationHelper.sol";
+
+import "../zksync/interfaces/IZkSync.sol";
+import "../common/libraries/UnsafeBytes.sol";
+import "../common/libraries/L2ContractHelper.sol";
+import "../common/ReentrancyGuard.sol";
+import "../vendor/AddressAliasHelper.sol";
+
+/// @author Matter Labs
+/// @custom:security-contact security@matterlabs.dev
+/// @notice Smart contract that allows depositing ERC721 tokens from Ethereum to zkSync Era
+/// @dev It is standard implementation of ERC721 Bridge that can be used as a reference
+/// for any other custom token bridges.
+contract L1ERC721Bridge is IL1Bridge, ReentrancyGuard {
+    /// @dev zkSync smart contract that is used to operate with L2 via asynchronous L2 <-> L1 communication
+    IZkSync internal immutable zkSync;
+
+    /// @dev A mapping L2 batch number => message number => flag
+    /// @dev Used to indicate that zkSync L2 -> L1 message was already processed
+    mapping(uint256 => mapping(uint256 => bool)) public isWithdrawalFinalized;
+
+    /// @dev A mapping account => L1 token address => L2 deposit transaction hash => token ID
+    /// @dev Used for saving the deposited token ID, to claim them in case the deposit transaction will fail
+    mapping(address => mapping(address => mapping(bytes32 => uint256))) internal depositTokenIds;
+
+    /// @dev A mapping account => L1 token address => L2 deposit transaction hash => token ID => bool
+    /// @dev Used for checking that token ID is deposited, to claim them in case the deposit transaction will fail
+    mapping(address => mapping(address => mapping(bytes32 => mapping(uint256 => bool)))) internal depositTokenIdsPresent;
+
+    /// @dev The address of deployed L2 bridge counterpart
+    address public l2Bridge;
+
+    /// @dev The address that acts as a beacon for L2 tokens
+    address public l2TokenBeacon;
+
+    /// @dev The bytecode hash of the L2 token contract
+    bytes32 public l2TokenProxyBytecodeHash;
+
+    /// @dev Contract is expected to be used as proxy implementation.
+    /// @dev Initialize the implementation to prevent Parity hack.
+    constructor(IZkSync _zkSync) reentrancyGuardInitializer {
+        zkSync = _zkSync;
+    }
+
+    /// @dev Initializes a contract bridge for later use. Expected to be used in the proxy
+    /// @dev During initialization deploys L2 bridge counterpart as well as provides some factory deps for it
+    /// @param _factoryDeps A list of raw bytecodes that are needed for deployment of the L2 bridge
+    /// @notice _factoryDeps[0] == a raw bytecode of L2 bridge implementation
+    /// @notice _factoryDeps[1] == a raw bytecode of proxy that is used as L2 bridge
+    /// @notice _factoryDeps[2] == a raw bytecode of token proxy
+    /// @param _l2TokenBeacon Pre-calculated address of the L2 token upgradeable beacon
+    /// @notice At the time of the function call, it is not yet deployed in L2, but knowledge of its address
+    /// @notice is necessary for determining L2 token address by L1 address, see `l2TokenAddress(address)` function
+    /// @param _governor Address which can change L2 token implementation and upgrade the bridge
+    /// @param _deployBridgeImplementationFee How much of the sent value should be allocated to deploying the L2 bridge
+    /// implementation
+    /// @param _deployBridgeProxyFee How much of the sent value should be allocated to deploying the L2 bridge proxy
+    function initialize(
+        bytes[] calldata _factoryDeps,
+        address _l2TokenBeacon,
+        address _governor,
+        uint256 _deployBridgeImplementationFee,
+        uint256 _deployBridgeProxyFee
+    ) external payable reentrancyGuardInitializer {
+        require(_l2TokenBeacon != address(0), "nf");
+        require(_governor != address(0), "nh");
+        // We are expecting to see the exact three bytecodes that are needed to initialize the bridge
+        require(_factoryDeps.length == 3, "mk");
+        // The caller miscalculated deploy transactions fees
+        require(msg.value == _deployBridgeImplementationFee + _deployBridgeProxyFee, "fee");
+        l2TokenProxyBytecodeHash = L2ContractHelper.hashL2Bytecode(_factoryDeps[2]);
+        l2TokenBeacon = _l2TokenBeacon;
+
+        bytes32 l2BridgeImplementationBytecodeHash = L2ContractHelper.hashL2Bytecode(_factoryDeps[0]);
+        bytes32 l2BridgeProxyBytecodeHash = L2ContractHelper.hashL2Bytecode(_factoryDeps[1]);
+
+        // Deploy L2 bridge implementation contract
+        address bridgeImplementationAddr = BridgeInitializationHelper.requestDeployTransaction(
+            zkSync,
+            _deployBridgeImplementationFee,
+            l2BridgeImplementationBytecodeHash,
+            "", // Empty constructor data
+            _factoryDeps // All factory deps are needed for L2 bridge
+        );
+
+        // Prepare the proxy constructor data
+        bytes memory l2BridgeProxyConstructorData;
+        {
+            // Data to be used in delegate call to initialize the proxy
+            bytes memory proxyInitializationParams = abi.encodeCall(
+                IL2ERC721Bridge.initialize,
+                (address(this), l2TokenProxyBytecodeHash, _governor)
+            );
+            l2BridgeProxyConstructorData = abi.encode(bridgeImplementationAddr, _governor, proxyInitializationParams);
+        }
+
+        // Deploy L2 bridge proxy contract
+        l2Bridge = BridgeInitializationHelper.requestDeployTransaction(
+            zkSync,
+            _deployBridgeProxyFee,
+            l2BridgeProxyBytecodeHash,
+            l2BridgeProxyConstructorData,
+            // No factory deps are needed for L2 bridge proxy, because it is already passed in previous step
+            new bytes[](0)
+        );
+    }
+
+    /// @notice Initiates a deposit by locking token on the contract and sending the request
+    /// of processing an L2 transaction where tokens would be minted
+    /// @param _l2Receiver The account address that should receive the token on L2
+    /// @param _l1Token The L1 token address which is deposited
+    /// @param _tokenId The L1 token ID which is deposited
+    /// @param _l2TxGasLimit The L2 gas limit to be used in the corresponding L2 transaction
+    /// @param _l2TxGasPerPubdataByte The gasPerPubdataByteLimit to be used in the corresponding L2 transaction
+    /// @param _refundRecipient The address on L2 that will receive the refund for the transaction.
+    /// @dev If the L2 deposit finalization transaction fails, the `_refundRecipient` will receive the `_l2Value`.
+    /// Please note, the contract may change the refund recipient's address to eliminate sending funds to addresses
+    /// out of control.
+    /// - If `_refundRecipient` is a contract on L1, the refund will be sent to the aliased `_refundRecipient`.
+    /// - If `_refundRecipient` is set to `address(0)` and the sender has NO deployed bytecode on L1, the refund will
+    /// be sent to the `msg.sender` address.
+    /// - If `_refundRecipient` is set to `address(0)` and the sender has deployed bytecode on L1, the refund will be
+    /// sent to the aliased `msg.sender` address.
+    /// @dev The address aliasing of L1 contracts as refund recipient on L2 is necessary to guarantee that the funds
+    /// are controllable through the Mailbox, since the Mailbox applies address aliasing to the from address for the
+    /// L2 tx if the L1 msg.sender is a contract. Without address aliasing for L1 contracts as refund recipients they
+    /// would not be able to make proper L2 tx requests through the Mailbox to use or withdraw the funds from L2, and
+    /// the funds would be lost.
+    /// @return l2TxHash The L2 transaction hash of deposit finalization
+    function deposit(
+        address _l2Receiver,
+        address _l1Token,
+        uint256 _tokenId,
+        uint256 _l2TxGasLimit,
+        uint256 _l2TxGasPerPubdataByte,
+        address _refundRecipient
+    ) public payable nonReentrant returns (bytes32 l2TxHash) {
+        _depositToken(msg.sender, IERC721(_l1Token), _tokenId);
+
+        bytes memory l2TxCalldata = _getDepositL2Calldata(msg.sender, _l2Receiver, _l1Token, _tokenId);
+        // If the refund recipient is not specified, the refund will be sent to the sender of the transaction.
+        // Otherwise, the refund will be sent to the specified address.
+        // If the recipient is a contract on L1, the address alias will be applied.
+        address refundRecipient = _refundRecipient;
+        if (_refundRecipient == address(0)) {
+            refundRecipient = msg.sender != tx.origin ? AddressAliasHelper.applyL1ToL2Alias(msg.sender) : msg.sender;
+        }
+        l2TxHash = zkSync.requestL2Transaction{value: msg.value}(
+            l2Bridge,
+            0, // L2 msg.value
+            l2TxCalldata,
+            _l2TxGasLimit,
+            _l2TxGasPerPubdataByte,
+            new bytes[](0),
+            refundRecipient
+        );
+
+        // Save the deposited token ID to claim on L1 if the deposit failed on L2
+        depositTokenIds[msg.sender][_l1Token][l2TxHash] = _tokenId;
+        depositTokenIdsPresent[msg.sender][_l1Token][l2TxHash][_tokenId] = true;
+
+        emit DepositInitiated(l2TxHash, msg.sender, _l2Receiver, _l1Token, _tokenId);
+    }
+
+     /// @notice Initiates a batch deposit by locking token on the contract and sending the request
+    /// of processing an L2 transaction where tokens would be minted
+    /// @param _l2Receiver The account address that should receive the token on L2
+    /// @param _l1Token The L1 token address which is deposited
+    /// @param _tokenIds The L1 token IDs which are deposited
+    /// @param _l2TxGasLimit The L2 gas limit to be used in the corresponding L2 transaction
+    /// @param _l2TxGasPerPubdataByte The gasPerPubdataByteLimit to be used in the corresponding L2 transaction
+    /// @param _refundRecipient The address on L2 that will receive the refund for the transaction.
+    /// @return l2TxHashes The L2 transaction hashes of deposit finalization
+    function depositBatch(
+        address _l2Receiver,
+        address _l1Token,
+        uint256[] memory _tokenIds,
+        uint256 _l2TxGasLimit,
+        uint256 _l2TxGasPerPubdataByte,
+        address _refundRecipient
+    ) public payable nonReentrant returns (bytes32[] memory l2TxHashes) {
+        l2TxHashes = new bytes32[](_tokenIds.length);
+
+        for (uint256 i; i < _tokenIds.length; i++) {
+            bytes32 l2TxHash = deposit(_l2Receiver, _l1Token, _tokenIds[i], _l2TxGasLimit, _l2TxGasPerPubdataByte, _refundRecipient);
+            l2TxHashes[i] = l2TxHash;
+        }
+    }
+
+    /// @dev Transfers tokens from the depositor address to the smart contract address
+    function _depositToken(address _from, IERC721 _token, uint256 _tokenId) internal {
+        _token.transferFrom(_from, address(this), _tokenId);
+        require(_token.ownerOf(_tokenId) == address(this), "Invalid transfer"); // The token has non-standard transfer logic
+    }
+
+    /// @dev Generate a calldata for calling the ERC721 deposit finalization on the L2 bridge contract
+    function _getDepositL2Calldata(
+        address _l1Sender,
+        address _l2Receiver,
+        address _l1Token,
+        uint256 _tokenId
+    ) internal view returns (bytes memory txCalldata) {
+        bytes memory gettersData = _getERC721Getters(_l1Token);
+        (, bytes memory tokenURI) =  _l1Token.staticcall(abi.encodeCall(IERC721Metadata.tokenURI, (_tokenId)));
+
+        txCalldata = abi.encodeCall(
+            IL2Bridge.finalizeDeposit,
+            (_l1Sender, _l2Receiver, _l1Token, 0, abi.encode(_tokenId, tokenURI, gettersData))
+        );
+    }
+
+    /// @dev Receives and parses (name, symbol) from the token contract
+    function _getERC721Getters(address _token) internal view returns (bytes memory data) {
+        (, bytes memory data1) = _token.staticcall(abi.encodeCall(IERC721Metadata.name, ()));
+        (, bytes memory data2) = _token.staticcall(abi.encodeCall(IERC721Metadata.symbol, ()));
+
+        data = abi.encode(data1, data2);
+    }
+
+    /// @dev Withdraw token from the initiated deposit, that failed when finalizing on L2
+    /// @param _depositSender The address of the deposit initiator
+    /// @param _l1Token The address of the deposited L1 ERC721 token
+    /// @param _l2TxHash The L2 transaction hash of the failed deposit finalization
+    /// @param _l2BatchNumber The L2 batch number where the deposit finalization was processed
+    /// @param _l2MessageIndex The position in the L2 logs Merkle tree of the l2Log that was sent with the message
+    /// @param _l2TxNumberInBatch The L2 transaction number in a batch, in which the log was sent
+    /// @param _merkleProof The Merkle proof of the processing L1 -> L2 transaction with deposit finalization
+    function claimFailedDeposit(
+        address _depositSender,
+        address _l1Token,
+        bytes32 _l2TxHash,
+        uint256 _l2BatchNumber,
+        uint256 _l2MessageIndex,
+        uint16 _l2TxNumberInBatch,
+        bytes32[] calldata _merkleProof
+    ) external nonReentrant {
+        bool proofValid = zkSync.proveL1ToL2TransactionStatus(
+            _l2TxHash,
+            _l2BatchNumber,
+            _l2MessageIndex,
+            _l2TxNumberInBatch,
+            _merkleProof,
+            TxStatus.Failure
+        );
+        require(proofValid, "yn");
+
+        // Double mapping to avoid attack concerning token ID 0 without changing claimFailedDeposit() API
+        uint256 tokenId = depositTokenIds[_depositSender][_l1Token][_l2TxHash];
+        bool tokenIdValid = depositTokenIdsPresent[_depositSender][_l1Token][_l2TxHash][tokenId];
+        require(tokenIdValid, "Invalid token ID");
+
+        delete depositTokenIds[_depositSender][_l1Token][_l2TxHash];
+        delete depositTokenIdsPresent[_depositSender][_l1Token][_l2TxHash][tokenId];
+
+        // Withdraw token
+        IERC721(_l1Token).transferFrom(address(this), _depositSender, tokenId);
+
+        emit ClaimedFailedDeposit(_depositSender, _l1Token, tokenId);
+    }
+
+    /// @notice Finalize the withdrawal and release token
+    /// @param _l2BatchNumber The L2 batch number where the withdrawal was processed
+    /// @param _l2MessageIndex The position in the L2 logs Merkle tree of the l2Log that was sent with the message
+    /// @param _l2TxNumberInBatch The L2 transaction number in the batch, in which the log was sent
+    /// @param _message The L2 withdraw data, stored in an L2 -> L1 message
+    /// @param _merkleProof The Merkle proof of the inclusion L2 -> L1 message about withdrawal initialization
+    function finalizeWithdrawal(
+        uint256 _l2BatchNumber,
+        uint256 _l2MessageIndex,
+        uint16 _l2TxNumberInBatch,
+        bytes calldata _message,
+        bytes32[] calldata _merkleProof
+    ) external nonReentrant {
+        require(!isWithdrawalFinalized[_l2BatchNumber][_l2MessageIndex], "pw");
+
+        L2Message memory l2ToL1Message = L2Message({
+            txNumberInBatch: _l2TxNumberInBatch,
+            sender: l2Bridge,
+            data: _message
+        });
+
+        (address l1Receiver, address l1Token, uint256 tokenId) = _parseL2WithdrawalMessage(l2ToL1Message.data);
+        // Preventing the stack too deep error
+        {
+            bool success = zkSync.proveL2MessageInclusion(_l2BatchNumber, _l2MessageIndex, l2ToL1Message, _merkleProof);
+            require(success, "nq");
+        }
+
+        isWithdrawalFinalized[_l2BatchNumber][_l2MessageIndex] = true;
+        // Withdraw token
+        IERC721(l1Token).transferFrom(address(this), l1Receiver, tokenId);
+
+        emit WithdrawalFinalized(l1Receiver, l1Token, tokenId);
+    }
+
+    /// @dev Decode the withdraw message that came from L2
+    function _parseL2WithdrawalMessage(
+        bytes memory _l2ToL1message
+    ) internal pure returns (address l1Receiver, address l1Token, uint256 tokenId) {
+        // Check that the message length is correct.
+        // It should be equal to the length of the function signature + address + address + uint256 = 4 + 20 + 20 + 32 =
+        // 76 (bytes).
+        require(_l2ToL1message.length == 76, "kk");
+
+        (uint32 functionSignature, uint256 offset) = UnsafeBytes.readUint32(_l2ToL1message, 0);
+        require(bytes4(functionSignature) == this.finalizeWithdrawal.selector, "nt");
+
+        (l1Receiver, offset) = UnsafeBytes.readAddress(_l2ToL1message, offset);
+        (l1Token, offset) = UnsafeBytes.readAddress(_l2ToL1message, offset);
+        (tokenId, offset) = UnsafeBytes.readUint256(_l2ToL1message, offset);
+    }
+
+    /// @return The L2 token address that would be minted for deposit of the given L1 token
+    function l2TokenAddress(address _l1Token) public view returns (address) {
+        bytes32 constructorInputHash = keccak256(abi.encode(address(l2TokenBeacon), ""));
+        bytes32 salt = bytes32(uint256(uint160(_l1Token)));
+
+        return L2ContractHelper.computeCreate2Address(l2Bridge, salt, l2TokenProxyBytecodeHash, constructorInputHash);
+    }
+}

--- a/l1-contracts/contracts/bridge/interfaces/IL2ERC721Bridge.sol
+++ b/l1-contracts/contracts/bridge/interfaces/IL2ERC721Bridge.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.20;
+
+/// @author Matter Labs
+interface IL2ERC721Bridge {
+    function initialize(address _l1Bridge, bytes32 _l2TokenProxyBytecodeHash, address _governor) external;
+}

--- a/l1-contracts/contracts/dev-contracts/TestnetERC721Token.sol
+++ b/l1-contracts/contracts/dev-contracts/TestnetERC721Token.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.20;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+contract TestnetERC721Token is ERC721 {
+    uint8 private _decimals;
+
+    constructor(string memory name_, string memory symbol_) ERC721(name_, symbol_) {}
+
+    function mint(address _to, uint256 _tokenId) public {
+        _mint(_to, _tokenId);
+    }
+}

--- a/l1-contracts/test/unit_tests/erc721-bridge-upgrade.fork.ts
+++ b/l1-contracts/test/unit_tests/erc721-bridge-upgrade.fork.ts
@@ -1,0 +1,82 @@
+import { expect } from "chai";
+import * as hardhat from "hardhat";
+
+import type { ethers } from "ethers";
+import type { L1ERC721Bridge } from "../../typechain";
+import { L1ERC721BridgeTestFactory } from "../../typechain";
+
+import type { ITransparentUpgradeableProxy } from "../../typechain/ITransparentUpgradeableProxy";
+import { ITransparentUpgradeableProxyFactory } from "../../typechain/ITransparentUpgradeableProxyFactory";
+
+// TODO: change to the mainet config
+const L1_ERC721_BRIDGE = "0x927DdFcc55164a59E0F33918D13a2D559bC10ce7";
+const GOVERNOR_ADDRESS = "0x98591957D9741e7E7d58FC253044e0A014A3a323";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function isPromiseFailed(promise: Promise<any>): Promise<boolean> {
+  let failed = false;
+  try {
+    await promise;
+  } catch {
+    failed = true;
+  }
+  return failed;
+}
+
+describe("L1 ERC721 proxy upgrade fork test", function () {
+  const mailboxOnNewImplementation = "0x1234567890123456789012345678901234567890";
+
+  let governor: ethers.Signer;
+  let randomSigner: ethers.Signer;
+  let bridgeProxy: ITransparentUpgradeableProxy;
+  let newBridgeImplementation: L1ERC721Bridge;
+  let oldBridgeImplementationAddress: string;
+
+  before(async () => {
+    await hardhat.network.provider.request({ method: "hardhat_impersonateAccount", params: [GOVERNOR_ADDRESS] });
+    governor = await hardhat.ethers.provider.getSigner(GOVERNOR_ADDRESS);
+    await hardhat.network.provider.send("hardhat_setBalance", [GOVERNOR_ADDRESS, "0xfffffffffffffffff"]);
+
+    const signers = await hardhat.ethers.getSigners();
+    randomSigner = signers[0];
+    bridgeProxy = ITransparentUpgradeableProxyFactory.connect(L1_ERC721_BRIDGE, randomSigner);
+    oldBridgeImplementationAddress = await bridgeProxy.connect(governor).callStatic.implementation();
+
+    const l1Erc721BridgeFactory = await hardhat.ethers.getContractFactory("L1ERC721BridgeTest");
+    const l1Erc721Bridge = await l1Erc721BridgeFactory.deploy(mailboxOnNewImplementation);
+    newBridgeImplementation = L1ERC721BridgeTestFactory.connect(l1Erc721Bridge.address, l1Erc721Bridge.signer);
+  });
+
+  it("should revert on non-existed methods", async () => {
+    const bridgeProxyAsNewImplementation = L1ERC721BridgeTestFactory.connect(bridgeProxy.address, randomSigner);
+
+    const failedGetMailbox = await isPromiseFailed(bridgeProxyAsNewImplementation.getZkSyncMailbox());
+    expect(failedGetMailbox).to.be.true;
+  });
+
+  it("should upgrade", async () => {
+    await bridgeProxy.connect(governor).upgradeTo(newBridgeImplementation.address);
+  });
+
+  it("check new functions", async () => {
+    const bridgeProxyAsNewImplementation = L1ERC721BridgeTestFactory.connect(bridgeProxy.address, randomSigner);
+
+    const mailbox = await bridgeProxyAsNewImplementation.getZkSyncMailbox();
+    expect(mailbox.toLocaleLowerCase()).to.be.eq(mailboxOnNewImplementation.toLocaleLowerCase());
+  });
+
+  it("should upgrade second time", async () => {
+    const bridgeAsTransparentProxy = ITransparentUpgradeableProxyFactory.connect(bridgeProxy.address, governor);
+    await bridgeAsTransparentProxy.upgradeTo(oldBridgeImplementationAddress);
+  });
+
+  it("should revert on non-existed methods", async () => {
+    const bridgeProxyAsNewImplementation = L1ERC721BridgeTestFactory.connect(bridgeProxy.address, randomSigner);
+
+    const failedGetAllowList = await isPromiseFailed(bridgeProxyAsNewImplementation.getAllowList());
+    expect(failedGetAllowList).to.be.true;
+
+    const failedGetMailbox = await isPromiseFailed(bridgeProxyAsNewImplementation.getZkSyncMailbox());
+    expect(failedGetMailbox).to.be.true;
+  });
+});

--- a/l1-contracts/test/unit_tests/l1_erc721_bridge_test.spec.ts
+++ b/l1-contracts/test/unit_tests/l1_erc721_bridge_test.spec.ts
@@ -1,0 +1,196 @@
+import { expect } from "chai";
+import { ethers } from "ethers";
+import * as hardhat from "hardhat";
+import { REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT } from "zksync-web3/build/src/utils";
+import type { IZkSync } from "zksync-web3/build/typechain";
+import { IZkSyncFactory } from "zksync-web3/build/typechain";
+import { Action, diamondCut, facetCut } from "../../src.ts/diamondCut";
+import type { TestnetERC721Token } from "../../typechain";
+import {
+  DiamondInitFactory,
+  GettersFacetFactory,
+  MailboxFacetFactory,
+  TestnetERC721TokenFactory,
+} from "../../typechain";
+import type { IL1Bridge } from "../../typechain/IL1Bridge";
+import { IL1BridgeFactory } from "../../typechain/IL1BridgeFactory";
+import { getCallRevertReason } from "./utils";
+
+describe("L1ERC721Bridge tests", function () {
+  let owner: ethers.Signer;
+  let randomSigner: ethers.Signer;
+  let l1ERC721Bridge: IL1Bridge;
+  let erc721TestToken: TestnetERC721Token;
+  let testnetERC721TokenContract: ethers.Contract;
+  let l1Erc721BridgeContract: ethers.Contract;
+  let zksyncContract: IZkSync;
+
+  before(async () => {
+    [owner, randomSigner] = await hardhat.ethers.getSigners();
+
+    const gettersFactory = await hardhat.ethers.getContractFactory("GettersFacet");
+    const gettersContract = await gettersFactory.deploy();
+    const gettersFacet = GettersFacetFactory.connect(gettersContract.address, gettersContract.signer);
+
+    const mailboxFactory = await hardhat.ethers.getContractFactory("MailboxFacet");
+    const mailboxContract = await mailboxFactory.deploy();
+    const mailboxFacet = MailboxFacetFactory.connect(mailboxContract.address, mailboxContract.signer);
+
+    const diamondInitFactory = await hardhat.ethers.getContractFactory("DiamondInit");
+    const diamondInitContract = await diamondInitFactory.deploy();
+    const diamondInit = DiamondInitFactory.connect(diamondInitContract.address, diamondInitContract.signer);
+
+    const dummyHash = new Uint8Array(32);
+    dummyHash.set([1, 0, 0, 1]);
+    const dummyAddress = ethers.utils.hexlify(ethers.utils.randomBytes(20));
+    const diamondInitData = diamondInit.interface.encodeFunctionData("initialize", [
+      {
+        verifier: dummyAddress,
+        governor: await owner.getAddress(),
+        admin: await owner.getAddress(),
+        genesisBatchHash: ethers.constants.HashZero,
+        genesisIndexRepeatedStorageChanges: 0,
+        genesisBatchCommitment: ethers.constants.HashZero,
+        verifierParams: {
+          recursionCircuitsSetVksHash: ethers.constants.HashZero,
+          recursionLeafLevelVkHash: ethers.constants.HashZero,
+          recursionNodeLevelVkHash: ethers.constants.HashZero,
+        },
+        zkPorterIsAvailable: false,
+        l2BootloaderBytecodeHash: dummyHash,
+        l2DefaultAccountBytecodeHash: dummyHash,
+        priorityTxMaxGasLimit: 10000000,
+        initialProtocolVersion: 0,
+      },
+    ]);
+
+    const facetCuts = [
+      facetCut(gettersFacet.address, gettersFacet.interface, Action.Add, false),
+      facetCut(mailboxFacet.address, mailboxFacet.interface, Action.Add, true),
+    ];
+
+    const diamondCutData = diamondCut(facetCuts, diamondInit.address, diamondInitData);
+
+    const diamondProxyFactory = await hardhat.ethers.getContractFactory("DiamondProxy");
+    const chainId = hardhat.network.config.chainId;
+    const diamondProxyContract = await diamondProxyFactory.deploy(chainId, diamondCutData);
+
+    const l1Erc721BridgeFactory = await hardhat.ethers.getContractFactory("L1ERC721Bridge");
+    l1Erc721BridgeContract = await l1Erc721BridgeFactory.deploy(diamondProxyContract.address);
+    l1ERC721Bridge = IL1BridgeFactory.connect(l1Erc721BridgeContract.address, l1Erc721BridgeContract.signer);
+
+    const testnetERC721TokenFactory = await hardhat.ethers.getContractFactory("TestnetERC721Token");
+    testnetERC721TokenContract = await testnetERC721TokenFactory.deploy("TestToken", "TT");
+    erc721TestToken = TestnetERC721TokenFactory.connect(
+      testnetERC721TokenContract.address,
+      testnetERC721TokenContract.signer
+    );
+
+    await erc721TestToken.mint(await randomSigner.getAddress(), 123);
+    await erc721TestToken
+      .connect(randomSigner)
+      .approve(l1Erc721BridgeContract.address, 123);
+
+    // Exposing the methods of IZkSync to the diamond proxy
+    zksyncContract = IZkSyncFactory.connect(diamondProxyContract.address, diamondProxyContract.provider);
+  });
+
+  it("Should deposit successfully", async () => {
+    const depositorAddress = await randomSigner.getAddress();
+    await depositERC721(
+      l1ERC721Bridge.connect(randomSigner),
+      zksyncContract,
+      depositorAddress,
+      testnetERC721TokenContract.address,
+      ethers.BigNumber.from("123"),
+      10000000
+    );
+  });
+
+  it("Should revert on finalizing a withdrawal with wrong message length", async () => {
+    const revertReason = await getCallRevertReason(
+      l1ERC721Bridge.connect(randomSigner).finalizeWithdrawal(0, 0, 0, "0x", [])
+    );
+    expect(revertReason).equal("kk");
+  });
+
+  it("Should revert on finalizing a withdrawal with wrong function signature", async () => {
+    const revertReason = await getCallRevertReason(
+      l1ERC721Bridge.connect(randomSigner).finalizeWithdrawal(0, 0, 0, ethers.utils.randomBytes(76), [])
+    );
+    expect(revertReason).equal("nt");
+  });
+
+  it("Should revert on finalizing a withdrawal with wrong batch number", async () => {
+    const functionSignature = "0x11a2ccc1";
+    const l1Receiver = await randomSigner.getAddress();
+    const l2ToL1message = ethers.utils.hexConcat([
+      functionSignature,
+      l1Receiver,
+      testnetERC721TokenContract.address,
+      ethers.constants.HashZero,
+    ]);
+    const revertReason = await getCallRevertReason(
+      l1ERC721Bridge.connect(randomSigner).finalizeWithdrawal(10, 0, 0, l2ToL1message, [])
+    );
+    expect(revertReason).equal("xx");
+  });
+
+  it("Should revert on finalizing a withdrawal with wrong length of proof", async () => {
+    const functionSignature = "0x11a2ccc1";
+    const l1Receiver = await randomSigner.getAddress();
+    const l2ToL1message = ethers.utils.hexConcat([
+      functionSignature,
+      l1Receiver,
+      testnetERC721TokenContract.address,
+      ethers.constants.HashZero,
+    ]);
+    const revertReason = await getCallRevertReason(
+      l1ERC721Bridge.connect(randomSigner).finalizeWithdrawal(0, 0, 0, l2ToL1message, [])
+    );
+    expect(revertReason).equal("xc");
+  });
+
+  it("Should revert on finalizing a withdrawal with wrong proof", async () => {
+    const functionSignature = "0x11a2ccc1";
+    const l1Receiver = await randomSigner.getAddress();
+    const l2ToL1message = ethers.utils.hexConcat([
+      functionSignature,
+      l1Receiver,
+      testnetERC721TokenContract.address,
+      ethers.constants.HashZero,
+    ]);
+    const revertReason = await getCallRevertReason(
+      l1ERC721Bridge
+        .connect(randomSigner)
+        .finalizeWithdrawal(0, 0, 0, l2ToL1message, Array(9).fill(ethers.constants.HashZero))
+    );
+    expect(revertReason).equal("nq");
+  });
+});
+
+async function depositERC721(
+  bridge: IL1Bridge,
+  zksyncContract: IZkSync,
+  l2Receiver: string,
+  l1Token: string,
+  tokenId: ethers.BigNumber,
+  l2GasLimit: number,
+  l2RefundRecipient = ethers.constants.AddressZero
+) {
+  const gasPrice = await bridge.provider.getGasPrice();
+  const gasPerPubdata = REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT;
+  const neededValue = await zksyncContract.l2TransactionBaseCost(gasPrice, l2GasLimit, gasPerPubdata);
+
+  await bridge.deposit(
+    l2Receiver,
+    l1Token,
+    tokenId,
+    l2GasLimit,
+    REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT,
+    l2RefundRecipient,
+    {
+      value: neededValue,
+    }
+  );
+}

--- a/l2-contracts/contracts/bridge/L2ERC721Bridge.sol
+++ b/l2-contracts/contracts/bridge/L2ERC721Bridge.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.20;
+
+import "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
+import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+
+import "./interfaces/IL1Bridge.sol";
+import "./interfaces/IL2Bridge.sol";
+import "./interfaces/IL2StandardERC721Token.sol";
+
+import "./L2StandardERC721.sol";
+import "../vendor/AddressAliasHelper.sol";
+import {L2ContractHelper, DEPLOYER_SYSTEM_CONTRACT, IContractDeployer} from "../L2ContractHelper.sol";
+import {SystemContractsCaller} from "../SystemContractsCaller.sol";
+
+/// @author Matter Labs
+/// @custom:security-contact security@matterlabs.dev
+/// @notice The "default" bridge implementation for the ERC721 tokens.
+contract L2ERC721Bridge is IL2Bridge, Initializable {
+    /// @dev The address of the L1 bridge counterpart.
+    address public override l1Bridge;
+
+    /// @dev Contract that stores the implementation address for token.
+    /// @dev For more details see https://docs.openzeppelin.com/contracts/3.x/api/proxy#UpgradeableBeacon.
+    UpgradeableBeacon public l2TokenBeacon;
+
+    /// @dev Bytecode hash of the proxy for tokens deployed by the bridge.
+    bytes32 internal l2TokenProxyBytecodeHash;
+
+    /// @dev A mapping L2 token address => L1 token address
+    mapping(address => address) public override l1TokenAddress;
+
+    /// @dev Contract is expected to be used as proxy implementation.
+    /// @dev Disable the initialization to prevent Parity hack.
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address _l1Bridge, bytes32 _l2TokenProxyBytecodeHash, address _governor) external initializer {
+        require(_l1Bridge != address(0), "bf");
+        require(_l2TokenProxyBytecodeHash != bytes32(0), "df");
+        require(_governor != address(0), "sf");
+
+        l1Bridge = _l1Bridge;
+
+        l2TokenProxyBytecodeHash = _l2TokenProxyBytecodeHash;
+        address l2StandardToken = address(new L2StandardERC721{salt: bytes32(0)}());
+        l2TokenBeacon = new UpgradeableBeacon{salt: bytes32(0)}(l2StandardToken);
+        l2TokenBeacon.transferOwnership(_governor);
+    }
+
+    /// @notice Finalize the deposit and mint token
+    /// @param _l1Sender The account address that initiated the deposit on L1
+    /// @param _l2Receiver The account address that would receive minted ether
+    /// @param _l1Token The address of the token that was locked on the L1
+    /// @param _data The additional data that user can pass with the deposit
+    function finalizeDeposit(
+        address _l1Sender,
+        address _l2Receiver,
+        address _l1Token,
+        uint256,
+        bytes calldata _data
+    ) external payable override {
+        // Only the L1 bridge counterpart can initiate and finalize the deposit.
+        require(AddressAliasHelper.undoL1ToL2Alias(msg.sender) == l1Bridge, "mq");
+        // The passed value should be 0 for ERC721 bridge.
+        require(msg.value == 0, "Value should be 0 for ERC721 bridge");
+
+        (uint256 _tokenId, bytes memory _tokenURI, bytes memory _gettersData) = abi.decode(_data, (uint256, bytes, bytes));
+
+        address expectedL2Token = l2TokenAddress(_l1Token);
+        address currentL1Token = l1TokenAddress[expectedL2Token];
+        if (currentL1Token == address(0)) {
+            address deployedToken = _deployL2Token(_l1Token, _gettersData);
+            require(deployedToken == expectedL2Token, "mt");
+            l1TokenAddress[expectedL2Token] = _l1Token;
+        } else {
+            require(currentL1Token == _l1Token, "gg"); // Double check that the expected value equal to real one
+        }
+
+        IL2StandardERC721Token(expectedL2Token).bridgeMint(_l2Receiver, _tokenId, _tokenURI);
+
+        emit FinalizeDeposit(_l1Sender, _l2Receiver, expectedL2Token, _tokenId);
+    }
+
+    /// @dev Deploy and initialize the L2 token for the L1 counterpart
+    function _deployL2Token(address _l1Token, bytes memory _data) internal returns (address) {
+        bytes32 salt = _getCreate2Salt(_l1Token);
+
+        BeaconProxy l2Token = _deployBeaconProxy(salt);
+        L2StandardERC721(address(l2Token)).bridgeInitialize(_l1Token, _data);
+
+        return address(l2Token);
+    }
+
+    /// @notice Initiates a withdrawal by burning token on the contract and sending the message to L1
+    /// where tokens would be unlocked
+    /// @param _l1Receiver The account address that should receive the token on L1
+    /// @param _l2Token The L2 token address which is withdrawn
+    /// @param _tokenId The token to be withdrawn
+    function withdraw(address _l1Receiver, address _l2Token, uint256 _tokenId) public override {
+        IL2StandardERC721Token(_l2Token).bridgeBurn(msg.sender, _tokenId);
+
+        address l1Token = l1TokenAddress[_l2Token];
+        require(l1Token != address(0), "yh");
+
+        bytes memory message = _getL1WithdrawMessage(_l1Receiver, l1Token, _tokenId);
+        L2ContractHelper.sendMessageToL1(message);
+
+        emit WithdrawalInitiated(msg.sender, _l1Receiver, _l2Token, _tokenId);
+    }
+
+    /// @notice Initiates a batch withdrawal by burning tokens on the contract and sending the message to L1
+    /// where tokens would be unlocked
+    /// @param _l1Receiver The account address that should receive the token on L1
+    /// @param _l2Token The L2 token address which is withdrawn
+    /// @param _tokenIds The token IDs to be withdrawn
+    function withdrawBatch(address _l1Receiver, address _l2Token, uint256[] memory _tokenIds) external {
+        for (uint256 i; i < _tokenIds.length; i++) {
+            withdraw(_l1Receiver, _l2Token, _tokenIds[i]);
+        }
+    }
+
+
+    /// @dev Encode the message for l2ToL1log sent with withdraw initialization
+    function _getL1WithdrawMessage(
+        address _to,
+        address _l1Token,
+        uint256 _tokenId
+    ) internal pure returns (bytes memory) {
+        return abi.encodePacked(IL1Bridge.finalizeWithdrawal.selector, _to, _l1Token, _tokenId);
+    }
+
+    /// @return Address of an L2 token counterpart
+    function l2TokenAddress(address _l1Token) public view override returns (address) {
+        bytes32 constructorInputHash = keccak256(abi.encode(address(l2TokenBeacon), ""));
+        bytes32 salt = _getCreate2Salt(_l1Token);
+
+        return
+            L2ContractHelper.computeCreate2Address(address(this), salt, l2TokenProxyBytecodeHash, constructorInputHash);
+    }
+
+    /// @dev Convert the L1 token address to the create2 salt of deployed L2 token
+    function _getCreate2Salt(address _l1Token) internal pure returns (bytes32 salt) {
+        salt = bytes32(uint256(uint160(_l1Token)));
+    }
+
+    /// @dev Deploy the beacon proxy for the L2 token, while using ContractDeployer system contract.
+    /// @dev This function uses raw call to ContractDeployer to make sure that exactly `l2TokenProxyBytecodeHash` is used
+    /// for the code of the proxy.
+    function _deployBeaconProxy(bytes32 salt) internal returns (BeaconProxy proxy) {
+        (bool success, bytes memory returndata) = SystemContractsCaller.systemCallWithReturndata(
+            uint32(gasleft()),
+            DEPLOYER_SYSTEM_CONTRACT,
+            0,
+            abi.encodeCall(
+                IContractDeployer.create2,
+                (salt, l2TokenProxyBytecodeHash, abi.encode(address(l2TokenBeacon), ""))
+            )
+        );
+
+        // The deployment should be successful and return the address of the proxy
+        require(success, "mk");
+        proxy = BeaconProxy(abi.decode(returndata, (address)));
+    }
+}

--- a/l2-contracts/contracts/bridge/L2StandardERC721.sol
+++ b/l2-contracts/contracts/bridge/L2StandardERC721.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.20;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "./interfaces/IL2StandardERC721Token.sol";
+
+/// @author Matter Labs
+/// @notice The ERC721 token implementation, that is used in the "default" ERC721 bridge
+contract L2StandardERC721 is ERC721Upgradeable, IL2StandardERC721Token {
+    /// @dev Describes whether there is a specific getter in the token.
+    /// @notice Used to explicitly separate which getters the token has and which it does not.
+    /// @notice Different tokens in L1 can implement or not implement getter function as `name`/`symbol`,
+    /// @notice Our goal is to store all the getters that L1 token implements, and for others, we keep it as an unimplemented method.
+    struct ERC721Getters {
+        bool ignoreName;
+        bool ignoreSymbol;
+    }
+
+    ERC721Getters availableGetters;
+
+    /// @dev Address of the L2 bridge that is used as trustee who can mint/burn tokens
+    address public override l2Bridge;
+
+    /// @dev Address of the L1 token that can be deposited to mint this L2 token
+    address public override l1Address;
+
+    /// @dev Mapping of token IDs to tokenURI
+    mapping(uint256 => string) public tokenURIs;
+
+    /// @dev Contract is expected to be used as proxy implementation.
+    constructor() {
+        // Disable initialization to prevent Parity hack.
+        _disableInitializers();
+    }
+
+    /// @notice Initializes a contract token for later use. Expected to be used in the proxy.
+    /// @dev Stores the L1 address of the bridge and set `name`/`symbol` getters that L1 token has.
+    /// @param _l1Address Address of the L1 token that can be deposited to mint this L2 token
+    /// @param _data The additional data that the L1 bridge provide for initialization.
+    /// In this case, it is packed `name`/`symbol` of the L1 token.
+    function bridgeInitialize(address _l1Address, bytes memory _data) external initializer {
+        require(_l1Address != address(0), "in6"); // Should be non-zero address
+        l1Address = _l1Address;
+
+        l2Bridge = msg.sender;
+
+        // We parse the data exactly as they were created on the L1 bridge
+        (bytes memory nameBytes, bytes memory symbolBytes) = abi.decode(
+            _data,
+            (bytes, bytes)
+        );
+
+        ERC721Getters memory getters;
+        string memory decodedName;
+        string memory decodedSymbol;
+
+        // L1 bridge didn't check if the L1 token return values with proper types for `name`/`symbol`
+        // That's why we need to try to decode them, and if it works out, set the values as getters.
+
+        // NOTE: Solidity doesn't have a convenient way to try to decode a value:
+        // - Decode them manually, i.e. write a function that will validate that data in the correct format
+        // and return decoded value and a boolean value - whether it was possible to decode.
+        // - Use the standard abi.decode method, but wrap it into an external call in which error can be handled.
+        // We use the second option here.
+
+        try this.decodeString(nameBytes) returns (string memory nameString) {
+            decodedName = nameString;
+        } catch {
+            getters.ignoreName = true;
+        }
+
+        try this.decodeString(symbolBytes) returns (string memory symbolString) {
+            decodedSymbol = symbolString;
+        } catch {
+            getters.ignoreSymbol = true;
+        }
+
+        // Set decoded values for name and symbol.
+        __ERC721_init(decodedName, decodedSymbol);
+
+        availableGetters = getters;
+        emit BridgeInitialize(_l1Address, decodedName, decodedSymbol);
+    }
+
+    modifier onlyBridge() {
+        require(msg.sender == l2Bridge, "xnt"); // Only L2 bridge can call this method
+        _;
+    }
+
+    /// @dev Mint tokens to a given account.
+    /// @param _to The account that will receive the created tokens.
+    /// @param _tokenId The token ID to mint.
+    /// @param _tokenURI The token URI
+    /// @notice Should be called by bridge after depositing tokens from L1.
+    function bridgeMint(address _to, uint256 _tokenId, bytes memory _tokenURI) external override onlyBridge {
+        _mint(_to, _tokenId);
+
+        tokenURIs[_tokenId] = abi.decode(_tokenURI, (string));
+    
+        emit BridgeMint(_to, _tokenId);
+    }
+
+    /// @dev Burn tokens from a given account.
+    /// @param _from The account from which tokens will be burned.
+    /// @param _tokenId The token ID to burn
+    /// @notice Should be called by bridge before withdrawing tokens to L1.
+    function bridgeBurn(address _from, uint256 _tokenId) external override onlyBridge {
+        require(ownerOf(_tokenId) == _from, "Invalid owner");
+
+        delete tokenURIs[_tokenId];
+
+        _burn(_tokenId);
+
+        emit BridgeBurn(_from, _tokenId);
+    }
+
+    function name() public view override returns (string memory) {
+        // If method is not available, behave like a token that does not implement this method - revert on call.
+        if (availableGetters.ignoreName) revert();
+        return super.name();
+    }
+
+    function symbol() public view override returns (string memory) {
+        // If method is not available, behave like a token that does not implement this method - revert on call.
+        if (availableGetters.ignoreSymbol) revert();
+        return super.symbol();
+    }
+
+    function tokenURI(uint256 _tokenId) public view override returns (string memory) {
+        string memory tokenURI_ = tokenURIs[_tokenId];
+        return bytes(tokenURI_).length != 0 ? tokenURI_ : super.tokenURI(_tokenId);
+    }
+
+    /// @dev External function to decode a string from bytes.
+    function decodeString(bytes memory _input) external pure returns (string memory result) {
+        (result) = abi.decode(_input, (string));
+    }
+}

--- a/l2-contracts/contracts/bridge/interfaces/IL2StandardERC721Token.sol
+++ b/l2-contracts/contracts/bridge/interfaces/IL2StandardERC721Token.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.20;
+
+interface IL2StandardERC721Token {
+    event BridgeInitialize(address indexed l1Token, string name, string symbol);
+
+    event BridgeMint(address indexed _account, uint256 _tokenId);
+
+    event BridgeBurn(address indexed _account, uint256 _tokenId);
+
+    function bridgeMint(address _account, uint256 _tokenId, bytes memory _tokenURI) external;
+
+    function bridgeBurn(address _account, uint256 _tokenId) external;
+
+    function l1Address() external view returns (address);
+
+    function l2Bridge() external view returns (address);
+}


### PR DESCRIPTION
# What ❔

This PR adds an ERC721 bridge that, to a large extent, mirrors the logic of the existing ERC20 bridge.

The main difference between this ERC721 bridge and the ERC20 bridge is management of token URI. 

`tokenURI()` is an interface getter for ERC721 contracts. However, because `_baseURI()` is an internal function in an L1 ERC721 contract, we cannot easily reference it in the deployment of the corresponding ERC721 contract on L2 just like we do for `name` and `symbol`. This means that we have to infer from the token URIs of each token ID as they are deposited. This necessitates the need of a token ID to token URI mapping in the storage of the L2 ERC721 contract that gets updated with each deposit and withdrawal of the individual token IDs. 

Separately, we added `depositBatch()` and `withdrawBatch()`, which as the names imply, implement the logic for a batch deposit and batch withdrawal. They are implemented as wrappers of the `deposit()` and the `withdraw()`.

## Why ❔

There isn't any ERC721 bridge.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated. (only inline documentation, where necessary)
