### PR TITLE
[EVM-Equivalent-Yul] Add mload, mstore and mstore8 opcodes

### DIFF
--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -513,7 +513,8 @@ object "EVMInterpreter" {
 
                     let expansionGas := expandMemory(add(offset, 32))
 
-                    sp := pushStackItem(sp, mload(add(MEM_OFFSET_INNER(), offset)))
+                    let memValue := mload(add(MEM_OFFSET_INNER(), offset))
+                    sp := pushStackItem(sp, memValue)
                     evmGasLeft := chargeGas(evmGasLeft, add(3, expansionGas))
                 }
                 case 0x52 { // OP_MSTORE

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -406,6 +406,24 @@ object "EVMInterpreter" {
                     mstore(add(MEM_OFFSET_INNER(), offset), value)
                     evmGasLeft := chargeGas(evmGasLeft, gasCounter)
                 }
+                case 0x53 { // OP_MSTORE8
+                    let offset, value
+
+                    offset, sp := popStackItem(sp)
+                    value, sp := popStackItem(sp)
+
+                    let end := add(offset, 1)
+                    let currentEnd := mload(MEM_OFFSET())
+                    if gt(end, currentEnd) {
+                        let newSize := roundUp(end, 32)
+                        for {} lt(currentEnd, newSize) {currentEnd := add(currentEnd, 32)} {
+                            mstore(currentEnd, 0)
+                        }
+                        mstore(MEM_OFFSET(), newSize)
+                    }
+
+                    mstore8(add(MEM_OFFSET_INNER(), offset), value)
+                }
                 case 0x55 { // OP_SSTORE
                     let key, value
 

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -369,9 +369,12 @@ object "EVMInterpreter" {
                     offset, sp := popStackItem(sp)
 
                     let end := add(offset, 32)
-                    if gt(end, mload(MEM_OFFSET())) {
+                    let currentEnd := mload(MEM_OFFSET())
+                    if gt(end, currentEnd) {
                         let newSize := roundUp(end, 32)
-                        mstore(sub(add(MEM_OFFSET_INNER(), newSize), 32), 0)
+                        for {} lt(currentEnd, newSize) { currentEnd := add(currentEnd, 32) } {
+                            mstore(currentEnd, 0)
+                        }
                         mstore(MEM_OFFSET(), newSize)
                     }
 
@@ -384,9 +387,12 @@ object "EVMInterpreter" {
                     value, sp := popStackItem(sp)
 
                     let end := add(offset, 32)
+                    let currentEnd := mload(MEM_OFFSET())
                     if gt(end, mload(MEM_OFFSET())) {
                         let newSize := roundUp(end, 32)
-                        mstore(sub(add(MEM_OFFSET_INNER(), newSize), 32), 0)
+                        for {} lt(currentEnd, newSize) { currentEnd := add(currentEnd, 32) } {
+                            mstore(currentEnd, 0)
+                        }
                         mstore(MEM_OFFSET(), newSize)
                     }
 

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -368,17 +368,21 @@ object "EVMInterpreter" {
 
                     offset, sp := popStackItem(sp)
 
+                    let gasCounter := 3
+
                     let end := add(offset, 32)
                     let currentEnd := mload(MEM_OFFSET())
                     if gt(end, currentEnd) {
                         let newSize := roundUp(end, 32)
                         for {} lt(currentEnd, newSize) { currentEnd := add(currentEnd, 32) } {
+                            gasCounter := add(gasCounter, 3)
                             mstore(currentEnd, 0)
                         }
                         mstore(MEM_OFFSET(), newSize)
                     }
 
                     sp := pushStackItem(sp, mload(add(MEM_OFFSET_INNER(), offset)))
+                    evmGasLeft := chargeGas(evmGasLeft, gasCounter)
                 }
                 case 0x52 { // OP_MSTORE
                     let offset, value
@@ -386,17 +390,21 @@ object "EVMInterpreter" {
                     offset, sp := popStackItem(sp)
                     value, sp := popStackItem(sp)
 
+                    let gasCounter := 3
+
                     let end := add(offset, 32)
                     let currentEnd := mload(MEM_OFFSET())
                     if gt(end, currentEnd) {
                         let newSize := roundUp(end, 32)
                         for {} lt(currentEnd, newSize) { currentEnd := add(currentEnd, 32) } {
+                            gasCounter := add(gasCounter, 3)
                             mstore(currentEnd, 0)
                         }
                         mstore(MEM_OFFSET(), newSize)
                     }
 
                     mstore(add(MEM_OFFSET_INNER(), offset), value)
+                    evmGasLeft := chargeGas(evmGasLeft, gasCounter)
                 }
                 case 0x55 { // OP_SSTORE
                     let key, value

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -412,17 +412,21 @@ object "EVMInterpreter" {
                     offset, sp := popStackItem(sp)
                     value, sp := popStackItem(sp)
 
+                    let gasCounter := 3
+
                     let end := add(offset, 1)
                     let currentEnd := mload(MEM_OFFSET())
                     if gt(end, currentEnd) {
                         let newSize := roundUp(end, 32)
                         for {} lt(currentEnd, newSize) {currentEnd := add(currentEnd, 32)} {
+                            gasCounter := add(gasCounter, 3)
                             mstore(currentEnd, 0)
                         }
                         mstore(MEM_OFFSET(), newSize)
                     }
 
                     mstore8(add(MEM_OFFSET_INNER(), offset), value)
+                    evmGasLeft := chargeGas(evmGasLeft, gasCounter)
                 }
                 case 0x55 { // OP_SSTORE
                     let key, value

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -194,6 +194,20 @@ object "EVMInterpreter" {
                 }
             }
 
+            function expandMemory(end) -> gasCost {
+                gasCost := 3
+
+                let currentEnd := mload(MEM_OFFSET())
+                if gt(end, currentEnd) {
+                    let newSize := roundUp(end, 32)
+                    for {} lt(currentEnd, newSize) { currentEnd := add(currentEnd, 32) } {
+                        gasCost := add(gasCost, 3)
+                        mstore(currentEnd, 0)
+                    }
+                    mstore(MEM_OFFSET(), newSize)
+                }
+            }
+
             // Essentially a NOP that will not get optimized away by the compiler
             function $llvm_NoInline_llvm$_unoptimized() {
                 pop(1)
@@ -368,21 +382,10 @@ object "EVMInterpreter" {
 
                     offset, sp := popStackItem(sp)
 
-                    let gasCounter := 3
-
-                    let end := add(offset, 32)
-                    let currentEnd := mload(MEM_OFFSET())
-                    if gt(end, currentEnd) {
-                        let newSize := roundUp(end, 32)
-                        for {} lt(currentEnd, newSize) { currentEnd := add(currentEnd, 32) } {
-                            gasCounter := add(gasCounter, 3)
-                            mstore(currentEnd, 0)
-                        }
-                        mstore(MEM_OFFSET(), newSize)
-                    }
+                    let expansionGas := expandMemory(add(offset, 32))
 
                     sp := pushStackItem(sp, mload(add(MEM_OFFSET_INNER(), offset)))
-                    evmGasLeft := chargeGas(evmGasLeft, gasCounter)
+                    evmGasLeft := chargeGas(evmGasLeft, add(3, expansionGas))
                 }
                 case 0x52 { // OP_MSTORE
                     let offset, value
@@ -390,21 +393,10 @@ object "EVMInterpreter" {
                     offset, sp := popStackItem(sp)
                     value, sp := popStackItem(sp)
 
-                    let gasCounter := 3
-
-                    let end := add(offset, 32)
-                    let currentEnd := mload(MEM_OFFSET())
-                    if gt(end, currentEnd) {
-                        let newSize := roundUp(end, 32)
-                        for {} lt(currentEnd, newSize) { currentEnd := add(currentEnd, 32) } {
-                            gasCounter := add(gasCounter, 3)
-                            mstore(currentEnd, 0)
-                        }
-                        mstore(MEM_OFFSET(), newSize)
-                    }
+                    let expansionGas := expandMemory(add(offset, 32))
 
                     mstore(add(MEM_OFFSET_INNER(), offset), value)
-                    evmGasLeft := chargeGas(evmGasLeft, gasCounter)
+                    evmGasLeft := chargeGas(evmGasLeft, add(3, expansionGas))
                 }
                 case 0x53 { // OP_MSTORE8
                     let offset, value
@@ -412,21 +404,10 @@ object "EVMInterpreter" {
                     offset, sp := popStackItem(sp)
                     value, sp := popStackItem(sp)
 
-                    let gasCounter := 3
-
-                    let end := add(offset, 1)
-                    let currentEnd := mload(MEM_OFFSET())
-                    if gt(end, currentEnd) {
-                        let newSize := roundUp(end, 32)
-                        for {} lt(currentEnd, newSize) {currentEnd := add(currentEnd, 32)} {
-                            gasCounter := add(gasCounter, 3)
-                            mstore(currentEnd, 0)
-                        }
-                        mstore(MEM_OFFSET(), newSize)
-                    }
+                    let expansionGas := expandMemory(add(offset, 1))
 
                     mstore8(add(MEM_OFFSET_INNER(), offset), value)
-                    evmGasLeft := chargeGas(evmGasLeft, gasCounter)
+                    evmGasLeft := chargeGas(evmGasLeft, add(3, expansionGas))
                 }
                 case 0x55 { // OP_SSTORE
                     let key, value

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -388,7 +388,7 @@ object "EVMInterpreter" {
 
                     let end := add(offset, 32)
                     let currentEnd := mload(MEM_OFFSET())
-                    if gt(end, mload(MEM_OFFSET())) {
+                    if gt(end, currentEnd) {
                         let newSize := roundUp(end, 32)
                         for {} lt(currentEnd, newSize) { currentEnd := add(currentEnd, 32) } {
                             mstore(currentEnd, 0)

--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -337,6 +337,13 @@ object "EVMInterpreter" {
 
                     sp := pushStackItem(sp, mulmod(a, b, N))
                 }
+                case 0x50 { // OP_POP
+                    let _y
+
+                    _y, sp := popStackItem(sp)
+
+                    evmGasLeft := chargeGas(evmGasLeft, 2)
+                }
                 case 0x55 { // OP_SSTORE
                     let key, value
 


### PR DESCRIPTION
# What ❔

This PR adds `mload`, `mstore` and `mstore8` opcodes, including their gas charges.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
