### PR TITLE
fix(kl-factory): add missing commands

### DIFF
--- a/l1-contracts/package.json
+++ b/l1-contracts/package.json
@@ -71,6 +71,7 @@
     "verify": "hardhat run --network env scripts/verify.ts",
     "read-variable": "ts-node scripts/read-variable.ts",
     "initialize-bridges": "ts-node scripts/initialize-bridges.ts",
+    "initialize-erc20-bridge": "ts-node scripts/initialize-erc20-bridge.ts",
     "initialize-validator": "ts-node scripts/initialize-validator.ts",
     "initialize-governance": "ts-node scripts/initialize-governance.ts",
     "migrate-governance": "ts-node scripts/migrate-governance.ts",


### PR DESCRIPTION
# What ❔

* Link the command `initialize-erc20-bridge` to the `initialize-erc20-bridge.ts` script file.

## Why ❔

During the execution of the `custom-erc20-bridge` integration test to command of the `l1-contracts` are called:
https://github.com/matter-labs/zksync-era/blob/kl-factory/core/tests/ts-integration/tests/custom-erc20-bridge.test.ts#L53
```typescript
        const baseCommandL1 = isLocalSetup
            ? `yarn --cwd /contracts/l1-contracts`
            : `cd $ZKSYNC_HOME && yarn l1-contracts`;
        let args = `--private-key ${alice.privateKey} --erc20-bridge ${l1BridgeProxy.address}`;
        let command = `${baseCommandL1} initialize-erc20-bridge ${args}`;
        await spawn(command);
        await sleep(2);
        let command2 = `${baseCommandL1} erc20-deploy-on-chain ${args}`;
        await spawn(command2);
        await sleep(2);
```

The first one is an existing command. But the second, `erc20-deploy-on-chain`,  is missing.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
