### PR TITLE
[EVM-Equivalent-YUL] Optimize readBytes function used by pushN opcodes

### DIFF
--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -68,8 +68,9 @@ object "EVMInterpreter" {
             }
 
             function readBytes(start, length) -> value {
-                for { let i := 0 } lt(i, length) { i := add(i, 1) } {
-                    let next_byte := readIP(add(start, i))
+                let max := add(start, length)
+                for {} lt(start, max) { start := add(start, 1) } {
+                    let next_byte := readIP(start)
 
                     value := or(shl(8, value), next_byte)
                 }


### PR DESCRIPTION
# What ❔

With this change, the function will stop doing N (from pushN) `add`s, but only one, whatever N be.

## Why ❔

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
