### PR TITLE
[EVM-Equivalence-Yul] Fix extcodehash on EVM contracts

### DIFF
--- a/system-contracts/contracts/AccountCodeStorage.sol
+++ b/system-contracts/contracts/AccountCodeStorage.sol
@@ -108,6 +108,10 @@ contract AccountCodeStorage is IAccountCodeStorage {
             codeHash = EMPTY_STRING_KECCAK;
         }
 
+        if (Utils.isCodeHashEVM(codeHash)) {
+            codeHash = DEPLOYER_SYSTEM_CONTRACT.evmCodeHash(account);
+        }
+
         return codeHash;
     }
 


### PR DESCRIPTION
# What ❔

`extcodehash` opcode now returns the keccak256 hash of the deployed code instead of the zkevm versioned hash.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

This enhance EVM compatibility
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
