### PR TITLE
[EVM-Equivalent-YUL] Add some logic operators opcodes

### DIFF
--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -336,6 +336,16 @@ object "EVMInterpreter" {
 
                     evmGasLeft := chargeGas(evmGasLeft, 3)
                 }
+                case 0x11 { // OP_GT
+                    let a, b
+
+                    a, sp := popStackItem(sp)
+                    b, sp := popStackItem(sp)
+
+                    sp := pushStackItem(sp, gt(a, b))
+
+                    evmGasLeft := chargeGas(evmGasLeft, 3)
+                }
                 case 0x55 { // OP_SSTORE
                     let key, value
 

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -326,6 +326,16 @@ object "EVMInterpreter" {
 
                     sp := pushStackItem(sp, mulmod(a, b, N))
                 }
+                case 0x10 { // OP_LT
+                    let a, b
+
+                    a, sp := popStackItem(sp)
+                    b, sp := popStackItem(sp)
+
+                    sp := pushStackItem(sp, lt(a, b))
+
+                    evmGasLeft := chargeGas(evmGasLeft, 3)
+                }
                 case 0x55 { // OP_SSTORE
                     let key, value
 

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -366,6 +366,16 @@ object "EVMInterpreter" {
 
                     evmGasLeft := chargeGas(evmGasLeft, 3)
                 }
+                case 0x14 { // OP_EQ
+                    let a, b
+
+                    a, sp := popStackItem(sp)
+                    b, sp := popStackItem(sp)
+
+                    sp := pushStackItem(sp, eq(a, b))
+
+                    evmGasLeft := chargeGas(evmGasLeft, 3)
+                }
                 case 0x55 { // OP_SSTORE
                     let key, value
 

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -346,6 +346,16 @@ object "EVMInterpreter" {
 
                     evmGasLeft := chargeGas(evmGasLeft, 3)
                 }
+                case 0x12 { // OP_SLT
+                    let a, b
+
+                    a, sp := popStackItem(sp)
+                    b, sp := popStackItem(sp)
+
+                    sp := pushStackItem(sp, slt(a, b))
+
+                    evmGasLeft := chargeGas(evmGasLeft, 3)
+                }
                 case 0x55 { // OP_SSTORE
                     let key, value
 

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -356,6 +356,16 @@ object "EVMInterpreter" {
 
                     evmGasLeft := chargeGas(evmGasLeft, 3)
                 }
+                case 0x13 { // OP_SGT
+                    let a, b
+
+                    a, sp := popStackItem(sp)
+                    b, sp := popStackItem(sp)
+
+                    sp := pushStackItem(sp, sgt(a, b))
+
+                    evmGasLeft := chargeGas(evmGasLeft, 3)
+                }
                 case 0x55 { // OP_SSTORE
                     let key, value
 

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -385,6 +385,16 @@ object "EVMInterpreter" {
 
                     evmGasLeft := chargeGas(evmGasLeft, 3)
                 }
+                case 0x18 { // OP_XOR
+                    let a, b
+
+                    a, sp := popStackItem(sp)
+                    b, sp := popStackItem(sp)
+
+                    sp := pushStackItem(sp, xor(a, b))
+
+                    evmGasLeft := chargeGas(evmGasLeft, 3)
+                }
                 case 0x55 { // OP_SSTORE
                     let key, value
 

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -395,6 +395,15 @@ object "EVMInterpreter" {
 
                     evmGasLeft := chargeGas(evmGasLeft, 3)
                 }
+                case 0x19 { // OP_NOT
+                    let a
+
+                    a, sp := popStackItem(sp)
+
+                    sp := pushStackItem(sp, not(a))
+
+                    evmGasLeft := chargeGas(evmGasLeft, 3)
+                }
                 case 0x55 { // OP_SSTORE
                     let key, value
 

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -376,6 +376,15 @@ object "EVMInterpreter" {
 
                     evmGasLeft := chargeGas(evmGasLeft, 3)
                 }
+                case 0x15 { // OP_ISZERO
+                    let a
+
+                    a, sp := popStackItem(sp)
+
+                    sp := pushStackItem(sp, iszero(a))
+
+                    evmGasLeft := chargeGas(evmGasLeft, 3)
+                }
                 case 0x55 { // OP_SSTORE
                     let key, value
 

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -404,6 +404,16 @@ object "EVMInterpreter" {
 
                     evmGasLeft := chargeGas(evmGasLeft, 3)
                 }
+                case 0x1A { // OP_BYTE
+                    let i, x
+
+                    i, sp := popStackItem(sp)
+                    x, sp := popStackItem(sp)
+
+                    sp := pushStackItem(sp, byte(i, x))
+
+                    evmGasLeft := chargeGas(evmGasLeft, 3)
+                }
                 case 0x55 { // OP_SSTORE
                     let key, value
 


### PR DESCRIPTION
# What ❔

This PR adds `lt`, `gt`, `slt`, `sgt`, `eq`, `iszero`, `xor`, `not` and `byte` opcodes

## Why ❔

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
