### PR TITLE
Ivan/fix l1 l2 address conversion

### DIFF
--- a/l1-contracts/scripts/utils.ts
+++ b/l1-contracts/scripts/utils.ts
@@ -79,7 +79,10 @@ export function getNumberFromEnv(envName: string): string {
 const ADDRESS_MODULO = ethers.BigNumber.from(2).pow(160);
 
 export function applyL1ToL2Alias(address: string): string {
-  return ethers.utils.hexlify(ethers.BigNumber.from(address).add(L1_TO_L2_ALIAS_OFFSET).mod(ADDRESS_MODULO));
+  return ethers.utils.hexZeroPad(
+    ethers.utils.hexlify(ethers.BigNumber.from(address).add(L1_TO_L2_ALIAS_OFFSET).mod(ADDRESS_MODULO)),
+    40
+  );
 }
 
 export function readBatchBootloaderBytecode() {

--- a/l1-contracts/scripts/utils.ts
+++ b/l1-contracts/scripts/utils.ts
@@ -81,7 +81,7 @@ const ADDRESS_MODULO = ethers.BigNumber.from(2).pow(160);
 export function applyL1ToL2Alias(address: string): string {
   return ethers.utils.hexZeroPad(
     ethers.utils.hexlify(ethers.BigNumber.from(address).add(L1_TO_L2_ALIAS_OFFSET).mod(ADDRESS_MODULO)),
-    40
+    20
   );
 }
 

--- a/l2-contracts/src/utils.ts
+++ b/l2-contracts/src/utils.ts
@@ -19,13 +19,17 @@ const L1_TO_L2_ALIAS_OFFSET = "0x1111000000000000000000000000000000001111";
 const ADDRESS_MODULO = ethers.BigNumber.from(2).pow(160);
 
 export function applyL1ToL2Alias(address: string): string {
-  return ethers.utils.hexlify(ethers.BigNumber.from(address).add(L1_TO_L2_ALIAS_OFFSET).mod(ADDRESS_MODULO));
+  return ethers.utils.hexZeroPad(
+    ethers.utils.hexlify(ethers.BigNumber.from(address).add(L1_TO_L2_ALIAS_OFFSET).mod(ADDRESS_MODULO)),
+    40
+  );
 }
 
 export function unapplyL1ToL2Alias(address: string): string {
   // We still add ADDRESS_MODULO to avoid negative numbers
-  return ethers.utils.hexlify(
-    ethers.BigNumber.from(address).sub(L1_TO_L2_ALIAS_OFFSET).add(ADDRESS_MODULO).mod(ADDRESS_MODULO)
+  return ethers.utils.hexZeroPad(
+    ethers.utils.hexlify(ethers.BigNumber.from(address).sub(L1_TO_L2_ALIAS_OFFSET).add(ADDRESS_MODULO).mod(ADDRESS_MODULO)),
+    40
   );
 }
 

--- a/l2-contracts/src/utils.ts
+++ b/l2-contracts/src/utils.ts
@@ -28,8 +28,9 @@ export function applyL1ToL2Alias(address: string): string {
 export function unapplyL1ToL2Alias(address: string): string {
   // We still add ADDRESS_MODULO to avoid negative numbers
   return ethers.utils.hexZeroPad(
-    ethers.utils.hexlify(ethers.BigNumber.from(address).sub(L1_TO_L2_ALIAS_OFFSET)
-      .add(ADDRESS_MODULO).mod(ADDRESS_MODULO)),
+    ethers.utils.hexlify(
+      ethers.BigNumber.from(address).sub(L1_TO_L2_ALIAS_OFFSET).add(ADDRESS_MODULO).mod(ADDRESS_MODULO)
+    ),
     20
   );
 }

--- a/l2-contracts/src/utils.ts
+++ b/l2-contracts/src/utils.ts
@@ -21,15 +21,16 @@ const ADDRESS_MODULO = ethers.BigNumber.from(2).pow(160);
 export function applyL1ToL2Alias(address: string): string {
   return ethers.utils.hexZeroPad(
     ethers.utils.hexlify(ethers.BigNumber.from(address).add(L1_TO_L2_ALIAS_OFFSET).mod(ADDRESS_MODULO)),
-    40
+    20
   );
 }
 
 export function unapplyL1ToL2Alias(address: string): string {
   // We still add ADDRESS_MODULO to avoid negative numbers
   return ethers.utils.hexZeroPad(
-    ethers.utils.hexlify(ethers.BigNumber.from(address).sub(L1_TO_L2_ALIAS_OFFSET).add(ADDRESS_MODULO).mod(ADDRESS_MODULO)),
-    40
+    ethers.utils.hexlify(ethers.BigNumber.from(address).sub(L1_TO_L2_ALIAS_OFFSET)
+      .add(ADDRESS_MODULO).mod(ADDRESS_MODULO)),
+    20
   );
 }
 


### PR DESCRIPTION
`let x = ethers.BigNumber.from(address).add(L1_TO_L2_ALIAS_OFFSET) .mod(ADDRESS_MODULO)`. So x is a big number and applying to `hexlify` will convert it hex string without extra padding. E.g. if `x == 1`, then `hexlify(x) == "0x1"`, we want address so it should padded to len 40.