### PR TITLE
Fix: move get nonce to correct location

### DIFF
--- a/l2-contracts/src/utils.ts
+++ b/l2-contracts/src/utils.ts
@@ -158,7 +158,6 @@ export async function publishBytecodeFromL1(
   const deployedAddresses = deployedAddressesFromEnv();
   const bridgehubAddress = deployedAddresses.Bridgehub.BridgehubProxy;
   const bridgehub = IBridgehubFactory.connect(bridgehubAddress, wallet);
-  const nonce = await wallet.getTransactionCount();
 
   const requiredValueToPublishBytecodes = await bridgehub.l2TransactionBaseCost(
     chainId,
@@ -178,6 +177,7 @@ export async function publishBytecodeFromL1(
     );
     await approveTx.wait(1);
   }
+  const nonce = await wallet.getTransactionCount();
   const tx1 = await bridgehub.requestL2TransactionDirect(
     {
       chainId,


### PR DESCRIPTION
# What ❔

Current `nonce` obtained and used inside of `publishBytecodeFromL1` is currently out of phase when using a base token different than `ETH`.

## Why ❔

Prevent `zk init --base-token-name` from failing.

Note: after this PR merges, the branch `kl-factory` of zksync-era should update it's _contracts_ submodule to the latest commit of `without-1.5.0` containing this changes.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
