### PR TITLE
DONT MERGE: Remove virtual blocks

### DIFF
--- a/l1-contracts/scripts/deploy-erc20.ts
+++ b/l1-contracts/scripts/deploy-erc20.ts
@@ -86,7 +86,7 @@ async function main() {
         ? new Wallet(cmd.privateKey, provider)
         : Wallet.fromMnemonic(ethTestConfig.mnemonic, "m/44'/60'/0'/0/1").connect(provider);
 
-      console.log(JSON.stringify(await deployToken(token, wallet), null, 2));
+      console.log(JSON.stringify((await deployToken(token, wallet), null, 2)[0]));
     });
 
   program

--- a/l1-contracts/scripts/deploy-erc20.ts
+++ b/l1-contracts/scripts/deploy-erc20.ts
@@ -27,22 +27,27 @@ type TokenDescription = Token & {
   implementation?: string;
 };
 
-async function deployToken(token: TokenDescription, wallet: Wallet): Promise<Token> {
+async function deployToken(token: TokenDescription, wallet: Wallet, nonce?: number): Promise<[Token, number]> {
+  if (nonce === undefined) {
+    nonce = await wallet.getTransactionCount();
+  }
   token.implementation = token.implementation || DEFAULT_ERC20;
   const tokenFactory = await hardhat.ethers.getContractFactory(token.implementation, wallet);
   const args = token.implementation !== "WETH9" ? [token.name, token.symbol, token.decimals] : [];
-  const erc20 = await tokenFactory.deploy(...args, { gasLimit: 5000000 });
+  const erc20 = await tokenFactory.deploy(...args, { gasLimit: 5000000, nonce: nonce });
   await erc20.deployTransaction.wait();
 
   if (token.implementation !== "WETH9") {
-    await erc20.mint(wallet.address, parseEther("3000000000"));
+    nonce += 1;
+    await erc20.mint(wallet.address, parseEther("3000000000"), { gasLimit: 5000000, nonce: nonce });
   }
   for (let i = 0; i < 10; ++i) {
     const testWallet = Wallet.fromMnemonic(ethTestConfig.test_mnemonic as string, "m/44'/60'/0'/0/" + i).connect(
       provider
     );
     if (token.implementation !== "WETH9") {
-      await erc20.mint(testWallet.address, parseEther("3000000000"));
+      nonce += 1;
+      await erc20.mint(testWallet.address, parseEther("3000000000"), { gasLimit: 5000000, nonce: nonce });
     }
   }
 
@@ -53,7 +58,7 @@ async function deployToken(token: TokenDescription, wallet: Wallet): Promise<Tok
     delete token.implementation;
   }
 
-  return token;
+  return [token, nonce + 1];
 }
 
 async function main() {
@@ -96,8 +101,11 @@ async function main() {
         ? new Wallet(cmd.privateKey, provider)
         : Wallet.fromMnemonic(ethTestConfig.mnemonic, "m/44'/60'/0'/0/1").connect(provider);
 
+      let nonce = await wallet.getTransactionCount();
       for (const token of tokens) {
-        result.push(await deployToken(token, wallet));
+        let token_result;
+        [token_result, nonce] = await deployToken(token, wallet, nonce);
+        result.push(token_result);
       }
 
       console.log(JSON.stringify(result, null, 2));

--- a/system-contracts/bootloader/bootloader.yul
+++ b/system-contracts/bootloader/bootloader.yul
@@ -2670,7 +2670,7 @@ object "Bootloader" {
                     SYSTEM_CONTEXT_ADDR(),
                     0,
                     0,
-                    108,
+                    132,
                     0,
                     0
                 )

--- a/system-contracts/bootloader/bootloader.yul
+++ b/system-contracts/bootloader/bootloader.yul
@@ -274,7 +274,7 @@ object "Bootloader" {
             /// - number of the block
             /// - timestamp of the block
             /// - hash of the previous block
-            /// - the maximal number of virtual blocks to create
+        
             function TX_OPERATOR_L2_BLOCK_INFO_SLOT_SIZE() -> ret {
                 ret := 4
             }
@@ -2652,28 +2652,25 @@ object "Bootloader" {
                 let currentL2BlockNumber := mload(txL2BlockPosition)
                 let currentL2BlockTimestamp := mload(add(txL2BlockPosition, 32))
                 let previousL2BlockHash := mload(add(txL2BlockPosition, 64))
-                let virtualBlocksToCreate := mload(add(txL2BlockPosition, 96))
 
                 let isFirstInBatch := iszero(txId)
 
                 debugLog("Setting new L2 block: ", currentL2BlockNumber)
                 debugLog("Setting new L2 block: ", currentL2BlockTimestamp)
                 debugLog("Setting new L2 block: ", previousL2BlockHash)
-                debugLog("Setting new L2 block: ", virtualBlocksToCreate)
 
                 mstore(0, {{RIGHT_PADDED_SET_L2_BLOCK_SELECTOR}})
                 mstore(4, currentL2BlockNumber)
                 mstore(36, currentL2BlockTimestamp)
                 mstore(68, previousL2BlockHash)
                 mstore(100, isFirstInBatch)
-                mstore(132, virtualBlocksToCreate)
 
                 let success := call(
                     gas(),
                     SYSTEM_CONTEXT_ADDR(),
                     0,
                     0,
-                    164,
+                    108,
                     0,
                     0
                 )
@@ -3859,7 +3856,7 @@ object "Bootloader" {
             // non-empty L2 block has been already sealed. We can not override old L2 blocks, so we need to create a new empty "fictive" block for it.
             //
             // The other reason why we need to set this block is so that in case of empty batch (i.e. the one which has no transactions), 
-            // the virtual block number as well as miniblock number are incremented.
+            // the miniblock number is incremented.
             setL2Block(transactionIndex)
 
             callSystemContext({{RIGHT_PADDED_RESET_TX_NUMBER_IN_BLOCK_SELECTOR}})

--- a/system-contracts/contracts/SystemContext.sol
+++ b/system-contracts/contracts/SystemContext.sol
@@ -74,7 +74,21 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
     /// - Their number will start from being equal to the number of the batch and it will increase until it reaches the L2 block number.
     /// - Their timestamp is updated each time a new virtual block is created.
     /// - Their hash is calculated as `keccak256(uint256(number))`
-    BlockInfo internal currentVirtualL2BlockInfo;
+    BlockInfo internal DEPRECATED_currentL2VirtualBlockInfo;
+
+    /// @notice The information about the virtual blocks upgrade, which tracks when the migration to the L2 blocks has started and finished.
+    struct DEPRECATED_VirtualBlockUpgradeInfo {
+        /// @notice In order to maintain consistent results for `blockhash` requests, we'll
+        /// have to remember the number of the batch when the upgrade to the virtual blocks has been done.
+        /// The hashes for virtual blocks before the upgrade are identical to the hashes of the corresponding batches.
+        uint128 virtualBlockStartBatch;
+        /// @notice L2 block when the virtual blocks have caught up with the L2 blocks. Starting from this block,
+        /// all the information returned to users for block.timestamp/number, etc should be the information about the L2 blocks and
+        /// not virtual blocks.
+        uint128 virtualBlockFinishL2Block;
+    }
+    DEPRECATED_VirtualBlockUpgradeInfo internal virtualBlockUpgradeInfo;
+
 
     /// @notice Number of current transaction in block.
     uint16 public txNumberInBlock;
@@ -98,7 +112,7 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
     /// its signature can not be changed to `getL2BlockHashEVM`.
     /// @return hash The blockhash of the block with the given number.
     function getBlockHashEVM(uint256 _block) external view returns (bytes32 hash) {
-        uint128 blockNumber = currentVirtualL2BlockInfo.number;
+        uint128 blockNumber = currentL2BlockInfo.number;
 
         // 1. If the block number is out of the 256-block supported range, return 0.
         // 2. If the block was created on genesis - return the hash of the batch.
@@ -142,7 +156,7 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
     /// its signature can not be changed to `getL2BlockNumber`.
     /// @return blockNumber The current L2 block's number.
     function getBlockNumber() public view returns (uint128) {
-        return currentVirtualL2BlockInfo.number;
+        return currentL2BlockInfo.number;
     }
 
     /// @notice Returns the current L2 block's timestamp.
@@ -150,7 +164,7 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, ISystemContr
     /// its signature can not be changed to `getL2BlockTimestamp`.
     /// @return timestamp The current L2 block's timestamp.
     function getBlockTimestamp() public view returns (uint128) {
-        return currentVirtualL2BlockInfo.timestamp;
+        return currentL2BlockInfo.timestamp;
     }
 
     /// @notice Assuming that block is one of the last MINIBLOCK_HASHES_TO_STORE ones, returns its hash.

--- a/system-contracts/contracts/interfaces/ISystemContext.sol
+++ b/system-contracts/contracts/interfaces/ISystemContext.sol
@@ -14,19 +14,6 @@ interface ISystemContext {
         uint128 number;
     }
 
-    /// @notice A structure representing the timeline for the upgrade from the batch numbers to the L2 block numbers.
-    /// @dev It will used for the L1 batch -> L2 block migration in Q3 2023 only.
-    struct VirtualBlockUpgradeInfo {
-        /// @notice In order to maintain consistent results for `blockhash` requests, we'll
-        /// have to remember the number of the batch when the upgrade to the virtual blocks has been done.
-        /// The hashes for virtual blocks before the upgrade are identical to the hashes of the corresponding batches.
-        uint128 virtualBlockStartBatch;
-        /// @notice L2 block when the virtual blocks have caught up with the L2 blocks. Starting from this block,
-        /// all the information returned to users for block.timestamp/number, etc should be the information about the L2 blocks and
-        /// not virtual blocks.
-        uint128 virtualBlockFinishL2Block;
-    }
-
     function chainId() external view returns (uint256);
 
     function origin() external view returns (address);


### PR DESCRIPTION
# What ❔

Removing virtual block legacy

## Why ❔

To make future development easier by shrinking codebase and reducing conner cases.
