### PR TITLE
feat(Validium): Test `getPubdataPricingMode` getter in `Getters.sol`

### DIFF
--- a/l1-contracts/contracts/dev-contracts/test/MailboxFacetTest.sol
+++ b/l1-contracts/contracts/dev-contracts/test/MailboxFacetTest.sol
@@ -17,4 +17,8 @@ contract MailboxFacetTest is MailboxFacet {
     function getL2GasPrice(uint256 _l1GasPrice) external view returns (uint256) {
         return _deriveL2GasPrice(_l1GasPrice, REQUIRED_L2_GAS_PRICE_PER_PUBDATA);
     }
+
+    function getPubdataPricingMode() external view returns (PubdataPricingMode) {
+        return s.pubdataPricingMode;
+    }
 }

--- a/l1-contracts/contracts/dev-contracts/test/MailboxFacetTest.sol
+++ b/l1-contracts/contracts/dev-contracts/test/MailboxFacetTest.sol
@@ -19,6 +19,6 @@ contract MailboxFacetTest is MailboxFacet {
     }
 
     function getPubdataPricingMode() external view returns (PubdataPricingMode) {
-        return s.pubdataPricingMode;
+        return s.feeParams.pubdataPricingMode;
     }
 }

--- a/l1-contracts/contracts/dev-contracts/test/MailboxFacetTest.sol
+++ b/l1-contracts/contracts/dev-contracts/test/MailboxFacetTest.sol
@@ -17,8 +17,4 @@ contract MailboxFacetTest is MailboxFacet {
     function getL2GasPrice(uint256 _l1GasPrice) external view returns (uint256) {
         return _deriveL2GasPrice(_l1GasPrice, REQUIRED_L2_GAS_PRICE_PER_PUBDATA);
     }
-
-    function getPubdataPricingMode() external view returns (PubdataPricingMode) {
-        return s.feeParams.pubdataPricingMode;
-    }
 }

--- a/l1-contracts/test/foundry/unit/concrete/Admin/Authorization.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Admin/Authorization.t.sol
@@ -32,8 +32,11 @@ contract AuthorizationTest is AdminTest {
     }
 
     function test_changePubdataPricingMode() public {
-        require(proxyAsGetters.getPubdataPricingMode() == PubdataPricingMode.Rollup, "Initial pubdata pricing mode is not Rollup");
-        
+        require(
+            proxyAsGetters.getPubdataPricingMode() == PubdataPricingMode.Rollup,
+            "Initial pubdata pricing mode is not Rollup"
+        );
+
         FeeParams memory newParams = FeeParams({
             pubdataPricingMode: PubdataPricingMode.Validium,
             batchOverheadL1Gas: 1_000,
@@ -45,8 +48,10 @@ contract AuthorizationTest is AdminTest {
         vm.prank(governor);
         proxyAsAdmin.changeFeeParams(newParams);
 
-        require(proxyAsGetters.getPubdataPricingMode() == PubdataPricingMode.Validium, "Pubdata pricing mode was not changed correctly");
-
+        require(
+            proxyAsGetters.getPubdataPricingMode() == PubdataPricingMode.Validium,
+            "Pubdata pricing mode was not changed correctly"
+        );
     }
 
     function test_changeFeeParams_RevertWhen_PriorityTxMaxPubdataHigherThanMaxPubdataPerBatch() public {

--- a/l1-contracts/test/foundry/unit/concrete/Admin/Authorization.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Admin/Authorization.t.sol
@@ -31,6 +31,24 @@ contract AuthorizationTest is AdminTest {
         require(currentFeeParamsHash == correctNewFeeParamsHash, "Fee params were not changed correctly");
     }
 
+    function test_changePubdataPricingMode() public {
+        require(proxyAsGetters.getPubdataPricingMode() == PubdataPricingMode.Rollup, "Initial pubdata pricing mode is not Rollup");
+        
+        FeeParams memory newParams = FeeParams({
+            pubdataPricingMode: PubdataPricingMode.Validium,
+            batchOverheadL1Gas: 1_000,
+            maxPubdataPerBatch: 1_000,
+            maxL2GasPerBatch: 80_000_000,
+            priorityTxMaxPubdata: 99,
+            minimalL2GasPrice: 500_000_000
+        });
+        vm.prank(governor);
+        proxyAsAdmin.changeFeeParams(newParams);
+
+        require(proxyAsGetters.getPubdataPricingMode() == PubdataPricingMode.Rollup, "Pubdata pricing mode was not changed correctly");
+
+    }
+
     function test_changeFeeParams_RevertWhen_PriorityTxMaxPubdataHigherThanMaxPubdataPerBatch() public {
         FeeParams memory newParams = FeeParams({
             pubdataPricingMode: PubdataPricingMode.Rollup,

--- a/l1-contracts/test/foundry/unit/concrete/Admin/Authorization.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Admin/Authorization.t.sol
@@ -45,7 +45,7 @@ contract AuthorizationTest is AdminTest {
         vm.prank(governor);
         proxyAsAdmin.changeFeeParams(newParams);
 
-        require(proxyAsGetters.getPubdataPricingMode() == PubdataPricingMode.Rollup, "Pubdata pricing mode was not changed correctly");
+        require(proxyAsGetters.getPubdataPricingMode() == PubdataPricingMode.Validium, "Pubdata pricing mode was not changed correctly");
 
     }
 

--- a/l1-contracts/test/foundry/unit/concrete/Utils/Utils.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Utils/Utils.sol
@@ -99,7 +99,7 @@ library Utils {
     }
 
     function getGettersSelectors() public pure returns (bytes4[] memory) {
-        bytes4[] memory selectors = new bytes4[](29);
+        bytes4[] memory selectors = new bytes4[](30);
         selectors[0] = GettersFacet.getVerifier.selector;
         selectors[1] = GettersFacet.getGovernor.selector;
         selectors[2] = GettersFacet.getPendingGovernor.selector;
@@ -128,6 +128,7 @@ library Utils {
         selectors[25] = GettersFacet.getTotalBatchesCommitted.selector;
         selectors[26] = GettersFacet.getTotalBatchesVerified.selector;
         selectors[27] = GettersFacet.getTotalBatchesExecuted.selector;
+        selectors[28] = GettersFacet.getPubdataPricingMode.selector;
         return selectors;
     }
 

--- a/l1-contracts/test/unit_tests/mailbox_test.spec.ts
+++ b/l1-contracts/test/unit_tests/mailbox_test.spec.ts
@@ -248,7 +248,7 @@ describe("Mailbox tests", function () {
           minimalL2GasPrice: 500_000_000,
         })
       ).wait();
-        
+
       const pricingMode = await testContract.getPubdataPricingMode();
       expect(pricingMode).to.equal(PubdataPricingMode.Rollup);
 

--- a/l1-contracts/test/unit_tests/mailbox_test.spec.ts
+++ b/l1-contracts/test/unit_tests/mailbox_test.spec.ts
@@ -248,6 +248,9 @@ describe("Mailbox tests", function () {
           minimalL2GasPrice: 500_000_000,
         })
       ).wait();
+        
+      const pricingMode = await testContract.getPubdataPricingMode();
+      expect(pricingMode).to.equal(PubdataPricingMode.Rollup);
 
       // Testing the logic under low / medium / high L1 gas price
       testOnAllGasPrices(expectedLegacyL2GasPrice);

--- a/l1-contracts/test/unit_tests/mailbox_test.spec.ts
+++ b/l1-contracts/test/unit_tests/mailbox_test.spec.ts
@@ -1,13 +1,14 @@
 import { expect } from "chai";
 import * as hardhat from "hardhat";
 import { Action, facetCut, diamondCut } from "../../src.ts/diamondCut";
-import type { MailboxFacet, MockExecutorFacet, Forwarder, MailboxFacetTest } from "../../typechain";
+import type { MailboxFacet, MockExecutorFacet, Forwarder, MailboxFacetTest, GettersFacet } from "../../typechain";
 import {
   MailboxFacetTestFactory,
   MailboxFacetFactory,
   MockExecutorFacetFactory,
   DiamondInitFactory,
   ForwarderFactory,
+  GettersFacetFactory,
 } from "../../typechain";
 import {
   DEFAULT_REVERT_REASON,
@@ -21,6 +22,7 @@ import * as ethers from "ethers";
 
 describe("Mailbox tests", function () {
   let mailbox: MailboxFacet;
+  let gettersFacet: GettersFacet;
   let proxyAsMockExecutor: MockExecutorFacet;
   let diamondProxyContract: ethers.Contract;
   let owner: ethers.Signer;
@@ -89,6 +91,10 @@ describe("Mailbox tests", function () {
     const forwarderFactory = await hardhat.ethers.getContractFactory("Forwarder");
     const forwarderContract = await forwarderFactory.deploy();
     forwarder = ForwarderFactory.connect(forwarderContract.address, forwarderContract.signer);
+
+    const gettersFacetFactory = await hardhat.ethers.getContractFactory("GettersFacet");
+    const gettersFacetContract = await gettersFacetFactory.deploy();
+    gettersFacet = GettersFacetFactory.connect(gettersFacetContract.address, gettersFacetContract.signer);
   });
 
   it("Should accept correctly formatted bytecode", async () => {
@@ -249,8 +255,8 @@ describe("Mailbox tests", function () {
         })
       ).wait();
 
-      const pricingMode = await testContract.getPubdataPricingMode();
-      expect(pricingMode).to.equal(PubdataPricingMode.Rollup);
+      const pubdataPricingMode = await gettersFacet.getPubdataPricingMode();
+      expect(pubdataPricingMode).to.equal(PubdataPricingMode.Rollup);
 
       // Testing the logic under low / medium / high L1 gas price
       testOnAllGasPrices(expectedLegacyL2GasPrice);
@@ -265,8 +271,8 @@ describe("Mailbox tests", function () {
         })
       ).wait();
 
-      const pricingMode = await testContract.getPubdataPricingMode();
-      expect(pricingMode).to.equal(PubdataPricingMode.Validium);
+      const pubdataPricingMode = await gettersFacet.getPubdataPricingMode();
+      expect(pubdataPricingMode).to.equal(PubdataPricingMode.Validium);
 
       // The gas price per pubdata is still constant, however, the L2 gas price is always equal to the minimalL2GasPrice
       testOnAllGasPrices(() => {

--- a/l1-contracts/test/unit_tests/mailbox_test.spec.ts
+++ b/l1-contracts/test/unit_tests/mailbox_test.spec.ts
@@ -265,6 +265,9 @@ describe("Mailbox tests", function () {
         })
       ).wait();
 
+      const pricingMode = await testContract.getPubdataPricingMode();
+      expect(pricingMode).to.equal(PubdataPricingMode.Validium);
+
       // The gas price per pubdata is still constant, however, the L2 gas price is always equal to the minimalL2GasPrice
       testOnAllGasPrices(() => {
         return ethers.BigNumber.from(defaultFeeParams().minimalL2GasPrice);


### PR DESCRIPTION
This PR aims to test the `getPubdataPricingMode` getter in `Getters.sol`. To do so we have called the mentioned method in 2 tests inside the `mailbox_test.spec.ts` to check that once the mode is set, the method returns the correct `pubdataPricingMode`

We have also added the test with  Foundry, the new test suite for this project. 

How to run foundry test: 
- [Install foundry](https://book.getfoundry.sh/getting-started/installation)
- Inside the repository run: `cd l1-contracts/ && yarn test:foundry --match-test test_changePubdataPricingMode`