### PR TITLE
[EVM-Equivalent-YUL] Add exp and signextend opcodes

### DIFF
--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -198,6 +198,14 @@ object "EVMInterpreter" {
 
                     sp := pushStackItem(sp, exp(a, exponent))
                 }
+                case 0x0B { // OP_SIGNEXTEND
+                    let b, x
+
+                    b, sp := popStackItem(sp)
+                    x, sp := popStackItem(sp)
+
+                    sp := pushStackItem(sp, signextend(b, x))
+                }
                 case 0x55 { // OP_SSTORE
                     let key, value
 

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -190,6 +190,14 @@ object "EVMInterpreter" {
 
                     sp := pushStackItem(sp, sub(a, b))
                 }
+                case 0x0A { // OP_EXP
+                    let a, b
+
+                    a, sp := popStackItem(sp)
+                    b, sp := popStackItem(sp)
+
+                    sp := pushStackItem(sp, exp(a, b))
+                }
                 case 0x55 { // OP_SSTORE
                     let key, value
 

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -191,12 +191,12 @@ object "EVMInterpreter" {
                     sp := pushStackItem(sp, sub(a, b))
                 }
                 case 0x0A { // OP_EXP
-                    let a, b
+                    let a, exponent
 
                     a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    exponent, sp := popStackItem(sp)
 
-                    sp := pushStackItem(sp, exp(a, b))
+                    sp := pushStackItem(sp, exp(a, exponent))
                 }
                 case 0x55 { // OP_SSTORE
                     let key, value


### PR DESCRIPTION
# What ❔

This PR adds `exp` and `signextend` opcodes to YUL EVM interpreter, as well as tests for them.

## Why ❔

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
