### PR TITLE
Clean up some of the warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,8 @@
     "import/no-named-as-default-member": "off",
     "import/namespace": "off",
     "import/no-unresolved": "off",
-    "import/order": "off"
+    "import/order": "off",
+    "no-console": "off"
   },
   "ignorePatterns": [
     "**/lib/*"

--- a/.solhint.json
+++ b/.solhint.json
@@ -13,6 +13,7 @@
     "no-complex-fallback": "off",
     "reason-string": "off",
     "func-name-mixedcase": "off",
+    "custom-errors": "off",
     "no-unused-vars": "error",
     "max-states-count": "off",
     "no-global-import": "error",


### PR DESCRIPTION
# What ❔

We actively use console in our scripts and it is hard for us to migrate to custom errors at this moment. Thus, turning off those warning us they clutter the lint results and prevent us from seeing actionable items

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
