### PR TITLE
fix: remove test() functions to display correct coverage

### DIFF
--- a/l1-contracts/contracts/dev-contracts/test/DiamondCutTestContract.sol
+++ b/l1-contracts/contracts/dev-contracts/test/DiamondCutTestContract.sol
@@ -6,9 +6,6 @@ import "../../state-transition/libraries/Diamond.sol";
 import "../../state-transition/chain-deps/facets/Getters.sol";
 
 contract DiamondCutTestContract is GettersFacet {
-    // add this to be excluded from coverage report
-    function test() internal virtual {}
-
     function diamondCut(Diamond.DiamondCutData memory _diamondCut) external {
         Diamond.diamondCut(_diamondCut);
     }

--- a/l1-contracts/contracts/dev-contracts/test/MerkleTest.sol
+++ b/l1-contracts/contracts/dev-contracts/test/MerkleTest.sol
@@ -5,9 +5,6 @@ pragma solidity 0.8.20;
 import "../../state-transition/libraries/Merkle.sol";
 
 contract MerkleTest {
-    // add this to be excluded from coverage report
-    function test() internal virtual {}
-
     function calculateRoot(
         bytes32[] calldata _path,
         uint256 _index,

--- a/l1-contracts/test/foundry/unit/concrete/Bridges/L1Erc20Bridge/Getters.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Bridges/L1Erc20Bridge/Getters.t.sol
@@ -12,20 +12,17 @@ contract GettersTest is L1Erc20BridgeTest {
         address daiOnEthereum = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
         address daiOnEra = 0x4B9eb6c0b6ea15176BBF62841C6B2A8a398cb656;
 
-        stdstore
-            .target(address(bridge))
-            .sig("l2Bridge()")
-            .checked_write(address(0x11f943b2c77b743AB90f4A0Ae7d5A4e7FCA3E102));
+        stdstore.target(address(bridge)).sig("l2Bridge()").checked_write(
+            address(0x11f943b2c77b743AB90f4A0Ae7d5A4e7FCA3E102)
+        );
 
-        stdstore
-            .target(address(bridge))
-            .sig("l2TokenBeacon()")
-            .checked_write(address(0x1Eb710030273e529A6aD7E1e14D4e601765Ba3c6));
+        stdstore.target(address(bridge)).sig("l2TokenBeacon()").checked_write(
+            address(0x1Eb710030273e529A6aD7E1e14D4e601765Ba3c6)
+        );
 
-        stdstore
-            .target(address(bridge))
-            .sig("l2TokenProxyBytecodeHash()")
-            .checked_write(bytes32(0x01000121a363b3fbec270986067c1b553bf540c30a6f186f45313133ff1a1019));
+        stdstore.target(address(bridge)).sig("l2TokenProxyBytecodeHash()").checked_write(
+            bytes32(0x01000121a363b3fbec270986067c1b553bf540c30a6f186f45313133ff1a1019)
+        );
 
         address token = bridge.l2TokenAddress(daiOnEthereum);
         assertEq(token, daiOnEra);

--- a/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/DiamondProxy/DiamondProxy.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/DiamondProxy/DiamondProxy.t.sol
@@ -77,7 +77,7 @@ contract DiamondProxyTest is Test {
         DiamondProxy diamondProxy = new DiamondProxy(block.chainid, diamondCutData);
 
         vm.expectRevert(abi.encodePacked("Ut"));
-        (bool success,) = address(diamondProxy).call("");
+        (bool success, ) = address(diamondProxy).call("");
         assertEq(success, false);
     }
 
@@ -93,7 +93,7 @@ contract DiamondProxyTest is Test {
         DiamondProxy diamondProxy = new DiamondProxy(block.chainid, diamondCutData);
 
         vm.expectRevert(abi.encodePacked("Ut"));
-        (bool success,) = address(diamondProxy).call(bytes.concat(bytes4(0xdeadbeef)));
+        (bool success, ) = address(diamondProxy).call(bytes.concat(bytes4(0xdeadbeef)));
         assertEq(success, false);
     }
 

--- a/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/DiamondProxy/DiamondProxy.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/DiamondProxy/DiamondProxy.t.sol
@@ -25,7 +25,7 @@ contract TestFacet is ZkSyncStateTransitionBase {
     function test() internal virtual {}
 }
 
-contract DiamondInitTest is Test {
+contract DiamondProxyTest is Test {
     Diamond.FacetCut[] internal facetCuts;
 
     function getTestFacetSelectors() public pure returns (bytes4[] memory selectors) {
@@ -77,7 +77,7 @@ contract DiamondInitTest is Test {
         DiamondProxy diamondProxy = new DiamondProxy(block.chainid, diamondCutData);
 
         vm.expectRevert(abi.encodePacked("Ut"));
-        (bool success, ) = address(diamondProxy).call("");
+        (bool success,) = address(diamondProxy).call("");
         assertEq(success, false);
     }
 
@@ -93,7 +93,7 @@ contract DiamondInitTest is Test {
         DiamondProxy diamondProxy = new DiamondProxy(block.chainid, diamondCutData);
 
         vm.expectRevert(abi.encodePacked("Ut"));
-        (bool success, ) = address(diamondProxy).call(bytes.concat(bytes4(0xdeadbeef)));
+        (bool success,) = address(diamondProxy).call(bytes.concat(bytes4(0xdeadbeef)));
         assertEq(success, false);
     }
 
@@ -147,6 +147,29 @@ contract DiamondInitTest is Test {
         assertEq(testFacet.func(), true);
     }
 
-    // add this to be excluded from coverage report
-    function test() internal virtual {}
+    function test_revertWhen_removeFunctions() public {
+        Diamond.FacetCut[] memory cuts = new Diamond.FacetCut[](3);
+        cuts[0] = facetCuts[0];
+        cuts[1] = facetCuts[1];
+        cuts[2] = Diamond.FacetCut({
+            facet: address(0),
+            action: Diamond.Action.Remove,
+            isFreezable: true,
+            selectors: getTestFacetSelectors()
+        });
+
+        InitializeData memory initializeData = Utils.makeInitializeData();
+
+        Diamond.DiamondCutData memory diamondCutData = Diamond.DiamondCutData({
+            facetCuts: cuts,
+            initAddress: address(new DiamondInit()),
+            initCalldata: abi.encodeWithSelector(DiamondInit.initialize.selector, initializeData)
+        });
+
+        DiamondProxy diamondProxy = new DiamondProxy(block.chainid, diamondCutData);
+        TestFacet testFacet = TestFacet(address(diamondProxy));
+
+        vm.expectRevert(bytes("F"));
+        testFacet.func();
+    }
 }

--- a/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/facets/Getters/IsFacetFreezable.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/facets/Getters/IsFacetFreezable.t.sol
@@ -5,6 +5,13 @@ pragma solidity 0.8.20;
 import {GettersFacetTest} from "./_Getters_Shared.t.sol";
 
 contract IsFacetFreezableTest is GettersFacetTest {
+    function test_noSelectors() public {
+        address facet = makeAddr("facet");
+        bool received = gettersFacet.isFacetFreezable(facet);
+
+        assertFalse(received, "Received isFacetFreezable is incorrect");
+    }
+
     function test() public {
         address facet = makeAddr("facet");
         gettersFacetWrapper.util_setIsFacetFreezable(facet, true);

--- a/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/facets/Getters/_Getters_Shared.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/facets/Getters/_Getters_Shared.t.sol
@@ -170,9 +170,6 @@ contract GettersFacetWrapper is GettersFacet {
         Diamond.DiamondStorage storage ds = Diamond.getDiamondStorage();
         ds.selectorToFacet[_selector].facetAddress = _facet;
     }
-
-    // add this to be excluded from coverage report
-    function test() internal virtual {}
 }
 
 contract GettersFacetTest is Test {


### PR DESCRIPTION
# What ❔

Removed some `test()` functions from intermediary contracts to display correct coverage, and added new test.
Current coverage stats:
<img width="1404" alt="image" src="https://github.com/matter-labs/era-contracts/assets/55756184/678c6670-1c81-462f-b910-ae9e79b87001">


## Why ❔

The usage of `test()` function indeed removes the unneeded files (like files from `dev-contracts` folder) from the coverage report, but it results in the coverage not being displayed for the libraries. I removed those functions temporarily, so we could see the real libraries coverage(unfortunately, we will see the dev-contracts as well, but I proposed a small change to foundry https://github.com/foundry-rs/foundry/pull/7301, that would allow us to ignore those files in the future).

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
