### PR TITLE
[EVM-Equivalent-YUL] Add jump and jumpi opcodes

### DIFF
--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -345,7 +345,7 @@ object "EVMInterpreter" {
 
                     ip := add(add(BYTECODE_OFFSET(), 32), counter)
 
-                    evmGasLeft = chargeGas(evmGasLeft, 8)
+                    evmGasLeft := chargeGas(evmGasLeft, 8)
 
                     // Check next opcode is JUMPDEST
                     let nextOpcode := readIP(ip)
@@ -359,7 +359,7 @@ object "EVMInterpreter" {
                     counter, sp := popStackItem(sp)
                     b, sp := popStackItem(sp)
 
-                    evmGasLeft = chargeGas(evmGasLeft, 10)
+                    evmGasLeft := chargeGas(evmGasLeft, 10)
 
                     if iszero(b) {
                         continue

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -304,6 +304,24 @@ object "EVMInterpreter" {
                         revert(0, 0)
                     }
                 }
+                case 0x57 { // OP_JUMPI
+                    let counter, b
+
+                    counter, sp := popStackItem(sp)
+                    b, sp := popStackItem(sp)
+
+                    if iszero(b) {
+                        continue
+                    }
+
+                    ip := add(add(BYTECODE_OFFSET(), 32), counter)
+
+                    // Check next opcode is JUMPDEST
+                    let nextOpcode := readIP(ip)
+                    if iszero(eq(nextOpcode, 0x5B)) {
+                        revert(0, 0)
+                    }
+                }
                 case 0x55 { // OP_SSTORE
                     let key, value
 

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -298,6 +298,8 @@ object "EVMInterpreter" {
 
                     ip := add(add(BYTECODE_OFFSET(), 32), counter)
 
+                    evmGasLeft = chargeGas(evmGasLeft, 8)
+
                     // Check next opcode is JUMPDEST
                     let nextOpcode := readIP(ip)
                     if iszero(eq(nextOpcode, 0x5B)) {
@@ -309,6 +311,8 @@ object "EVMInterpreter" {
 
                     counter, sp := popStackItem(sp)
                     b, sp := popStackItem(sp)
+
+                    evmGasLeft = chargeGas(evmGasLeft, 10)
 
                     if iszero(b) {
                         continue


### PR DESCRIPTION
# What ❔

This PR adds `jump` and `jumpi` (also `jumpdest`)

## Why ❔

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
