### PR TITLE
chore: fix typos

### DIFF
--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -181,7 +181,7 @@ enum SystemLogKey {
 When a batch is committed, we process L2 -> L1 system logs. Here are the invariants that are expected there:
 
 - In a given batch there will be either 7 or 8 system logs. The 8th log is only required for a protocol upgrade.
-- There will be a single log for each key that is containted within `SystemLogKey`
+- There will be a single log for each key that is contained within `SystemLogKey`
 - Three logs from the `L2_TO_L1_MESSENGER` with keys:
 - `L2_TO_L1_LOGS_TREE_ROOT_KEY`
 - `TOTAL_L2_TO_L1_PUBDATA_KEY`
@@ -251,11 +251,11 @@ the Alpha stage.
 This contract consists of four main functions `commitBatches`, `proveBatches`, `executeBatches`, and `revertBatches`, that
 can be called only by the validator.
 
-When the validator calls `commitBatches`, the same calldata will be propogated to the zkSync contract (`DiamondProxy` through
+When the validator calls `commitBatches`, the same calldata will be propagated to the zkSync contract (`DiamondProxy` through
 `call` where it invokes the `ExecutorFacet` through `delegatecall`), and also a timestamp is assigned to these batches to track
-the time these batches are commited by the validator to enforce a delay between committing and execution of batches. Then, the
+the time these batches are committed by the validator to enforce a delay between committing and execution of batches. Then, the
 validator can prove the already commited batches regardless of the mentioned timestamp, and again the same calldata (related
-to the `proveBatches` function) will be propogated to the zkSync contract. After, the `delay` is elapsed, the validator
+to the `proveBatches` function) will be propagated to the zkSync contract. After, the `delay` is elapsed, the validator
 is allowed to call `executeBatches` to propogate the same calldata to zkSync contract.
 
 ### L2 specifics

--- a/l1-contracts/contracts/dev-contracts/RevertReceiveAccount.sol
+++ b/l1-contracts/contracts/dev-contracts/RevertReceiveAccount.sol
@@ -16,7 +16,7 @@ contract RevertReceiveAccount {
     }
 
     receive() external payable {
-        // Assert is used here to also simulate the out-of-gas error, since failed asserion
+        // Assert is used here to also simulate the out-of-gas error, since failed assertion
         // consumes up all the remaining gas
         assert(!revertReceive);
     }

--- a/system-contracts/bootloader/test_infra/src/hook.rs
+++ b/system-contracts/bootloader/test_infra/src/hook.rs
@@ -55,7 +55,7 @@ fn test_hook_as_string(hook_param: U256) -> String {
 }
 
 fn test_hook_as_int_or_hex(hook_param: U256) -> String {
-    // For long data, it is better to use hex-encoding for greater readibility
+    // For long data, it is better to use hex-encoding for greater readability
     if hook_param > U256::from(u64::max_value()) {
         let mut bytes = [0u8; 32];
         hook_param.to_big_endian(&mut bytes);

--- a/system-contracts/contracts/Constants.sol
+++ b/system-contracts/contracts/Constants.sol
@@ -127,7 +127,7 @@ uint256 constant INITIAL_WRITE_STARTING_POSITION = 4;
 
 /// @dev Each storage diffs consists of the following elements:
 /// [20bytes address][32bytes key][32bytes derived key][8bytes enum index][32bytes initial value][32bytes final value]
-/// @dev The offset of the deriived key in a storage diff.
+/// @dev The offset of the derived key in a storage diff.
 uint256 constant STATE_DIFF_DERIVED_KEY_OFFSET = 52;
 /// @dev The offset of the enum index in a storage diff.
 uint256 constant STATE_DIFF_ENUM_INDEX_OFFSET = 84;

--- a/system-contracts/contracts/DefaultAccount.sol
+++ b/system-contracts/contracts/DefaultAccount.sol
@@ -62,7 +62,7 @@ contract DefaultAccount is IAccount {
     /// @param _suggestedSignedHash The suggested hash of the transaction to be signed by the user.
     /// This is the hash that is signed by the EOA by default.
     /// @param _transaction The transaction structure itself.
-    /// @dev Besides the params above, it also accepts unused first paramter "_txHash", which
+    /// @dev Besides the params above, it also accepts unused first parameter "_txHash", which
     /// is the unique (canonical) hash of the transaction.
     function validateTransaction(
         bytes32, // _txHash
@@ -155,7 +155,7 @@ contract DefaultAccount is IAccount {
     /// @notice Validation that the ECDSA signature of the transaction is correct.
     /// @param _hash The hash of the transaction to be signed.
     /// @param _signature The signature of the transaction.
-    /// @return EIP1271_SUCCESS_RETURN_VALUE if the signaure is correct. It reverts otherwise.
+    /// @return EIP1271_SUCCESS_RETURN_VALUE if the signature is correct. It reverts otherwise.
     function _isValidSignature(bytes32 _hash, bytes memory _signature) internal view returns (bool) {
         require(_signature.length == 65, "Signature length is incorrect");
         uint8 v;

--- a/system-contracts/contracts/SystemContext.sol
+++ b/system-contracts/contracts/SystemContext.sol
@@ -105,7 +105,7 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
 
         VirtualBlockUpgradeInfo memory currentVirtualBlockUpgradeInfo = virtualBlockUpgradeInfo;
 
-        // Due to virtual blocks upgrade, we'll have to use the following logic for retreiving the blockhash:
+        // Due to virtual blocks upgrade, we'll have to use the following logic for retrieving the blockhash:
         // 1. If the block number is out of the 256-block supported range, return 0.
         // 2. If the block was created before the upgrade for the virtual blocks (i.e. there we used to use hashes of the batches),
         // we return the hash of the batch.

--- a/system-contracts/contracts/libraries/SystemContractHelper.sol
+++ b/system-contracts/contracts/libraries/SystemContractHelper.sol
@@ -315,7 +315,7 @@ library SystemContractHelper {
         }
     }
 
-    /// @notice Retuns whether the current call is a system call.
+    /// @notice Returns whether the current call is a system call.
     /// @return `true` or `false` based on whether the current call is a system call.
     function isSystemCall() internal view returns (bool) {
         uint256 callFlags = getCallFlags();


### PR DESCRIPTION
1. Fix `docs/Overview.md`  typo
2. Fix `l1-contracts/contracts/dev-contracts/RevertReceiveAccount.sol`  typo
3. Fix `system-contracts/bootloader/test_infra/src/hook.rs`  typo
4. Fix `system-contracts/contracts/Constants.sol`  typo
5. Fix `system-contracts/contracts/DefaultAccount.sol`  typo
6. Fix `system-contracts/contracts/SystemContext.sol`  typo
7. Fix `system-contracts/contracts/libraries/SystemContractHelper.sol`  typo