### PR TITLE
fix: update revert message to prevent comment syntax issues

### DIFF
--- a/l2-contracts/contracts/TestnetPaymaster.sol
+++ b/l2-contracts/contracts/TestnetPaymaster.sol
@@ -51,7 +51,7 @@ contract TestnetPaymaster is IPaymaster {
                 // If the revert reason is empty or represented by just a function selector,
                 // we replace the error with a more user-friendly message
                 if (revertReason.length <= 4) {
-                    revert("Failed to transferFrom from users account");
+                    revert("Failed to transferFrom from user's account");
                 } else {
                     assembly {
                         revert(add(0x20, revertReason), mload(revertReason))

--- a/l2-contracts/contracts/TestnetPaymaster.sol
+++ b/l2-contracts/contracts/TestnetPaymaster.sol
@@ -51,7 +51,7 @@ contract TestnetPaymaster is IPaymaster {
                 // If the revert reason is empty or represented by just a function selector,
                 // we replace the error with a more user-friendly message
                 if (revertReason.length <= 4) {
-                    revert("Failed to transferFrom from user's account");
+                    revert("Failed to transfer from the account of the user");
                 } else {
                     assembly {
                         revert(add(0x20, revertReason), mload(revertReason))

--- a/l2-contracts/contracts/TestnetPaymaster.sol
+++ b/l2-contracts/contracts/TestnetPaymaster.sol
@@ -51,7 +51,7 @@ contract TestnetPaymaster is IPaymaster {
                 // If the revert reason is empty or represented by just a function selector,
                 // we replace the error with a more user-friendly message
                 if (revertReason.length <= 4) {
-                    revert("Failed to transferFrom from user's account");
+                    revert("Failed to transferFrom from users account");
                 } else {
                     assembly {
                         revert(add(0x20, revertReason), mload(revertReason))

--- a/l2-contracts/contracts/TestnetPaymaster.sol
+++ b/l2-contracts/contracts/TestnetPaymaster.sol
@@ -51,7 +51,7 @@ contract TestnetPaymaster is IPaymaster {
                 // If the revert reason is empty or represented by just a function selector,
                 // we replace the error with a more user-friendly message
                 if (revertReason.length <= 4) {
-                    revert("Failed to transferFrom from users' account");
+                    revert("Failed to transferFrom from user's account");
                 } else {
                     assembly {
                         revert(add(0x20, revertReason), mload(revertReason))

--- a/l2-contracts/contracts/TestnetPaymaster.sol
+++ b/l2-contracts/contracts/TestnetPaymaster.sol
@@ -51,7 +51,7 @@ contract TestnetPaymaster is IPaymaster {
                 // If the revert reason is empty or represented by just a function selector,
                 // we replace the error with a more user-friendly message
                 if (revertReason.length <= 4) {
-                    revert("Failed to transfer from the account of the user");
+                    revert("Failed to execute transferFrom for the user account");
                 } else {
                     assembly {
                         revert(add(0x20, revertReason), mload(revertReason))


### PR DESCRIPTION
This pull request updates the revert message in the contract to fix grammatical errors and avoid issues with the Solidity compiler mistaking apostrophes for the beginning of a comment. The original message "Failed to transferFrom from user's account" could be misinterpreted by the compiler due to the apostrophe. The updated message avoids this issue by rephrasing to "Failed to transfer from the account of the user", thereby maintaining the intended meaning without the risk of creating syntax errors in Solidity.

 
![image](https://github.com/matter-labs/era-contracts/assets/120671243/55475887-c55f-4d7a-8f50-17c466a7b33f)
