### PR TITLE
[EVM-Equivalent-YUL] Add addmod and mulmod opcodes

### DIFF
--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -199,6 +199,15 @@ object "EVMInterpreter" {
 
                     sp := pushStackItem(sp, addmod(a, b, N))
                 }
+                case 0x09 { // OP_MULMOD
+                    let a, b, N
+
+                    a, sp := popStackItem(sp)
+                    b, sp := popStackItem(sp)
+                    N, sp := popStackItem(sp)
+
+                    sp := pushStackItem(sp, mulmod(a, b, N))
+                }
                 case 0x55 { // OP_SSTORE
                     let key, value
 

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -190,6 +190,15 @@ object "EVMInterpreter" {
 
                     sp := pushStackItem(sp, sub(a, b))
                 }
+                case 0x08 { // OP_ADDMOD
+                    let a, b, N
+
+                    a, sp := popStackItem(sp)
+                    b, sp := popStackItem(sp)
+                    N, sp := popStackItem(sp)
+
+                    sp := pushStackItem(sp, addmod(a, b, N))
+                }
                 case 0x55 { // OP_SSTORE
                     let key, value
 


### PR DESCRIPTION
# What ❔

This PR adds `addmod` and `mulmod` opcodes to YUL EVM interpreter, as well as tests for them.

## Why ❔

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
