### PR TITLE
Sync dev with the sb-1-5-0-integration branch

### DIFF
--- a/system-contracts/SystemContractsHashes.json
+++ b/system-contracts/SystemContractsHashes.json
@@ -171,35 +171,35 @@
     "contractName": "bootloader_test",
     "bytecodePath": "bootloader/build/artifacts/bootloader_test.yul.zbin",
     "sourceCodePath": "bootloader/build/bootloader_test.yul",
-    "bytecodeHash": "0x010003ef8d8e294c449ec20eeebbcfa8a51d489bd3e2b37a30f12b07a760010c",
-    "sourceCodeHash": "0x7f31a8f207976f782f8393cd6d55b09b66f5f6b1860bc627b4b52229d70e5ed8"
+    "bytecodeHash": "0x010003cb97ba002b7d24d57d9114bd4b3ac63be70f9366a654aefbb0da3a4b6c",
+    "sourceCodeHash": "0x9c10ce625496554ed18682d05057621cf444b79d641ce504e90cc28ec04c4520"
   },
   {
     "contractName": "fee_estimate",
     "bytecodePath": "bootloader/build/artifacts/fee_estimate.yul.zbin",
     "sourceCodePath": "bootloader/build/fee_estimate.yul",
-    "bytecodeHash": "0x0100095bc0217f39ec459623d55494a2dea6227222e7a857ece5da273391fe84",
-    "sourceCodeHash": "0x8189f2bcc8d02fd0b91c288131b9622fa6af1db948d84875a241787076ac48b8"
+    "bytecodeHash": "0x01000923d3d4774c555588f8ea1fa508c1936edac542c85e8ecb376c5c4de4ef",
+    "sourceCodeHash": "0xa7a6b6f3c21df66b90f4560d9ab27640b17ab78a5de86de29167bbb69f61547e"
   },
   {
     "contractName": "gas_test",
     "bytecodePath": "bootloader/build/artifacts/gas_test.yul.zbin",
     "sourceCodePath": "bootloader/build/gas_test.yul",
-    "bytecodeHash": "0x010008d9b498fcf2343771daefba01a622fb2de96c469c1afa694f0aa3657114",
-    "sourceCodeHash": "0x90f6adcf5f49310daf449cb287d2bfa7120f798d6a3707f52a9e99fd392209ac"
+    "bytecodeHash": "0x010008a96331870a7826aba492e59d4f48a7d580863103ea7d3a6797636985ae",
+    "sourceCodeHash": "0x2cc4b7553bd53c39b0cca8ef8a16b70b7822f7b6172a0de44c45f12fc6cfda47"
   },
   {
     "contractName": "playground_batch",
     "bytecodePath": "bootloader/build/artifacts/playground_batch.yul.zbin",
     "sourceCodePath": "bootloader/build/playground_batch.yul",
-    "bytecodeHash": "0x0100095fcc0efe483c9cc25715e7a211433bb786d35b8f9d0ea9222276ac054c",
-    "sourceCodeHash": "0x7eeb78d47c364e9c9d8b11799476e76c59385f30d9a5f1f832bfc9aad87780dc"
+    "bytecodeHash": "0x010009299ec0751e13e6435a386741eaeff6b6cdefd36ddeb92729be4f01fd42",
+    "sourceCodeHash": "0xa0aec06e7fdf887a30e1a7940755af9865bb95b48289134855cd256744131d51"
   },
   {
     "contractName": "proved_batch",
     "bytecodePath": "bootloader/build/artifacts/proved_batch.yul.zbin",
     "sourceCodePath": "bootloader/build/proved_batch.yul",
-    "bytecodeHash": "0x010008e91510c60e8c956e992be6f5732defd0a5ac1e9ee34012fcf18f8de096",
-    "sourceCodeHash": "0xb3a49983491e0828ea4fc19264d30e6e7e986f3fa8234be5971bb170f5ce2858"
+    "bytecodeHash": "0x010008bb22aea1e22373cb8d807b15c67eedd65523e9cba4cc556adfa504f7b8",
+    "sourceCodeHash": "0x55660d644b2fb9141ce658140dd130d680ade5e14225b64d63c04238998bce69"
   }
 ]

--- a/system-contracts/SystemContractsHashes.json
+++ b/system-contracts/SystemContractsHashes.json
@@ -108,8 +108,8 @@
     "contractName": "SystemContext",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/SystemContext.sol/SystemContext.json",
     "sourceCodePath": "contracts-preprocessed/SystemContext.sol",
-    "bytecodeHash": "0x010001b1035d6cf93ae06dcf2d36e99e6239923319d7470fa9158b16370bcef9",
-    "sourceCodeHash": "0x31184af67115dff08b6a89c9cf1431b3474e8297ba976d40af01da03fd58a9a0"
+    "bytecodeHash": "0x010001b3cb685fa8221f55e4e0b7f2c049364f825e623c4d573f4c11aeba169c",
+    "sourceCodeHash": "0xca00c8688483df675303159b188b708dda0c5138ace99881078c3aad7b8541fc"
   },
   {
     "contractName": "EventWriter",
@@ -171,35 +171,35 @@
     "contractName": "bootloader_test",
     "bytecodePath": "bootloader/build/artifacts/bootloader_test.yul.zbin",
     "sourceCodePath": "bootloader/build/bootloader_test.yul",
-    "bytecodeHash": "0x010003ef683ee34bf16f9c200b331e0adcdb0c278369a6ea17f68bc38be83dc1",
-    "sourceCodeHash": "0x34d81ae9103a4a08192fe36387a396ea2e938bbf9ac08f8e8ff96a9975b112bd"
+    "bytecodeHash": "0x010003cba0abd7bdd046095d40de57a48455bc790d85c7a64d235806be0276ca",
+    "sourceCodeHash": "0x92dbb2c70b9b1bcfc38daeae6fe1141a69bdd4376dd63a2fb6def3cc9f80dae0"
   },
   {
     "contractName": "fee_estimate",
     "bytecodePath": "bootloader/build/artifacts/fee_estimate.yul.zbin",
     "sourceCodePath": "bootloader/build/fee_estimate.yul",
-    "bytecodeHash": "0x0100095b7ec3351174a37c4704bc038abd22efd9063b2675899ad9f32dc2591c",
-    "sourceCodeHash": "0x11369bd387339dbd551d68c0eb504d2ff240698d2390cb15cd9db8b10f72161c"
+    "bytecodeHash": "0x0100092336b49cc30fd1028a5ae80fa33f3c570a31cf31f700d50cb99cb45f5a",
+    "sourceCodeHash": "0x11aecf67bfbe097c621e6e66ade40cbd85b3de69349c8a22befc1ecf4e494a0c"
   },
   {
     "contractName": "gas_test",
     "bytecodePath": "bootloader/build/artifacts/gas_test.yul.zbin",
     "sourceCodePath": "bootloader/build/gas_test.yul",
-    "bytecodeHash": "0x010007afcc84ced867838e3d1af5ed90676cf8127c7678b4efd22fee652b92af",
-    "sourceCodeHash": "0x4eeeab2ee3046ab0df0165c765aa74dfb9dfa9ffe86a308ee744cfb5c289822f"
+    "bytecodeHash": "0x0100078b17f23b7f722d3be629c179b47c1688484d68af6db57bcb4e9e34da7c",
+    "sourceCodeHash": "0x2f9c4980c155ff8c58ddb21f5c09279f72fb1ad164d162b78458277f33c73c8a"
   },
   {
     "contractName": "playground_batch",
     "bytecodePath": "bootloader/build/artifacts/playground_batch.yul.zbin",
     "sourceCodePath": "bootloader/build/playground_batch.yul",
-    "bytecodeHash": "0x0100095f97a23b9cf5e09eb36d159786e6e0703bbd614605cad7d3c5b6432c46",
-    "sourceCodeHash": "0x9bb4bb44ff4e577b3313572e1e2e31c5a6717c6d4b0027e610eb64e26b937412"
+    "bytecodeHash": "0x01000929ed1583fb194fd0862415a2ad88975eae7a8d2f06d5ee1bbdf34f0a50",
+    "sourceCodeHash": "0x000e7428a0f6dd935dccd49a81baf63df0d2aa0ac8309e291aa05f3928b056be"
   },
   {
     "contractName": "proved_batch",
     "bytecodePath": "bootloader/build/artifacts/proved_batch.yul.zbin",
     "sourceCodePath": "bootloader/build/proved_batch.yul",
-    "bytecodeHash": "0x010007bd2e0e78c5c6a07421f45466e6e433556d85d7920fb19d013e547d1f10",
-    "sourceCodeHash": "0xeb84173d72f33f6cfcba136134210b38d70fd701d84e1231159d026092e6344c"
+    "bytecodeHash": "0x01000799eb57fbb442cd965bbecd9f0b88727e0cb5bd4dd58e824f6e2e49db9a",
+    "sourceCodeHash": "0xc93345502537064787e62275daa7b4955777772e16b2c6bcd7f323e334dbadcf"
   }
 ]

--- a/system-contracts/bootloader/bootloader.yul
+++ b/system-contracts/bootloader/bootloader.yul
@@ -3318,7 +3318,7 @@ object "Bootloader" {
                 }
 
                 let gasLimitValue := getGasLimit(innerTxDataOffset)
-                if iszero(validateUint32(gasLimitValue)) {
+                if iszero(validateUint64(gasLimitValue)) {
                     assertionError("Encoding gasLimit")
                 }
 

--- a/system-contracts/bootloader/bootloader.yul
+++ b/system-contracts/bootloader/bootloader.yul
@@ -539,12 +539,6 @@ object "Bootloader" {
                 ret := 1000000
             }
 
-            /// @dev The maximal amount of pubdata that can be safely used by a transaction.
-            /// If a transaction uses more pubdata than this, it will be reverted.
-            function MAX_PUBDATA_FOR_TX() -> ret {
-                ret := 120000
-            }
-
             /// @dev Ceil division of integers
             function ceilDiv(x, y) -> ret {
                 switch or(eq(x, 0), eq(y, 0))
@@ -2764,11 +2758,8 @@ object "Bootloader" {
                 let spentErgs := getErgsSpentForPubdata(basePubdataSpent, gasPerPubdata)
                 debugLog("spentErgsPubdata", spentErgs)
                 let allowedGasLimit := add(computeGas, reservedGas)
-
-                let notEnoughGas := lt(allowedGasLimit, spentErgs)
-                let tooMuchPubdata := gt(getCurrentPubdataSpent(basePubdataSpent), MAX_PUBDATA_FOR_TX())
-
-                ret := or(notEnoughGas, tooMuchPubdata)
+                
+                ret := lt(allowedGasLimit, spentErgs)
             }
 
             /// @dev Set the new value for the tx origin context value

--- a/system-contracts/bootloader/bootloader.yul
+++ b/system-contracts/bootloader/bootloader.yul
@@ -1625,7 +1625,7 @@ object "Bootloader" {
                     assertionError("refundInGas > gasLimit")
                 }
 
-                if iszero(validateUint32(refundInGas)) {
+                if iszero(validateUint64(refundInGas)) {
                     assertionError("refundInGas is not uint32")
                 }
 

--- a/system-contracts/bootloader/bootloader.yul
+++ b/system-contracts/bootloader/bootloader.yul
@@ -82,6 +82,7 @@ object "Bootloader" {
 
             /// @dev The maximal allowed gasPerPubdata, we want it multiplied by the u32::MAX
             /// (i.e. the maximal possible value of the pubdata counter) to be a safe JS integer with a good enough margin.
+            /// @dev For now, the 50000 value is used for backward compatibility with SDK, but in the future we will migrate to 2^20.
             function MAX_L2_GAS_PER_PUBDATA() -> ret {
                 ret := 50000
             }

--- a/system-contracts/bootloader/bootloader.yul
+++ b/system-contracts/bootloader/bootloader.yul
@@ -83,7 +83,7 @@ object "Bootloader" {
             /// @dev The maximal allowed gasPerPubdata, we want it multiplied by the u32::MAX
             /// (i.e. the maximal possible value of the pubdata counter) to be a safe JS integer with a good enough margin.
             function MAX_L2_GAS_PER_PUBDATA() -> ret {
-                ret := 1048576
+                ret := 50000
             }
 
             /// @dev The overhead for the interaction with L1.

--- a/system-contracts/bootloader/bootloader.yul
+++ b/system-contracts/bootloader/bootloader.yul
@@ -1627,7 +1627,7 @@ object "Bootloader" {
                 }
 
                 if iszero(validateUint64(refundInGas)) {
-                    assertionError("refundInGas is not uint32")
+                    assertionError("refundInGas is not uint64")
                 }
 
                 let ethToRefund := safeMul(

--- a/system-contracts/contracts/SystemContext.sol
+++ b/system-contracts/contracts/SystemContext.sol
@@ -34,7 +34,9 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
     uint256 public gasPrice;
 
     /// @notice The current block's gasLimit.
-    uint256 public blockGasLimit = type(uint32).max;
+    /// @dev The same limit is used for both batches and L2 blocks. At this moment this limit is not explicitly 
+    /// forced by the system, rather it is the responsibility of the operator to ensure that this value is never achieved.
+    uint256 public blockGasLimit = (1 << 50);
 
     /// @notice The `block.coinbase` in the current transaction.
     /// @dev For the support of coinbase, we will use the bootloader formal address for now

--- a/system-contracts/contracts/SystemContext.sol
+++ b/system-contracts/contracts/SystemContext.sol
@@ -34,7 +34,7 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
     uint256 public gasPrice;
 
     /// @notice The current block's gasLimit.
-    /// @dev The same limit is used for both batches and L2 blocks. At this moment this limit is not explicitly 
+    /// @dev The same limit is used for both batches and L2 blocks. At this moment this limit is not explicitly
     /// forced by the system, rather it is the responsibility of the operator to ensure that this value is never achieved.
     uint256 public blockGasLimit = (1 << 50);
 


### PR DESCRIPTION
# What ❔

Due to lots of merge conflicts, all the commits except for [this PR](https://github.com/matter-labs/era-contracts/pull/283/files) were cherry-picked

- Removed `MAX_PUBDATA_FOR_TX` to avoid additional limitations for the operator. DDoS protection could be achieved via offchain means.
- Fixed how encoding is checked for `gasLimit` / `gasRefund` since both can be u64
- Decreased `MAX_L2_GAS_PER_PUBDATA` to 50k. The reason behind this is that the latest SDK signs the 50k value by default. We'll increase back to the 2^20 

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
