### PR TITLE
Fix some comments and typo in Mailbox and Executor

### DIFF
--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Executor.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Executor.sol
@@ -44,13 +44,13 @@ contract ExecutorFacet is ZkSyncHyperchainBase, IExecutor {
             "us"
         );
 
-        // Check that batch contain all meta information for L2 logs.
-        // Get the chained hash of priority transaction hashes.
+        // Check that batch contains all meta information for L2 logs.
+        // Get the chained hash of the priority transaction hashes.
         LogProcessingOutput memory logOutput = _processL2Logs(_newBatch, _expectedSystemContractUpgradeTxHash);
 
         bytes32[] memory blobCommitments = new bytes32[](MAX_NUMBER_OF_BLOBS);
         if (pricingMode == PubdataPricingMode.Validium) {
-            // skipping data validation for validium, we just check that the data is empty
+            // Skipping data validation for validium, we just check that the data is empty
             require(logOutput.pubdataHash == 0x00, "v0h");
             require(_newBatch.pubdataCommitments.length == 1, "EF: v0l");
         } else if (pubdataSource == uint8(PubdataSource.Blob)) {
@@ -145,7 +145,7 @@ contract ExecutorFacet is ZkSyncHyperchainBase, IExecutor {
         // See SystemLogKey enum in Constants.sol for ordering.
         uint256 processedLogs;
 
-        // linear traversal of the logs
+        // Linear traversal of the logs
         for (uint256 i = 0; i < emittedL2Logs.length; i = i.uncheckedAdd(L2_TO_L1_LOG_SERIALIZE_SIZE)) {
             // Extract the values to be compared to/used such as the log sender, key, and value
             // slither-disable-next-line unused-return
@@ -231,8 +231,8 @@ contract ExecutorFacet is ZkSyncHyperchainBase, IExecutor {
         StoredBatchInfo memory _lastCommittedBatchData,
         CommitBatchInfo[] calldata _newBatchesData
     ) internal {
-        // check that we have the right protocol version
-        // three comments:
+        // Check that we have the right protocol version
+        // Three comments:
         // 1. A chain has to keep their protocol version up to date, as processing a block requires the latest or previous protocol version
         // to solve this we will need to add the feature to create batches with only the protocol upgrade tx, without any other txs.
         // 2. A chain might become out of sync if it launches while we are in the middle of a protocol upgrade. This would mean they cannot process their genesis upgrade
@@ -242,9 +242,9 @@ contract ExecutorFacet is ZkSyncHyperchainBase, IExecutor {
             IStateTransitionManager(s.stateTransitionManager).protocolVersionIsActive(s.protocolVersion),
             "Executor facet: wrong protocol version"
         );
-        // With the new changes for EIP-4844, namely the restriction on number of blobs per block, we only allow for a single batch to be committed at a time.
+        // With the new changes for EIP-4844, namely the restriction on the number of blobs per block, we only allow for a single batch to be committed at a time.
         require(_newBatchesData.length == 1, "e4");
-        // Check that we commit batches after last committed batch
+        // Check that we commit batches after the last committed batch
         require(s.storedBatchHashes[s.totalBatchesCommitted] == _hashStoredBatchInfo(_lastCommittedBatchData), "i"); // incorrect previous batch data
 
         bytes32 systemContractsUpgradeTxHash = s.l2SystemContractsUpgradeTxHash;

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Executor.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Executor.sol
@@ -52,7 +52,7 @@ contract ExecutorFacet is ZkSyncHyperchainBase, IExecutor {
         if (pricingMode == PubdataPricingMode.Validium) {
             // Skipping data validation for validium, we just check that the data is empty
             require(logOutput.pubdataHash == 0x00, "v0h");
-            require(_newBatch.pubdataCommitments.length == 1, "EF: v0l");
+            require(_newBatch.pubdataCommitments.length == 1, "v0l");
         } else if (pubdataSource == uint8(PubdataSource.Blob)) {
             // In this scenario, pubdataCommitments is a list of: opening point (16 bytes) || claimed value (32 bytes) || commitment (48 bytes) || proof (48 bytes)) = 144 bytes
             blobCommitments = _verifyBlobInformation(_newBatch.pubdataCommitments[1:], logOutput.blobHashes);

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol
@@ -34,7 +34,7 @@ contract MailboxFacet is ZkSyncHyperchainBase, IMailbox {
     string public constant override getName = "MailboxFacet";
 
     /// @dev Era's chainID
-    uint256 immutable ERA_CHAIN_ID;
+    uint256 immutable internal ERA_CHAIN_ID;
 
     constructor(uint256 _eraChainId) {
         ERA_CHAIN_ID = _eraChainId;

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol
@@ -202,7 +202,7 @@ contract MailboxFacet is ZkSyncHyperchainBase, IMailbox {
         });
     }
 
-    ///  @inheritdoc IMailbox
+    /// @inheritdoc IMailbox
     function requestL2Transaction(
         address _contractL2,
         uint256 _l2Value,
@@ -254,7 +254,7 @@ contract MailboxFacet is ZkSyncHyperchainBase, IMailbox {
 
         // Enforcing that `_request.l2GasPerPubdataByteLimit` equals to a certain constant number. This is needed
         // to ensure that users do not get used to using "exotic" numbers for _request.l2GasPerPubdataByteLimit, e.g. 1-2, etc.
-        // VERY IMPORTANT: nobody should rely on this constant to be fixed and every contract should give their users the ability to provide the
+        // VERY IMPORTANT: nobody should rely on this constant to be fixed and every contract should give their users the
         // ability to provide `_request.l2GasPerPubdataByteLimit` for each independent transaction.
         // CHANGING THIS CONSTANT SHOULD BE A CLIENT-SIDE CHANGE.
         require(_request.l2GasPerPubdataByteLimit == REQUIRED_L2_GAS_PRICE_PER_PUBDATA, "qp");


### PR DESCRIPTION
# What ❔
1. Fix comments(related to #392)
2. Add internal as a default access prefix to Mailbox.ERA_CHAIN_ID
3. Fix error msg

## Why ❔

1. For readability
2. For explicit code expression
3. It seems different from other error messages using the error code in `Executor.sol`.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
