### PR TITLE
fix(Validium): Get rid of needing solpp for preprocessing `Executor.sol`

### DIFF
--- a/l1-contracts/contracts/dev-contracts/test/ExecutorProvingTest.sol
+++ b/l1-contracts/contracts/dev-contracts/test/ExecutorProvingTest.sol
@@ -24,7 +24,7 @@ contract ExecutorProvingTest is ExecutorFacet {
         bytes32 _expectedSystemContractUpgradeTxHash
     )
         external
-        pure
+        view
         returns (
             uint256 numberOfLayer1Txs,
             bytes32 chainedPriorityTxsHash,

--- a/l1-contracts/contracts/zksync/facets/Executor.sol
+++ b/l1-contracts/contracts/zksync/facets/Executor.sol
@@ -24,8 +24,6 @@ contract ExecutorFacet is Base, IExecutor {
     /// @inheritdoc IBase
     string public constant override getName = "ExecutorFacet";
 
-    bool constant VALIDIUM_MODE = $(VALIDIUM_MODE);
-
     /// @dev Process one batch commit using the previous batch StoredBatchInfo
     /// @dev returns new batch StoredBatchInfo
     /// @notice Does not change storage
@@ -125,9 +123,10 @@ contract ExecutorFacet is Base, IExecutor {
         // See SystemLogKey enum in Constants.sol for ordering.
         uint256 processedLogs;
 
-        // #if VALIDIUM_MODE == false
-        bytes32 providedL2ToL1PubdataHash = keccak256(_newBatch.totalL2ToL1Pubdata);
-        // #endif
+        bytes32 providedL2ToL1PubdataHash;
+        if (feeParams.pubdataPricingMode == PubdataPricingMode.Rollup) {
+            providedL2ToL1PubdataHash = keccak256(_newBatch.totalL2ToL1Pubdata);
+        }
 
         // linear traversal of the logs
         for (uint256 i = 0; i < emittedL2Logs.length; i = i.uncheckedAdd(L2_TO_L1_LOG_SERIALIZE_SIZE)) {
@@ -144,11 +143,9 @@ contract ExecutorFacet is Base, IExecutor {
             if (logKey == uint256(SystemLogKey.L2_TO_L1_LOGS_TREE_ROOT_KEY)) {
                 require(logSender == L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, "lm");
                 l2LogsTreeRoot = logValue;
-            } else if (logKey == uint256(SystemLogKey.TOTAL_L2_TO_L1_PUBDATA_KEY)) {
-            // #if VALIDIUM_MODE == false
+            } else if (logKey == uint256(SystemLogKey.TOTAL_L2_TO_L1_PUBDATA_KEY) && feeParams.pubdataPricingMode == PubdataPricingMode.Rollup) {
                 require(logSender == L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, "ln");
                 require(providedL2ToL1PubdataHash == logValue, "wp");
-            // #endif
             } else if (logKey == uint256(SystemLogKey.STATE_DIFF_HASH_KEY)) {
                 require(logSender == L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, "lb");
                 stateDiffHash = logValue;

--- a/l1-contracts/contracts/zksync/facets/Executor.sol
+++ b/l1-contracts/contracts/zksync/facets/Executor.sol
@@ -143,7 +143,10 @@ contract ExecutorFacet is Base, IExecutor {
             if (logKey == uint256(SystemLogKey.L2_TO_L1_LOGS_TREE_ROOT_KEY)) {
                 require(logSender == L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, "lm");
                 l2LogsTreeRoot = logValue;
-            } else if (logKey == uint256(SystemLogKey.TOTAL_L2_TO_L1_PUBDATA_KEY) && s.feeParams.pubdataPricingMode == PubdataPricingMode.Rollup) {
+            } else if (
+                logKey == uint256(SystemLogKey.TOTAL_L2_TO_L1_PUBDATA_KEY) &&
+                s.feeParams.pubdataPricingMode == PubdataPricingMode.Rollup
+            ) {
                 require(logSender == L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, "ln");
                 require(providedL2ToL1PubdataHash == logValue, "wp");
             } else if (logKey == uint256(SystemLogKey.STATE_DIFF_HASH_KEY)) {

--- a/l1-contracts/contracts/zksync/facets/Executor.sol
+++ b/l1-contracts/contracts/zksync/facets/Executor.sol
@@ -143,12 +143,11 @@ contract ExecutorFacet is Base, IExecutor {
             if (logKey == uint256(SystemLogKey.L2_TO_L1_LOGS_TREE_ROOT_KEY)) {
                 require(logSender == L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, "lm");
                 l2LogsTreeRoot = logValue;
-            } else if (
-                logKey == uint256(SystemLogKey.TOTAL_L2_TO_L1_PUBDATA_KEY) &&
-                s.feeParams.pubdataPricingMode == PubdataPricingMode.Rollup
-            ) {
-                require(logSender == L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, "ln");
-                require(providedL2ToL1PubdataHash == logValue, "wp");
+            } else if (logKey == uint256(SystemLogKey.TOTAL_L2_TO_L1_PUBDATA_KEY)) {
+                if (s.feeParams.pubdataPricingMode == PubdataPricingMode.Rollup) {
+                    require(logSender == L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, "ln");
+                    require(providedL2ToL1PubdataHash == logValue, "wp");
+                }
             } else if (logKey == uint256(SystemLogKey.STATE_DIFF_HASH_KEY)) {
                 require(logSender == L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, "lb");
                 stateDiffHash = logValue;

--- a/l1-contracts/contracts/zksync/facets/Executor.sol
+++ b/l1-contracts/contracts/zksync/facets/Executor.sol
@@ -106,7 +106,7 @@ contract ExecutorFacet is Base, IExecutor {
         bytes32 _expectedSystemContractUpgradeTxHash
     )
         internal
-        pure
+        view
         returns (
             uint256 numberOfLayer1Txs,
             bytes32 chainedPriorityTxsHash,
@@ -124,7 +124,7 @@ contract ExecutorFacet is Base, IExecutor {
         uint256 processedLogs;
 
         bytes32 providedL2ToL1PubdataHash;
-        if (feeParams.pubdataPricingMode == PubdataPricingMode.Rollup) {
+        if (s.feeParams.pubdataPricingMode == PubdataPricingMode.Rollup) {
             providedL2ToL1PubdataHash = keccak256(_newBatch.totalL2ToL1Pubdata);
         }
 
@@ -143,7 +143,7 @@ contract ExecutorFacet is Base, IExecutor {
             if (logKey == uint256(SystemLogKey.L2_TO_L1_LOGS_TREE_ROOT_KEY)) {
                 require(logSender == L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, "lm");
                 l2LogsTreeRoot = logValue;
-            } else if (logKey == uint256(SystemLogKey.TOTAL_L2_TO_L1_PUBDATA_KEY) && feeParams.pubdataPricingMode == PubdataPricingMode.Rollup) {
+            } else if (logKey == uint256(SystemLogKey.TOTAL_L2_TO_L1_PUBDATA_KEY) && s.feeParams.pubdataPricingMode == PubdataPricingMode.Rollup) {
                 require(logSender == L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, "ln");
                 require(providedL2ToL1PubdataHash == logValue, "wp");
             } else if (logKey == uint256(SystemLogKey.STATE_DIFF_HASH_KEY)) {

--- a/l1-contracts/contracts/zksync/facets/Executor.sol
+++ b/l1-contracts/contracts/zksync/facets/Executor.sol
@@ -8,7 +8,7 @@ import {IExecutor, L2_LOG_ADDRESS_OFFSET, L2_LOG_KEY_OFFSET, L2_LOG_VALUE_OFFSET
 import {PriorityQueue, PriorityOperation} from "../libraries/PriorityQueue.sol";
 import {UncheckedMath} from "../../common/libraries/UncheckedMath.sol";
 import {UnsafeBytes} from "../../common/libraries/UnsafeBytes.sol";
-import {VerifierParams} from "../Storage.sol";
+import {VerifierParams, PubdataPricingMode} from "../Storage.sol";
 import {L2_BOOTLOADER_ADDRESS, L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT_ADDR} from "../../common/L2ContractAddresses.sol";
 
 // While formally the following import is not used, it is needed to inherit documentation from it

--- a/l1-contracts/hardhat.config.ts
+++ b/l1-contracts/hardhat.config.ts
@@ -93,7 +93,6 @@ export default {
       return {
         ...systemParams,
         ...defs,
-        VALIDIUM_MODE: process.env.VALIDIUM_MODE == "true",
       };
     })(),
   },


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Get rid of needing solpp for preprocessing `Executor.sol` differently depending on which local mode is set.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

`era-contracts` repo has native support for Validium already, so there is no need to use the preprocessor.

Links for reference:

- https://github.com/matter-labs/era-contracts/blob/main/l1-contracts/contracts/zksync/Storage.sol#L172C15-L172C24
- https://github.com/matter-labs/era-contracts/blob/main/l1-contracts/contracts/zksync/Storage.sol#L90
- https://github.com/matter-labs/era-contracts/blob/main/l1-contracts/contracts/zksync/Storage.sol#L78

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
