### PR TITLE
Comments and nits Hyperchains

### DIFF
--- a/l1-contracts/contracts/bridge/L1ERC20Bridge.sol
+++ b/l1-contracts/contracts/bridge/L1ERC20Bridge.sol
@@ -15,7 +15,7 @@ import {ReentrancyGuard} from "../common/ReentrancyGuard.sol";
 /// @custom:security-contact security@matterlabs.dev
 /// @notice Smart contract that allows depositing ERC20 tokens from Ethereum to hyperchains
 /// @dev It is a legacy bridge from zkSync Era, that was deprecated in favour of shared bridge.
-/// It is needed for backward compatibility with already integrated projects
+/// It is needed for backward compatibility with already integrated projects.
 contract L1ERC20Bridge is IL1ERC20Bridge, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
@@ -130,6 +130,7 @@ contract L1ERC20Bridge is IL1ERC20Bridge, ReentrancyGuard {
         uint256 _l2TxGasPerPubdataByte,
         address _refundRecipient
     ) public payable nonReentrant returns (bytes32 l2TxHash) {
+        require(_amount != 0, "0T"); // empty deposit
         uint256 amount = _depositFundsToSharedBridge(msg.sender, IERC20(_l1Token), _amount);
         require(amount == _amount, "3T"); // The token has non-standard transfer logic
 
@@ -174,6 +175,7 @@ contract L1ERC20Bridge is IL1ERC20Bridge, ReentrancyGuard {
         bytes32[] calldata _merkleProof
     ) external nonReentrant {
         uint256 amount = depositAmount[_depositSender][_l1Token][_l2TxHash];
+        require(amount != 0, "2T"); // empty deposit
         delete depositAmount[_depositSender][_l1Token][_l2TxHash];
 
         sharedBridge.claimFailedDepositLegacyErc20Bridge(

--- a/l1-contracts/contracts/bridge/interfaces/IL1SharedBridge.sol
+++ b/l1-contracts/contracts/bridge/interfaces/IL1SharedBridge.sol
@@ -48,7 +48,7 @@ interface IL1SharedBridge {
         uint256 amount
     );
 
-    function isWithdrawalFinalizedShared(
+    function isWithdrawalFinalized(
         uint256 _chainId,
         uint256 _l2BatchNumber,
         uint256 _l2MessageIndex
@@ -132,7 +132,7 @@ interface IL1SharedBridge {
 
     function bridgehubConfirmL2Transaction(uint256 _chainId, bytes32 _txDataHash, bytes32 _txHash) external;
 
-    function l1WethAddress() external view returns (address payable);
+    function l1WethAddress() external view returns (address);
 
     /// @dev Event emitted when ETH is received by the contract.
     event EthReceived(uint256 amount);

--- a/l1-contracts/contracts/dev-contracts/test/L1SharedBridgeTest.sol
+++ b/l1-contracts/contracts/dev-contracts/test/L1SharedBridgeTest.sol
@@ -42,7 +42,7 @@ contract L1SharedBridgeTest is L1SharedBridge {
             // The Bridgehub also checks this, but we want to be sure
             require(msg.value == 0, "ShB m.v > 0 b d.it");
 
-            uint256 amount = _depositFunds(_prevMsgSender, _l1Token, _amount); // note if _prevMsgSender is this contract, this will return 0. This does not happen.
+            uint256 amount = _depositFunds(_prevMsgSender, IERC20(_l1Token), _amount); // note if _prevMsgSender is this contract, this will return 0. This does not happen.
             require(amount == _amount, "3T"); // The token has non-standard transfer logic
         }
 


### PR DESCRIPTION
# What ❔

- Comments for `L1SharedBridge`
- `reinitializer(2)` -> `initializer` (bridge wasn't deployed, so no sense to put version 2)
- Rename of 
    - `isWithdrawalFinalizedShared` -> `isWithdrawalFinalized`
    - `eraIsEthWithdrawalFinalizedStorageSwitchBatchNumber` -> `eraFirstPostUpgradeBatch`
    - `_isLegacyWithdrawal` -> `_isEraLegacyWithdrawal`
    - `_msgSender` -> `_prevMsgSender` in `depositLegacyErc20Bridge` (for consistency)
- Remove payable from `l1WethAddress`
- Change type from `address` to `IERC20` in `_depositFunds`

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
