### PR TITLE
feat: Validium mode

### DIFF
--- a/l1-contracts/contracts/zksync/facets/Executor.sol
+++ b/l1-contracts/contracts/zksync/facets/Executor.sol
@@ -24,6 +24,8 @@ contract ExecutorFacet is Base, IExecutor {
     /// @inheritdoc IBase
     string public constant override getName = "ExecutorFacet";
 
+    bool constant VALIDIUM_MODE = $(VALIDIUM_MODE);
+
     /// @dev Process one batch commit using the previous batch StoredBatchInfo
     /// @dev returns new batch StoredBatchInfo
     /// @notice Does not change storage
@@ -123,7 +125,9 @@ contract ExecutorFacet is Base, IExecutor {
         // See SystemLogKey enum in Constants.sol for ordering.
         uint256 processedLogs;
 
+        // #if VALIDIUM_MODE == true
         bytes32 providedL2ToL1PubdataHash = keccak256(_newBatch.totalL2ToL1Pubdata);
+        // #endif
 
         // linear traversal of the logs
         for (uint256 i = 0; i < emittedL2Logs.length; i = i.uncheckedAdd(L2_TO_L1_LOG_SERIALIZE_SIZE)) {
@@ -141,8 +145,10 @@ contract ExecutorFacet is Base, IExecutor {
                 require(logSender == L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, "lm");
                 l2LogsTreeRoot = logValue;
             } else if (logKey == uint256(SystemLogKey.TOTAL_L2_TO_L1_PUBDATA_KEY)) {
+            // #if VALIDIUM_MODE == false
                 require(logSender == L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, "ln");
                 require(providedL2ToL1PubdataHash == logValue, "wp");
+            // #endif
             } else if (logKey == uint256(SystemLogKey.STATE_DIFF_HASH_KEY)) {
                 require(logSender == L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, "lb");
                 stateDiffHash = logValue;

--- a/l1-contracts/contracts/zksync/facets/Executor.sol
+++ b/l1-contracts/contracts/zksync/facets/Executor.sol
@@ -125,7 +125,7 @@ contract ExecutorFacet is Base, IExecutor {
         // See SystemLogKey enum in Constants.sol for ordering.
         uint256 processedLogs;
 
-        // #if VALIDIUM_MODE == true
+        // #if VALIDIUM_MODE == false
         bytes32 providedL2ToL1PubdataHash = keccak256(_newBatch.totalL2ToL1Pubdata);
         // #endif
 

--- a/l1-contracts/hardhat.config.ts
+++ b/l1-contracts/hardhat.config.ts
@@ -93,6 +93,7 @@ export default {
       return {
         ...systemParams,
         ...defs,
+        VALIDIUM_MODE: process.env.VALIDIUM_MODE === "true",
       };
     })(),
   },

--- a/l1-contracts/hardhat.config.ts
+++ b/l1-contracts/hardhat.config.ts
@@ -93,7 +93,7 @@ export default {
       return {
         ...systemParams,
         ...defs,
-        VALIDIUM_MODE: process.env.VALIDIUM_MODE === "true",
+        VALIDIUM_MODE: process.env.VALIDIUM_MODE == "true",
       };
     })(),
   },

--- a/l1-contracts/scripts/deploy.ts
+++ b/l1-contracts/scripts/deploy.ts
@@ -49,11 +49,6 @@ async function main() {
         verbose: true,
       });
 
-      if (cmd.onlyVerifier) {
-        await deployer.deployVerifier(create2Salt, { gasPrice, nonce });
-        return;
-      }
-
       // Create2 factory already deployed on the public networks, only deploy it on local node
       if (process.env.CHAIN_ETH_NETWORK === "localhost") {
         await deployer.deployCreate2Factory({ gasPrice, nonce });
@@ -61,6 +56,11 @@ async function main() {
 
         await deployer.deployMulticall3(create2Salt, { gasPrice, nonce });
         nonce++;
+      }
+
+      if (cmd.onlyVerifier) {
+        await deployer.deployVerifier(create2Salt, { gasPrice, nonce });
+        return;
       }
 
       // Deploy diamond upgrade init contract if needed

--- a/l1-contracts/src.ts/deploy.ts
+++ b/l1-contracts/src.ts/deploy.ts
@@ -78,8 +78,11 @@ export class Deployer {
     const initialProtocolVersion = getNumberFromEnv("CONTRACTS_INITIAL_PROTOCOL_VERSION");
     const DiamondInit = new Interface(hardhat.artifacts.readArtifactSync("DiamondInit").abi);
 
+    const validiumMode = process.env["VALIDIUM_MODE"] == "true";
+    const pubdataPricingMode = validiumMode ? PubdataPricingMode.Validium : PubdataPricingMode.Rollup;
+
     const feeParams = {
-      pubdataPricingMode: PubdataPricingMode.Rollup,
+      pubdataPricingMode,
       batchOverheadL1Gas: SYSTEM_CONFIG.priorityTxBatchOverheadL1Gas,
       maxPubdataPerBatch: SYSTEM_CONFIG.priorityTxPubdataPerBatch,
       priorityTxMaxPubdata: SYSTEM_CONFIG.priorityTxMaxPubdata,


### PR DESCRIPTION
# What ❔

This PR adds the necessary changes for supporting Validium mode on the `zksync-era` side. For the moment, these are:
- Skipping some pubdata checks in `Executor.sol` when Validium mode is on.
- The `PubdataPricingMode` should be initialized correctly depending on the mode.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->


## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.

## TODOs
- [ ] Using PubdataPricingMode we can get rid of the use of the pre-processor.
- [ ] Passing the `--validium-mode` flag from `zksync-era` we can get rid of `VALIDIUM_MODE` env finally (the above point is required as we won't be using the env for the preprocessor).