### PR TITLE
[EVM-Equivalence-Yul] Move gas charge up on opcodes

### DIFF
--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -533,37 +533,43 @@ for { } true { } {
         _y, sp := popStackItem(sp)
     }
     case 0x51 { // OP_MLOAD
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let offset
 
         offset, sp := popStackItem(sp)
 
         let expansionGas := expandMemory(add(offset, 32))
+        evmGasLeft := chargeGas(evmGasLeft, expansionGas)
 
         let memValue := mload(add(MEM_OFFSET_INNER(), offset))
         sp := pushStackItem(sp, memValue)
-        evmGasLeft := chargeGas(evmGasLeft, add(3, expansionGas))
     }
     case 0x52 { // OP_MSTORE
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let offset, value
 
         offset, sp := popStackItem(sp)
         value, sp := popStackItem(sp)
 
         let expansionGas := expandMemory(add(offset, 32))
+        evmGasLeft := chargeGas(evmGasLeft, expansionGas)
 
         mstore(add(MEM_OFFSET_INNER(), offset), value)
-        evmGasLeft := chargeGas(evmGasLeft, add(3, expansionGas))
     }
     case 0x53 { // OP_MSTORE8
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let offset, value
 
         offset, sp := popStackItem(sp)
         value, sp := popStackItem(sp)
 
         let expansionGas := expandMemory(add(offset, 1))
+        evmGasLeft := chargeGas(evmGasLeft, expansionGas)
 
         mstore8(add(MEM_OFFSET_INNER(), offset), value)
-        evmGasLeft := chargeGas(evmGasLeft, add(3, expansionGas))
     }
     case 0x54 { // OP_SLOAD
         let key,value,isWarm

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -283,7 +283,7 @@ for { } true { } {
         // an expansion, which costs gas.
         // dynamic_gas = 6 * minimum_word_size + memory_expansion_cost
         // minimum_word_size = (size + 31) / 32
-        let minWordSize := shr(add(size, 31), 5)
+        let minWordSize := shr(5, add(size, 31))
         let dynamicGas := add(mul(6, minWordSize), expandMemory(add(offset, size)))
         evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
 
@@ -350,7 +350,7 @@ for { } true { } {
 
         // dynamic_gas = 3 * minimum_word_size + memory_expansion_cost
         // minimum_word_size = (size + 31) / 32
-        let minWordSize := shr(add(size, 31), 5)
+        let minWordSize := shr(5, add(size, 31))
         let dynamicGas := add(mul(3, minWordSize), expandMemory(add(destOffset, size)))
         evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
 

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -649,8 +649,9 @@ for { } true { } {
         sstore(key, value)
     }
     case 0x59 { // OP_MSIZE
-        let size
         evmGasLeft := chargeGas(evmGasLeft,2)
+
+        let size
 
         size := mload(MEM_OFFSET())
         size := shl(5,size)
@@ -658,10 +659,10 @@ for { } true { } {
 
     }
     case 0x58 { // OP_PC
+        evmGasLeft := chargeGas(evmGasLeft, 2)
+
         // PC = ip - 32 (bytecode size) - 1 (current instruction)
         sp := pushStackItem(sp, sub(sub(ip, BYTECODE_OFFSET()), 33))
-
-        evmGasLeft := chargeGas(evmGasLeft, 2)
     }
     case 0x5A { // OP_GAS
         evmGasLeft := chargeGas(evmGasLeft, 2)

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -288,9 +288,9 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, usedGas)
     }
     case 0x30 { // OP_ADDRESS
-        sp := pushStackItem(sp, address())
-
         evmGasLeft := chargeGas(evmGasLeft, 2)
+
+        sp := pushStackItem(sp, address())
     }
     case 0x31 { // OP_BALANCE
         let addr
@@ -306,33 +306,33 @@ for { } true { } {
         default { evmGasLeft := chargeGas(evmGasLeft, 100) }
     }
     case 0x32 { // OP_ORIGIN
-        sp := pushStackItem(sp, origin())
-
         evmGasLeft := chargeGas(evmGasLeft, 2)
+
+        sp := pushStackItem(sp, origin())
     }
     case 0x33 { // OP_CALLER
-        sp := pushStackItem(sp, caller())
-
         evmGasLeft := chargeGas(evmGasLeft, 2)
+
+        sp := pushStackItem(sp, caller())
     }
     case 0x34 { // OP_CALLVALUE
-        sp := pushStackItem(sp, callvalue())
-
         evmGasLeft := chargeGas(evmGasLeft, 2)
+
+        sp := pushStackItem(sp, callvalue())
     }
     case 0x35 { // OP_CALLDATALOAD
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let i
 
         i, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, calldataload(i))
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x36 { // OP_CALLDATASIZE
-        sp := pushStackItem(sp, calldatasize())
-
         evmGasLeft := chargeGas(evmGasLeft, 2)
+
+        sp := pushStackItem(sp, calldatasize())
     }
     case 0x37 { // OP_CALLDATACOPY
         let destOffset, offset, size

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -1201,11 +1201,13 @@ for { } true { } {
             default { sp := pushStackItem(sp, addr) }
     }
     case 0xF1 { // OP_CALL
+        evmGasLeft := chargeGas(evmGasLeft, 100)
+
         let gasUsed
 
         // A function was implemented in order to avoid stack depth errors.
         gasUsed, sp := performCall(sp, evmGasLeft, isStatic)
-        
+
         // Check if the following is ok
         evmGasLeft := chargeGas(evmGasLeft, gasUsed)
     }
@@ -1224,6 +1226,8 @@ for { } true { } {
         break
     }
     case 0xF4 { // OP_DELEGATECALL
+        evmGasLeft := chargeGas(evmGasLeft, 100)
+
         let gasUsed
         sp, isStatic, gasUsed := delegateCall(sp, isStatic, evmGasLeft)
 
@@ -1284,6 +1288,8 @@ for { } true { } {
             default { sp := pushStackItem(sp, addr) }
     }
     case 0xFA { // OP_STATICCALL
+        evmGasLeft := chargeGas(evmGasLeft, 100)
+
         let gasUsed
         gasUsed, sp := performStaticCall(sp,evmGasLeft)
         evmGasLeft := chargeGas(evmGasLeft,gasUsed)

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -281,7 +281,7 @@ for { } true { } {
 
         // When an offset is first accessed (either read or write), memory may trigger 
         // an expansion, which costs gas.
-        // dynamic_gas = 6 * minimum_word_size + memory_expansion_cost
+        // dynamicGas = 6 * minimum_word_size + memory_expansion_cost
         // minimum_word_size = (size + 31) / 32
         let minWordSize := shr(5, add(size, 31))
         let dynamicGas := add(mul(6, minWordSize), expandMemory(add(offset, size)))
@@ -348,7 +348,7 @@ for { } true { } {
         checkMemOverflow(add(add(offset, size), MEM_OFFSET_INNER()))
         checkMemOverflow(add(add(destOffset, size), MEM_OFFSET_INNER()))
 
-        // dynamic_gas = 3 * minimum_word_size + memory_expansion_cost
+        // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
         // minimum_word_size = (size + 31) / 32
         let minWordSize := shr(5, add(size, 31))
         let dynamicGas := add(mul(3, minWordSize), expandMemory(add(destOffset, size)))
@@ -371,7 +371,7 @@ for { } true { } {
         offset, sp := popStackItem(sp)
         len, sp := popStackItem(sp)
 
-        // dynamic_gas = 3 * minimum_word_size + memory_expansion_cost
+        // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
         // minimum_word_size = (size + 31) / 32
         let minWordSize := shr(5, add(len, 31))
         let dynamicGas := add(mul(3, minWordSize), expandMemory(add(dst, len)))
@@ -424,7 +424,7 @@ for { } true { } {
         offset, sp := popStackItem(sp)
         len, sp := popStackItem(sp)
 
-        // dynamic_gas = 3 * minimum_word_size + memory_expansion_cost + address_access_cost
+        // dynamicGas = 3 * minimum_word_size + memory_expansion_cost + address_access_cost
         // minimum_word_size = (size + 31) / 32
         let dynamicGas := add(
             mul(3, shr(5, add(len, 31))),
@@ -466,7 +466,7 @@ for { } true { } {
         checkMemOverflow(add(add(dest, MEM_OFFSET_INNER()), len))
 
         // minimum_word_size = (size + 31) / 32
-        // dynamic_gas = 3 * minimum_word_size + memory_expansion_cost
+        // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
         let minWordSize := shr(5, add(len, 31))
         let dynamicGas := add(mul(3, minWordSize), expandMemory(add(offset, len)))
         evmGasLeft := chargeGas(evmGasLeft, dynamicGas)

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -117,7 +117,7 @@ for { } true { } {
         sp := pushStackItem(sp, exp(a, exponent))
 
         if exponent {
-            expSizeByte := div(add(exponent, 256), 256) // TODO: Replace with shr(8, add(exponent, 256))
+            let expSizeByte := div(add(exponent, 256), 256) // TODO: Replace with shr(8, add(exponent, 256))
             evmGasLeft := chargeGas(evmGasLeft, mul(50, expSizeByte))
         }
     }

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -295,17 +295,17 @@ for { } true { } {
         sp := pushStackItem(sp, address())
     }
     case 0x31 { // OP_BALANCE
+        evmGasLeft := chargeGas(evmGasLeft, 100)
+
         let addr
 
         addr, sp := popStackItem(sp)
 
-        let wasWarm := warmAddress(addr)
+        if iszero(warmAddress(addr)) {
+            evmGasLeft := chargeGas(evmGasLeft, 2600)
+        }
 
         sp := pushStackItem(sp, balance(addr))
-
-        switch wasWarm
-        case 0 { evmGasLeft := chargeGas(evmGasLeft, 2600) }
-        default { evmGasLeft := chargeGas(evmGasLeft, 100) }
     }
     case 0x32 { // OP_ORIGIN
         evmGasLeft := chargeGas(evmGasLeft, 2)

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -673,267 +673,267 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, 1)
     }
     case 0x5F { // OP_PUSH0
+        evmGasLeft := chargeGas(evmGasLeft, 2)
+
         let value := 0
 
         sp := pushStackItem(sp, value)
-
-        evmGasLeft := chargeGas(evmGasLeft, 2)
     }
     case 0x60 { // OP_PUSH1
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,1)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 1)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x61 { // OP_PUSH2
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,2)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 2)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }     
     case 0x62 { // OP_PUSH3
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,3)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 3)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x63 { // OP_PUSH4
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,4)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 4)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x64 { // OP_PUSH5
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,5)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 5)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x65 { // OP_PUSH6
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,6)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 6)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x66 { // OP_PUSH7
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,7)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 7)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x67 { // OP_PUSH8
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,8)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 8)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x68 { // OP_PUSH9
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,9)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 9)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x69 { // OP_PUSH10
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,10)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 10)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x6A { // OP_PUSH11
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,11)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 11)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x6B { // OP_PUSH12
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,12)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 12)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x6C { // OP_PUSH13
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,13)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 13)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x6D { // OP_PUSH14
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,14)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 14)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x6E { // OP_PUSH15
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,15)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 15)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x6F { // OP_PUSH16
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,16)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 16)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x70 { // OP_PUSH17
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,17)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 17)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x71 { // OP_PUSH18
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,18)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 18)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x72 { // OP_PUSH19
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,19)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 19)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x73 { // OP_PUSH20
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,20)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 20)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x74 { // OP_PUSH21
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,21)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 21)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x75 { // OP_PUSH22
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,22)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 22)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x76 { // OP_PUSH23
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,23)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 23)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x77 { // OP_PUSH24
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,24)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 24)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x78 { // OP_PUSH25
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,25)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 25)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x79 { // OP_PUSH26
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,26)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 26)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x7A { // OP_PUSH27
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,27)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 27)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x7B { // OP_PUSH28
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,28)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 28)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x7C { // OP_PUSH29
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,29)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 29)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x7D { // OP_PUSH30
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,30)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 30)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x7E { // OP_PUSH31
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,31)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 31)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x7F { // OP_PUSH32
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let value := readBytes(ip,32)
 
         sp := pushStackItem(sp, value)
         ip := add(ip, 32)
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x80 { // OP_DUP1 
         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 1)

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -354,9 +354,10 @@ for { } true { } {
         calldatacopy(add(MEM_OFFSET_INNER(), destOffset), offset, size)
     }
     case 0x38 { // OP_CODESIZE
+        evmGasLeft := chargeGas(evmGasLeft, 2)
+
         let bytecodeLen := mload(BYTECODE_OFFSET())
         sp := pushStackItem(sp, bytecodeLen)
-        evmGasLeft := chargeGas(evmGasLeft, 2)
     }
     case 0x39 { // OP_CODECOPY
         let bytecodeLen := mload(BYTECODE_OFFSET())
@@ -387,8 +388,9 @@ for { } true { } {
         }
     }
     case 0x3A { // OP_GASPRICE
-        sp := pushStackItem(sp, gasprice())
         evmGasLeft := chargeGas(evmGasLeft, 2)
+
+        sp := pushStackItem(sp, gasprice())
     }
     case 0x3B { // OP_EXTCODESIZE
         let addr
@@ -443,6 +445,7 @@ for { } true { } {
     }
     case 0x3D { // OP_RETURNDATASIZE
         evmGasLeft := chargeGas(evmGasLeft, 2)
+
         let rdz := mload(LAST_RETURNDATA_SIZE_OFFSET())
         sp := pushStackItem(sp, rdz)
     }
@@ -485,10 +488,11 @@ for { } true { } {
         sp := pushStackItem(sp, extcodehash(addr))
     }
     case 0x40 { // OP_BLOCKHASH
+        evmGasLeft := chargeGas(evmGasLeft, 20)
+
         let blockNumber
         blockNumber, sp := popStackItem(sp)
 
-        evmGasLeft := chargeGas(evmGasLeft, 20)
         sp := pushStackItem(sp, blockhash(blockNumber))
     }
     case 0x41 { // OP_COINBASE
@@ -524,11 +528,11 @@ for { } true { } {
         sp := pushStackItem(sp, basefee())
     }
     case 0x50 { // OP_POP
+        evmGasLeft := chargeGas(evmGasLeft, 2)
+
         let _y
 
         _y, sp := popStackItem(sp)
-
-        evmGasLeft := chargeGas(evmGasLeft, 2)
     }
     case 0x51 { // OP_MLOAD
         let offset

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -182,7 +182,7 @@ for { } true { } {
         sp := pushStackItem(sp, eq(a, b))
     }
     case 0x15 { // OP_ISZERO
-        //evmGasLeft := chargeGas(evmGasLeft, 3) TODO: Add this back
+        evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let a
 

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -570,13 +570,13 @@ for { } true { } {
     // NOTE: We don't currently do full jumpdest validation
     // (i.e. validating a jumpdest isn't in PUSH data)
     case 0x56 { // OP_JUMP
+        evmGasLeft := chargeGas(evmGasLeft, 8)
+
         let counter
 
         counter, sp := popStackItem(sp)
 
         ip := add(add(BYTECODE_OFFSET(), 32), counter)
-
-        evmGasLeft := chargeGas(evmGasLeft, 8)
 
         // Check next opcode is JUMPDEST
         let nextOpcode := readIP(ip)
@@ -585,12 +585,12 @@ for { } true { } {
         }
     }
     case 0x57 { // OP_JUMPI
+        evmGasLeft := chargeGas(evmGasLeft, 10)
+
         let counter, b
 
         counter, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
-
-        evmGasLeft := chargeGas(evmGasLeft, 10)
 
         if iszero(b) {
             continue

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -120,16 +120,18 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, add(10, mul(50, expSizeByte)))
     }
     case 0x0B { // OP_SIGNEXTEND
+        evmGasLeft := chargeGas(evmGasLeft, 5)
+
         let b, x
 
         b, sp := popStackItem(sp)
         x, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, signextend(b, x))
-
-        evmGasLeft := chargeGas(evmGasLeft, 5)
     }
     case 0x08 { // OP_ADDMOD
+        evmGasLeft := chargeGas(evmGasLeft, 8)
+
         let a, b, N
 
         a, sp := popStackItem(sp)
@@ -137,10 +139,10 @@ for { } true { } {
         N, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, addmod(a, b, N))
-
-        evmGasLeft := chargeGas(evmGasLeft, 8)
     }
     case 0x09 { // OP_MULMOD
+        evmGasLeft := chargeGas(evmGasLeft, 8)
+
         let a, b, N
 
         a, sp := popStackItem(sp)
@@ -148,126 +150,124 @@ for { } true { } {
         N, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, mulmod(a, b, N))
-
-        evmGasLeft := chargeGas(evmGasLeft, 8)
     }
     case 0x10 { // OP_LT
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let a, b
 
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, lt(a, b))
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x11 { // OP_GT
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let a, b
 
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, gt(a, b))
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x12 { // OP_SLT
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let a, b
 
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, slt(a, b))
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x13 { // OP_SGT
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let a, b
 
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, sgt(a, b))
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x14 { // OP_EQ
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let a, b
 
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, eq(a, b))
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x15 { // OP_ISZERO
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let a
 
         a, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, iszero(a))
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x18 { // OP_XOR
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let a, b
 
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, xor(a, b))
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x19 { // OP_NOT
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let a
 
         a, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, not(a))
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x1A { // OP_BYTE
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let i, x
 
         i, sp := popStackItem(sp)
         x, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, byte(i, x))
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x1B { // OP_SHL
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let shift, value
 
         shift, sp := popStackItem(sp)
         value, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, shl(shift, value))
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x1C { // OP_SHR
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let shift, value
 
         shift, sp := popStackItem(sp)
         value, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, shr(shift, value))
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x1D { // OP_SAR
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let shift, value
 
         shift, sp := popStackItem(sp)
         value, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, sar(shift, value))
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
 
     case 0x20 { // OP_KECCAK256

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -302,7 +302,7 @@ for { } true { } {
         addr, sp := popStackItem(sp)
 
         if iszero(warmAddress(addr)) {
-            evmGasLeft := chargeGas(evmGasLeft, 2600)
+            evmGasLeft := chargeGas(evmGasLeft, 2500)
         }
 
         sp := pushStackItem(sp, balance(addr))
@@ -400,12 +400,12 @@ for { } true { } {
     }
     case 0x3B { // OP_EXTCODESIZE
         evmGasLeft := chargeGas(evmGasLeft, 100)
-        
+
         let addr
         addr, sp := popStackItem(sp)
 
         if iszero(warmAddress(addr)) {
-            evmGasLeft := chargeGas(evmGasLeft, 2600)
+            evmGasLeft := chargeGas(evmGasLeft, 2500)
         }
 
         // TODO: check, the .sol uses extcodesize directly, but it doesnt seem to work

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -15,87 +15,94 @@ for { } true { } {
         break
     }
     case 0x01 { // OP_ADD
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let a, b
 
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, add(a, b))
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x02 { // OP_MUL
+        evmGasLeft := chargeGas(evmGasLeft, 5)
+
         let a, b
 
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, mul(a, b))
-        evmGasLeft := chargeGas(evmGasLeft, 5)
     }
     case 0x03 { // OP_SUB
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let a, b
 
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, sub(a, b))
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x04 { // OP_DIV
+        evmGasLeft := chargeGas(evmGasLeft, 5)
+
         let a, b
 
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, div(a, b))
-        evmGasLeft := chargeGas(evmGasLeft, 5)
     }
     case 0x05 { // OP_SDIV
+        evmGasLeft := chargeGas(evmGasLeft, 5)
+
         let a, b
 
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, sdiv(a, b))
-        evmGasLeft := chargeGas(evmGasLeft, 5)
     }
     case 0x06 { // OP_MOD
+        evmGasLeft := chargeGas(evmGasLeft, 5)
+
         let a, b
 
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, mod(a, b))
-        evmGasLeft := chargeGas(evmGasLeft, 5)
     }
     case 0x07 { // OP_SMOD
+        evmGasLeft := chargeGas(evmGasLeft, 5)
+
         let a, b
 
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, smod(a, b))
-        evmGasLeft := chargeGas(evmGasLeft, 5)
     }
     case 0x16 { // OP_AND
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let a, b
 
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, and(a,b))
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x17 { // OP_OR
+        evmGasLeft := chargeGas(evmGasLeft, 3)
+
         let a, b
 
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
         sp := pushStackItem(sp, or(a,b))
-
-        evmGasLeft := chargeGas(evmGasLeft, 3)
     }
     case 0x0A { // OP_EXP
         let a, exponent

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -1045,6 +1045,8 @@ for { } true { } {
         evmGasLeft := swapStackItem(sp, evmGasLeft, 16)
     }
     case 0xA0 { // OP_LOG0
+        evmGasLeft := chargeGas(evmGasLeft, 375)
+
         if isStatic {
             revert(0, 0)
         }
@@ -1053,17 +1055,17 @@ for { } true { } {
         offset, sp := popStackItem(sp)
         size, sp := popStackItem(sp)
 
-        checkMemOverflow(add(offset, MEM_OFFSET_INNER()))
         checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size))
 
-        {
-            let gasUsed := add(add(375, mul(8, size)), expandMemory(add(offset, size)))
-            evmGasLeft := chargeGas(evmGasLeft, gasUsed)
-        }
+        // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
+        let dynamicGas := add(shl(3, size), expandMemory(add(offset, size)))
+        evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
 
         log0(add(offset, MEM_OFFSET_INNER()), size)
     }
     case 0xA1 { // OP_LOG1
+        evmGasLeft := chargeGas(evmGasLeft, 375)
+
         if isStatic {
             revert(0, 0)
         }
@@ -1073,11 +1075,12 @@ for { } true { } {
         size, sp := popStackItem(sp)
         topic1, sp := popStackItem(sp)
 
-        checkMemOverflow(add(offset, MEM_OFFSET_INNER()))
         checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size))
 
-        let gasUsed := add(add(750, mul(8, size)), expandMemory(add(offset, size)))
-        evmGasLeft := chargeGas(evmGasLeft, gasUsed)
+        // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
+        let dynamicGas := add(shl(3, size), expandMemory(add(offset, size)))
+        dynamicGas := add(dynamicGas, 375)
+        evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
 
         log1(add(offset, MEM_OFFSET_INNER()), size, topic1)
     }
@@ -1086,24 +1089,24 @@ for { } true { } {
             revert(0, 0)
         }
 
-        let offset, size
+        let offset, size, topic1, topic2
         offset, sp := popStackItem(sp)
         size, sp := popStackItem(sp)
+        topic1, sp := popStackItem(sp)
+        topic2, sp := popStackItem(sp)
 
-        checkMemOverflow(add(offset, MEM_OFFSET_INNER()))
         checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size))
 
-        let gasUsed := add(add(1125, mul(8, size)), expandMemory(add(offset, size)))
-        evmGasLeft := chargeGas(evmGasLeft, gasUsed)
+        // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
+        let dynamicGas := add(shl(3, size), expandMemory(add(offset, size)))
+        dynamicGas := add(dynamicGas, 750)
+        evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
 
-        {
-            let topic1, topic2
-            topic1, sp := popStackItem(sp)
-            topic2, sp := popStackItem(sp)
-            log2(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2)
-        }
+        log2(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2)
     }
     case 0xA3 { // OP_LOG3
+        evmGasLeft := chargeGas(evmGasLeft, 375)
+
         if isStatic {
             revert(0, 0)
         }
@@ -1112,11 +1115,12 @@ for { } true { } {
         offset, sp := popStackItem(sp)
         size, sp := popStackItem(sp)
 
-        checkMemOverflow(add(offset, MEM_OFFSET_INNER()))
         checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size))
 
-        let gasUsed := add(add(1500, mul(8, size)), expandMemory(add(offset, size)))
-        evmGasLeft := chargeGas(evmGasLeft, gasUsed)
+        // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
+        let dynamicGas := add(shl(3, size), expandMemory(add(offset, size)))
+        dynamicGas := add(dynamicGas, 1125)
+        evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
 
         {
             let topic1, topic2, topic3
@@ -1127,6 +1131,8 @@ for { } true { } {
         }
     }
     case 0xA4 { // OP_LOG4
+        evmGasLeft := chargeGas(evmGasLeft, 375)
+
         if isStatic {
             revert(0, 0)
         }
@@ -1135,11 +1141,12 @@ for { } true { } {
         offset, sp := popStackItem(sp)
         size, sp := popStackItem(sp)
 
-        checkMemOverflow(add(offset, MEM_OFFSET_INNER()))
         checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size))
 
-        let gasUsed := add(add(1875, mul(8, size)), expandMemory(add(offset, size)))
-        evmGasLeft := chargeGas(evmGasLeft, gasUsed)
+        // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
+        let dynamicGas := add(shl(3, size), expandMemory(add(offset, size)))
+        dynamicGas := add(dynamicGas, 1500)
+        evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
 
         {
             let topic1, topic2, topic3, topic4

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -270,12 +270,14 @@ for { } true { } {
         sp := pushStackItem(sp, sar(shift, value))
     }
     case 0x20 { // OP_KECCAK256
+        evmGasLeft := chargeGas(evmGasLeft, 30)
+
         let offset, size
 
         offset, sp := popStackItem(sp)
         size, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, keccak256(add(MEM_OFFSET_INNER(), offset), size))
+        let keccak := keccak256(add(MEM_OFFSET_INNER(), offset), size)
 
         // When an offset is first accessed (either read or write), memory may trigger 
         // an expansion, which costs gas.
@@ -283,8 +285,9 @@ for { } true { } {
         // minimum_word_size = (size + 31) / 32
         let minWordSize := shr(add(size, 31), 5)
         let dynamicGas := add(mul(6, minWordSize), expandMemory(add(offset, size)))
-        let usedGas := add(30, dynamicGas)
-        evmGasLeft := chargeGas(evmGasLeft, usedGas)
+        evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
+
+        sp := pushStackItem(sp, keccak)
     }
     case 0x30 { // OP_ADDRESS
         evmGasLeft := chargeGas(evmGasLeft, 2)

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -107,6 +107,8 @@ for { } true { } {
         sp := pushStackItem(sp, mulmod(a, b, N))
     }
     case 0x0A { // OP_EXP
+        evmGasLeft := chargeGas(evmGasLeft, 10)
+
         let a, exponent
 
         a, sp := popStackItem(sp)
@@ -114,12 +116,10 @@ for { } true { } {
 
         sp := pushStackItem(sp, exp(a, exponent))
 
-        let expSizeByte := 0
         if exponent {
-            expSizeByte := div(add(exponent, 256), 256)
+            expSizeByte := div(add(exponent, 256), 256) // TODO: Replace with shr(8, add(exponent, 256))
+            evmGasLeft := chargeGas(evmGasLeft, mul(50, expSizeByte))
         }
-
-        evmGasLeft := chargeGas(evmGasLeft, add(10, mul(50, expSizeByte)))
     }
     case 0x0B { // OP_SIGNEXTEND
         evmGasLeft := chargeGas(evmGasLeft, 5)

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -399,17 +399,14 @@ for { } true { } {
         sp := pushStackItem(sp, gasprice())
     }
     case 0x3B { // OP_EXTCODESIZE
+        evmGasLeft := chargeGas(evmGasLeft, 100)
+        
         let addr
         addr, sp := popStackItem(sp)
 
-        // Check if its warm or cold
-        switch warmAddress(addr)
-            case true {
-                evmGasLeft := chargeGas(evmGasLeft, 100)
-            }
-            default {
-                evmGasLeft := chargeGas(evmGasLeft, 2600)
-            }
+        if iszero(warmAddress(addr)) {
+            evmGasLeft := chargeGas(evmGasLeft, 2600)
+        }
 
         // TODO: check, the .sol uses extcodesize directly, but it doesnt seem to work
         // if a contract is created it works, but if the address is a zkSync's contract

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -474,17 +474,14 @@ for { } true { } {
         copyActivePtrData(add(MEM_OFFSET_INNER(), dest), offset, len)
     }
     case 0x3F { // OP_EXTCODEHASH
+        evmGasLeft := chargeGas(evmGasLeft, 100)
+
         let addr
         addr, sp := popStackItem(sp)
 
-
-        switch warmAddress(addr)
-            case 0 { 
-                evmGasLeft := chargeGas(evmGasLeft,2600) 
-            }
-            default { 
-                evmGasLeft := chargeGas(evmGasLeft,100) 
-            }
+        if iszero(warmAddress(addr)) {
+            evmGasLeft := chargeGas(evmGasLeft, 2500) 
+        }
 
         sp := pushStackItem(sp, extcodehash(addr))
     }


### PR DESCRIPTION
# What ❔

This PR moves the gas charge upper so if the opcode fails and reverts, the gas is charged anyway.

Works with tests on [zksync-era #1837](https://github.com/matter-labs/zksync-era/pull/1837)
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
