### PR TITLE
WIP: minimum change for 1.5.0 to ignore verifier params

### DIFF
--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Executor.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Executor.sol
@@ -460,9 +460,7 @@ contract ExecutorFacet is ZkSyncStateTransitionBase, IExecutor {
                 keccak256(
                     abi.encodePacked(
                         _prevBatchCommitment,
-                        _currentBatchCommitment,
-                        _verifierParams.recursionNodeLevelVkHash,
-                        _verifierParams.recursionLeafLevelVkHash
+                        _currentBatchCommitment
                     )
                 )
             ) >> PUBLIC_INPUT_SHIFT;


### PR DESCRIPTION
# What ❔

* The minimum set of changes to stop including the verification keys in the public proof input (as we no longer require them from 1.5.0 release)