### PR TITLE
chore: speed up deploy-erc20 script

### DIFF
--- a/l1-contracts/scripts/deploy-erc20.ts
+++ b/l1-contracts/scripts/deploy-erc20.ts
@@ -120,7 +120,7 @@ async function main() {
         name: cmd.tokenName,
         symbol: cmd.symbol,
         decimals: cmd.decimals,
-        implementation: cmd.implementation
+        implementation: cmd.implementation,
       };
 
       const wallet = cmd.privateKey

--- a/l1-contracts/scripts/deploy-erc20.ts
+++ b/l1-contracts/scripts/deploy-erc20.ts
@@ -88,9 +88,7 @@ async function deployToken(token: TokenDescription, wallet: Wallet): Promise<Tok
         provider
       );
 
-      if (token.implementation !== "WETH9") {
-        await erc20.mint(testWallet.address, parseEther("3000000000"));
-      }
+      await erc20.mint(testWallet.address, parseEther("3000000000"));
     }
   }
 


### PR DESCRIPTION
# What ❔

This PR speeds up the ERC20 deployment script used by `zk init` by deploying contracts and minting tokens in parallel.

## Why ❔

The previous implementation took 60+ seconds to finish.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
