### PR TITLE
[EVM-Equivalent-YUL] Add environment4 opcodes

### DIFF
--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -502,10 +502,15 @@ object "EVMInterpreter" {
                         default {
                             evmGasLeft := chargeGas(evmGasLeft, 2600)
                         }
+
                     // TODO: Check if the way of accessing the address is ok
-                    // in EvmInterpreter.sol:
-                    // _extcodecopy(address(uint160(addr)), destOffset, offset, size);
-                    // extcodecopy(addr, add(MEM_OFFSET(), dest), add(MEM_OFFSET(), offset), len)
+                    // Zero out the memory, is it necessary?
+                    let _lastByte := add(dest, len)
+                    for {let i := dest} lt(i, _lastByte) { i := add(i, 1) } {
+                            mstore8(i, 0)
+                    }
+                    // Gets the code from the addr
+                    pop(_fetchDeployedCode(addr, offset, len))
                 }
                 case 0x3D { // OP_RETURNDATASIZE
                     evmGasLeft := chargeGas(evmGasLeft, 2)


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Add `EXTCODESIZE` `EXTCODECOPY` `RETURNDATASIZE` `RETURNDATACOPY`

Note:  The opcode`EXTCODESIZE` makes use of the instruction extcodesize() of yul. Currently it is not supported by the `zksolc` compiler.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
