### PR TITLE
ci: update logic for determine branch for releases

### DIFF
--- a/.github/workflows/buld-release.yaml
+++ b/.github/workflows/buld-release.yaml
@@ -23,7 +23,7 @@ jobs:
         id: init
         run: |
           yarn
-          echo "release_tag=$(echo ${GITHUB_REF#refs/heads/})-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "release_tag=$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}})-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Build contracts
         run: |


### PR DESCRIPTION
# What ❔
Fix logic for release naming for gh release

## Why ❔
It's processed a little bit wrong for now

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
