### PR TITLE
feat(Validium): Add getter to `Executor.sol` for retrieving the init mode (Validium or Rollup)

### DIFF
--- a/l1-contracts/contracts/zksync/facets/Executor.sol
+++ b/l1-contracts/contracts/zksync/facets/Executor.sol
@@ -10,6 +10,7 @@ import {UncheckedMath} from "../../common/libraries/UncheckedMath.sol";
 import {UnsafeBytes} from "../../common/libraries/UnsafeBytes.sol";
 import {VerifierParams} from "../Storage.sol";
 import {L2_BOOTLOADER_ADDRESS, L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT_ADDR} from "../../common/L2ContractAddresses.sol";
+import {PubdataPricingMode} from "../Storage.sol";
 
 // While formally the following import is not used, it is needed to inherit documentation from it
 import {IBase} from "../interfaces/IBase.sol";
@@ -25,6 +26,10 @@ contract ExecutorFacet is Base, IExecutor {
     string public constant override getName = "ExecutorFacet";
 
     bool constant VALIDIUM_MODE = $(VALIDIUM_MODE);
+
+    function getPubdataPriceMode() external view returns (PubdataPricingMode) {
+        return s.feeParams.pubdataPricingMode;
+    }
 
     /// @dev Process one batch commit using the previous batch StoredBatchInfo
     /// @dev returns new batch StoredBatchInfo

--- a/l1-contracts/contracts/zksync/facets/Executor.sol
+++ b/l1-contracts/contracts/zksync/facets/Executor.sol
@@ -146,10 +146,10 @@ contract ExecutorFacet is Base, IExecutor {
                 require(logSender == L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, "lm");
                 l2LogsTreeRoot = logValue;
             } else if (logKey == uint256(SystemLogKey.TOTAL_L2_TO_L1_PUBDATA_KEY)) {
-            // #if VALIDIUM_MODE == false
+                // #if VALIDIUM_MODE == false
                 require(logSender == L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, "ln");
                 require(providedL2ToL1PubdataHash == logValue, "wp");
-            // #endif
+                // #endif
             } else if (logKey == uint256(SystemLogKey.STATE_DIFF_HASH_KEY)) {
                 require(logSender == L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, "lb");
                 stateDiffHash = logValue;

--- a/l1-contracts/contracts/zksync/facets/Executor.sol
+++ b/l1-contracts/contracts/zksync/facets/Executor.sol
@@ -27,10 +27,6 @@ contract ExecutorFacet is Base, IExecutor {
 
     bool constant VALIDIUM_MODE = $(VALIDIUM_MODE);
 
-    function getPubdataPriceMode() external view returns (PubdataPricingMode) {
-        return s.feeParams.pubdataPricingMode;
-    }
-
     /// @dev Process one batch commit using the previous batch StoredBatchInfo
     /// @dev returns new batch StoredBatchInfo
     /// @notice Does not change storage

--- a/l1-contracts/contracts/zksync/facets/Executor.sol
+++ b/l1-contracts/contracts/zksync/facets/Executor.sol
@@ -10,7 +10,6 @@ import {UncheckedMath} from "../../common/libraries/UncheckedMath.sol";
 import {UnsafeBytes} from "../../common/libraries/UnsafeBytes.sol";
 import {VerifierParams} from "../Storage.sol";
 import {L2_BOOTLOADER_ADDRESS, L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT_ADDR} from "../../common/L2ContractAddresses.sol";
-import {PubdataPricingMode} from "../Storage.sol";
 
 // While formally the following import is not used, it is needed to inherit documentation from it
 import {IBase} from "../interfaces/IBase.sol";

--- a/l1-contracts/contracts/zksync/facets/Getters.sol
+++ b/l1-contracts/contracts/zksync/facets/Getters.sol
@@ -158,6 +158,12 @@ contract GettersFacet is Base, IGetters, ILegacyGetters {
         return s.isEthWithdrawalFinalized[_l2BatchNumber][_l2MessageIndex];
     }
 
+    /// @inheritdoc IGetters
+    /// @notice This method is unstable.
+    function getPubdataPriceMode() external view returns (PubdataPricingMode) {
+        return s.feeParams.pubdataPricingMode;
+    }
+
     /*//////////////////////////////////////////////////////////////
                             DIAMOND LOUPE
      //////////////////////////////////////////////////////////////*/

--- a/l1-contracts/contracts/zksync/facets/Getters.sol
+++ b/l1-contracts/contracts/zksync/facets/Getters.sol
@@ -3,7 +3,7 @@
 pragma solidity 0.8.20;
 
 import {Base} from "./Base.sol";
-import {VerifierParams} from "../Storage.sol";
+import {VerifierParams, PubdataPricingMode} from "../Storage.sol";
 import {Diamond} from "../libraries/Diamond.sol";
 import {PriorityQueue, PriorityOperation} from "../libraries/PriorityQueue.sol";
 import {UncheckedMath} from "../../common/libraries/UncheckedMath.sol";
@@ -159,8 +159,7 @@ contract GettersFacet is Base, IGetters, ILegacyGetters {
     }
 
     /// @inheritdoc IGetters
-    /// @notice This method is unstable.
-    function getPubdataPriceMode() external view returns (PubdataPricingMode) {
+    function getPubdataPricingMode() external view returns (PubdataPricingMode) {
         return s.feeParams.pubdataPricingMode;
     }
 

--- a/l1-contracts/contracts/zksync/interfaces/IGetters.sol
+++ b/l1-contracts/contracts/zksync/interfaces/IGetters.sol
@@ -3,7 +3,7 @@
 pragma solidity 0.8.20;
 
 import {PriorityOperation} from "../libraries/PriorityQueue.sol";
-import {VerifierParams, UpgradeState} from "../Storage.sol";
+import {VerifierParams, UpgradeState, PubdataPricingMode} from "../Storage.sol";
 import "./IBase.sol";
 
 /// @title The interface of the Getters Contract that implements functions for getting contract state from outside the blockchain.
@@ -91,6 +91,10 @@ interface IGetters is IBase {
     /// @param _l2BatchNumber The L2 batch number within which the withdrawal happened.
     /// @param _l2MessageIndex The index of the L2->L1 message denoting the withdrawal.
     function isEthWithdrawalFinalized(uint256 _l2BatchNumber, uint256 _l2MessageIndex) external view returns (bool);
+
+    /// @return The pubdata pricing mode.
+    /// @dev This method is unstable.
+    function getPubdataPricingMode() external view returns (PubdataPricingMode);
 
     /*//////////////////////////////////////////////////////////////
                             DIAMOND LOUPE

--- a/l1-contracts/scripts/deploy.ts
+++ b/l1-contracts/scripts/deploy.ts
@@ -49,11 +49,6 @@ async function main() {
         verbose: true,
       });
 
-      if (cmd.onlyVerifier) {
-        await deployer.deployVerifier(create2Salt, { gasPrice, nonce });
-        return;
-      }
-
       // Create2 factory already deployed on the public networks, only deploy it on local node
       if (process.env.CHAIN_ETH_NETWORK === "localhost") {
         await deployer.deployCreate2Factory({ gasPrice, nonce });
@@ -61,6 +56,11 @@ async function main() {
 
         await deployer.deployMulticall3(create2Salt, { gasPrice, nonce });
         nonce++;
+      }
+
+      if (cmd.onlyVerifier) {
+        await deployer.deployVerifier(create2Salt, { gasPrice, nonce });
+        return;
       }
 
       // Deploy diamond upgrade init contract if needed


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Add a getter for the mode (Validium or Rollup for the moment) for the server to be able to cross-check said mode to avoid inconsistencies in the config.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

It is now possible to run the node with an incorrect config that doesn’t match the L1 config.

We should force the node to ask the pre-deployed contracts on L1 in which mode it should run.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
