### PR TITLE
fix: Deploy `Multicall3` and `Create2Factory` before deploying `Verifier`

### DIFF
--- a/l1-contracts/scripts/deploy.ts
+++ b/l1-contracts/scripts/deploy.ts
@@ -49,11 +49,6 @@ async function main() {
         verbose: true,
       });
 
-      if (cmd.onlyVerifier) {
-        await deployer.deployVerifier(create2Salt, { gasPrice, nonce });
-        return;
-      }
-
       // Create2 factory already deployed on the public networks, only deploy it on local node
       if (process.env.CHAIN_ETH_NETWORK === "localhost") {
         await deployer.deployCreate2Factory({ gasPrice, nonce });
@@ -61,6 +56,11 @@ async function main() {
 
         await deployer.deployMulticall3(create2Salt, { gasPrice, nonce });
         nonce++;
+      }
+
+      if (cmd.onlyVerifier) {
+        await deployer.deployVerifier(create2Salt, { gasPrice, nonce });
+        return;
       }
 
       // Deploy diamond upgrade init contract if needed


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

This PR kind of rolls back https://github.com/matter-labs/era-contracts/commit/ebfac9e385be7b881c6eb8ac297eab0a8bf22741. Letting `Multicall3` and `Create2Factory` be deployed before the `Verifier`.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

As it was stated in https://github.com/matter-labs/era-contracts/commit/ebfac9e385be7b881c6eb8ac297eab0a8bf22741,
> Right now `--only-verifier` still deploys CREATE2 Factory and Multicall3. In other words, every `zk init` run deploys two copies of the same contracts. This commit fixes the issue
it is true that `zk init` run deploys two copies of the same contracts (Multicall3 and CREATE2 Factory), it is also true that that commit fixes that. But the introduction of that change breaks the `zk init` run as the `Deploying L1 verifier` step happens before the `Deploying L1 contracts` step (which essentially deploys Multicall3 and CREATE2 Factory) because the Verifier cannot be deployed via CREATE2.

In this PR that fix is rolled back with the only intention of fixing the `zk init` run, but we still need to figure out how not to deploy two copies of the same contract.

## Additional Info

Nowadays `zksync-era`'s `era-contracts` submodule commit is not set `main` (it points to this https://github.com/matter-labs/era-contracts/commit/2dfbc6bac84ecada93cab4a0dea113bc2aceba1c instead). This can be double-checked if you run `zk init` in a fresh cloned `zksync-era`.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
