### PR TITLE
chore: Compile yul files in parallel within a single folder

### DIFF
--- a/system-contracts/scripts/compile-yul.ts
+++ b/system-contracts/scripts/compile-yul.ts
@@ -16,9 +16,11 @@ export async function compileYul(paths: CompilerPaths, file: string) {
 export async function compileYulFolder(path: string) {
   const paths = prepareCompilerPaths(path);
   const files: string[] = (await fs.promises.readdir(path)).filter((fn) => fn.endsWith(".yul"));
+  const promises: Promise<void>[] = [];
   for (const file of files) {
-    await compileYul(paths, `${file}`);
+    promises.push(compileYul(paths, `${file}`));
   }
+  await Promise.all(promises);
 }
 
 async function main() {


### PR DESCRIPTION
# What ❔

Replaces sequential compilation of yul with parallel within one folder.

## Why ❔

Shaves off some time from `zk init` for free.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
