### PR TITLE
Packed protocol version

### DIFF
--- a/l1-contracts/contracts/common/Config.sol
+++ b/l1-contracts/contracts/common/Config.sol
@@ -27,15 +27,6 @@ uint256 constant PRIORITY_OPERATION_L2_TX_TYPE = 255;
 /// @dev Denotes the type of the zkSync transaction that is used for system upgrades.
 uint256 constant SYSTEM_UPGRADE_L2_TX_TYPE = 254;
 
-/// @dev The number of bits dedicated to the "patch" portion of the protocol version.
-/// This also defines the bit starting from which the "minor" part is located.
-uint256 constant SEMVER_MINOR_OFFSET = 32;
-
-/// @dev The number of bits dedicated to the "patch" and "minor" portions of the protocol version.
-/// This also defines the bit starting from which the "major" part is located.
-/// Note, that currently, only major version of "0" is supported.
-uint256 constant SEMVER_MAJOR_OFFSET = 64;
-
 /// @dev The maximal allowed difference between protocol versions in an upgrade. The 100 gap is needed
 /// in case a protocol version has been tested on testnet, but then not launched on mainnet, e.g.
 /// due to a bug found.

--- a/l1-contracts/contracts/common/Config.sol
+++ b/l1-contracts/contracts/common/Config.sol
@@ -30,9 +30,10 @@ uint256 constant SYSTEM_UPGRADE_L2_TX_TYPE = 254;
 /// @dev The number of bits dedicated to the "patch" portion of the protocol version.
 /// This also defines the bit starting from which the "minor" part is located.
 uint256 constant SEMVER_MINOR_OFFSET = 32;
+
 /// @dev The number of bits dedicated to the "patch" and "minor" portions of the protocol version.
 /// This also defines the bit starting from which the "major" part is located.
-/// @notice Currently, only major version of "0" is supported.
+/// Note, that currently, only major version of "0" is supported.
 uint256 constant SEMVER_MAJOR_OFFSET = 64;
 
 /// @dev The maximal allowed difference between protocol versions in an upgrade. The 100 gap is needed
@@ -40,9 +41,6 @@ uint256 constant SEMVER_MAJOR_OFFSET = 64;
 /// due to a bug found.
 /// We are allowed to jump at most 100 minor versions at a time. The major version is always expected to be 0.
 uint256 constant MAX_ALLOWED_MINOR_VERSION_DELTA = 100;
-
-/// @dev The same as `MAX_ALLOWED_MINOR_VERSION_DELTA` but in the absolute terms for protocolUpgrade
-uint256 constant MAX_ALLOWED_PROTOCOL_VERSION_DELTA = MAX_ALLOWED_MINOR_VERSION_DELTA * (1 << SEMVER_MINOR_OFFSET);
 
 /// @dev The amount of time in seconds the validator has to process the priority transaction
 /// NOTE: The constant is set to zero for the Alpha release period

--- a/l1-contracts/contracts/common/Config.sol
+++ b/l1-contracts/contracts/common/Config.sol
@@ -30,7 +30,7 @@ uint256 constant SYSTEM_UPGRADE_L2_TX_TYPE = 254;
 /// @dev The maximal allowed difference between protocol versions in an upgrade. The 100 gap is needed
 /// in case a protocol version has been tested on testnet, but then not launched on mainnet, e.g.
 /// due to a bug found.
-/// We are allowed to jump at most 100 minor versions at a time. 
+/// We are allowed to jump at most 100 minor versions at a time.
 uint256 constant MAX_ALLOWED_PROTOCOL_VERSION_DELTA = 100 * (1 << 32);
 
 /// @dev The amount of time in seconds the validator has to process the priority transaction

--- a/l1-contracts/contracts/common/Config.sol
+++ b/l1-contracts/contracts/common/Config.sol
@@ -30,7 +30,8 @@ uint256 constant SYSTEM_UPGRADE_L2_TX_TYPE = 254;
 /// @dev The maximal allowed difference between protocol versions in an upgrade. The 100 gap is needed
 /// in case a protocol version has been tested on testnet, but then not launched on mainnet, e.g.
 /// due to a bug found.
-uint256 constant MAX_ALLOWED_PROTOCOL_VERSION_DELTA = 100;
+/// We are allowed to jump at most 100 minor versions at a time. 
+uint256 constant MAX_ALLOWED_PROTOCOL_VERSION_DELTA = 100 * (1 << 32);
 
 /// @dev The amount of time in seconds the validator has to process the priority transaction
 /// NOTE: The constant is set to zero for the Alpha release period

--- a/l1-contracts/contracts/common/Config.sol
+++ b/l1-contracts/contracts/common/Config.sol
@@ -27,11 +27,22 @@ uint256 constant PRIORITY_OPERATION_L2_TX_TYPE = 255;
 /// @dev Denotes the type of the zkSync transaction that is used for system upgrades.
 uint256 constant SYSTEM_UPGRADE_L2_TX_TYPE = 254;
 
+/// @dev The number of bits dedicated to the "patch" portion of the protocol version.
+/// This also defines the bit starting from which the "minor" part is located.
+uint256 constant SEMVER_MINOR_OFFSET = 32;
+/// @dev The number of bits dedicated to the "patch" and "minor" portions of the protocol version.
+/// This also defines the bit starting from which the "major" part is located.
+/// @notice Currently, only major version of "0" is supported.
+uint256 constant SEMVER_MAJOR_OFFSET = 64;
+
 /// @dev The maximal allowed difference between protocol versions in an upgrade. The 100 gap is needed
 /// in case a protocol version has been tested on testnet, but then not launched on mainnet, e.g.
 /// due to a bug found.
-/// We are allowed to jump at most 100 minor versions at a time.
-uint256 constant MAX_ALLOWED_PROTOCOL_VERSION_DELTA = 100 * (1 << 32);
+/// We are allowed to jump at most 100 minor versions at a time. The major version is always expected to be 0.
+uint256 constant MAX_ALLOWED_MINOR_VERSION_DELTA = 100;
+
+/// @dev The same as `MAX_ALLOWED_MINOR_VERSION_DELTA` but in the absolute terms for protocolUpgrade
+uint256 constant MAX_ALLOWED_PROTOCOL_VERSION_DELTA = MAX_ALLOWED_MINOR_VERSION_DELTA * (1 << SEMVER_MINOR_OFFSET);
 
 /// @dev The amount of time in seconds the validator has to process the priority transaction
 /// NOTE: The constant is set to zero for the Alpha release period

--- a/l1-contracts/contracts/common/libraries/SemVer.sol
+++ b/l1-contracts/contracts/common/libraries/SemVer.sol
@@ -2,7 +2,14 @@
 
 pragma solidity 0.8.24;
 
-import {SEMVER_MINOR_OFFSET, SEMVER_MAJOR_OFFSET} from "../Config.sol";
+/// @dev The number of bits dedicated to the "patch" portion of the protocol version.
+/// This also defines the bit starting from which the "minor" part is located.
+uint256 constant SEMVER_MINOR_OFFSET = 32;
+
+/// @dev The number of bits dedicated to the "patch" and "minor" portions of the protocol version.
+/// This also defines the bit starting from which the "major" part is located.
+/// Note, that currently, only major version of "0" is supported.
+uint256 constant SEMVER_MAJOR_OFFSET = 64;
 
 /**
  * @author Matter Labs
@@ -16,9 +23,8 @@ library SemVer {
     /// @return minor The minor version.
     /// @return patch The patch version.
     function unpackSemVer(
-        uint256 _packedProtocolVersion
+        uint96 _packedProtocolVersion
     ) internal pure returns (uint32 major, uint32 minor, uint32 patch) {
-        require(_packedProtocolVersion <= uint256(type(uint96).max), "Semver: version is too large");
         patch = uint32(_packedProtocolVersion);
         minor = uint32(_packedProtocolVersion >> SEMVER_MINOR_OFFSET);
         major = uint32(_packedProtocolVersion >> SEMVER_MAJOR_OFFSET);

--- a/l1-contracts/contracts/common/libraries/SemVer.sol
+++ b/l1-contracts/contracts/common/libraries/SemVer.sol
@@ -4,7 +4,17 @@ pragma solidity 0.8.24;
 
 import {SEMVER_MINOR_OFFSET, SEMVER_MAJOR_OFFSET} from "../Config.sol";
 
+/**
+ * @author Matter Labs
+ * @custom:security-contact security@matterlabs.dev
+ * @notice The library for managing SemVer for the protocol version.
+ */
 library SemVer {
+    /// @notice Unpacks the SemVer version from a single uint256 into major, minor and patch components.
+    /// @param _packedProtocolVersion The packed protocol version.
+    /// @return major The major version.
+    /// @return minor The minor version.
+    /// @return patch The patch version.
     function unpackSemVer(
         uint256 _packedProtocolVersion
     ) internal pure returns (uint32 major, uint32 minor, uint32 patch) {

--- a/l1-contracts/contracts/common/libraries/SemVer.sol
+++ b/l1-contracts/contracts/common/libraries/SemVer.sol
@@ -40,6 +40,9 @@ library SemVer {
         uint32 _minor,
         uint32 _patch
     ) internal pure returns (uint96 packedProtocolVersion) {
-        packedProtocolVersion = uint96(_patch) | (uint96(_minor) << SEMVER_MINOR_OFFSET) | (uint96(_major) << SEMVER_MAJOR_OFFSET);
+        packedProtocolVersion =
+            uint96(_patch) |
+            (uint96(_minor) << SEMVER_MINOR_OFFSET) |
+            (uint96(_major) << SEMVER_MAJOR_OFFSET);
     }
 }

--- a/l1-contracts/contracts/common/libraries/SemVer.sol
+++ b/l1-contracts/contracts/common/libraries/SemVer.sol
@@ -2,14 +2,13 @@
 
 pragma solidity 0.8.24;
 
-uint256 constant UINT32_MASK = 0xFFFFFFFF;
-
+import { SEMVER_MINOR_OFFSET, SEMVER_MAJOR_OFFSET } from "../Config.sol"; 
 
 library SemVer {
     function unpackSemVer(
         uint256 _packedProtocolVersion
     ) internal pure returns (uint32 major, uint32 minor, uint32 patch) {
-        require(_packedProtocolVersion <= uint256(uint96.max), "Semver: version is too large");
+        require(_packedProtocolVersion <= uint256(type(uint96).max), "Semver: version is too large");
         patch = uint32(_packedProtocolVersion);
         minor = uint32(_packedProtocolVersion >> SEMVER_MINOR_OFFSET);
         major = uint32(_packedProtocolVersion >> SEMVER_MAJOR_OFFSET);

--- a/l1-contracts/contracts/common/libraries/SemVer.sol
+++ b/l1-contracts/contracts/common/libraries/SemVer.sol
@@ -8,7 +8,9 @@ uint256 constant SEMVER_MINOR_OFFSET = 32;
 uint256 constant SEMVER_MAJOR_OFFSET = 64;
 
 library SemVer {
-    function unpackSemVer(uint256 _packedProtocolVersion)internal pure returns (uint32 major, uint32 minor, uint32 patch)  {
+    function unpackSemVer(
+        uint256 _packedProtocolVersion
+    ) internal pure returns (uint32 major, uint32 minor, uint32 patch) {
         patch = uint32(_packedProtocolVersion);
         minor = uint32(_packedProtocolVersion >> SEMVER_MINOR_OFFSET);
         major = uint32(_packedProtocolVersion >> SEMVER_MAJOR_OFFSET);

--- a/l1-contracts/contracts/common/libraries/SemVer.sol
+++ b/l1-contracts/contracts/common/libraries/SemVer.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+uint256 constant UINT32_MASK = 0xFFFFFFFF;
+
+uint256 constant SEMVER_MINOR_OFFSET = 32;
+uint256 constant SEMVER_MAJOR_OFFSET = 64;
+
+library SemVer {
+    function unpackSemVer(uint256 _packedProtocolVersion) returns (uint32 major, uint32 minor, uint32 patch) {
+        patch = (_packedProtocolVersion & UINT32_MASK);
+        minor = (_packedProtocolVersion >> SEMVER_MINOR_OFFSET) & UINT32_MASK;
+        major = (_packedProtocolVersion >> SEMVER_MAJOR_OFFSET) & UINT32_MASK;
+    }
+
+    function packSemVer(uint256 _major, uint256 _minor, uint256 _patch) returns (uint256) {
+        return (_major << SEMVER_MAJOR_OFFSET) | (_minor << SEMVER_MINOR_OFFSET) | (_patch);
+    }
+}

--- a/l1-contracts/contracts/common/libraries/SemVer.sol
+++ b/l1-contracts/contracts/common/libraries/SemVer.sol
@@ -29,4 +29,17 @@ library SemVer {
         minor = uint32(_packedProtocolVersion >> SEMVER_MINOR_OFFSET);
         major = uint32(_packedProtocolVersion >> SEMVER_MAJOR_OFFSET);
     }
+
+    /// @notice Packs the SemVer version from the major, minor and patch components into a single uint96.
+    /// @param _major The major version.
+    /// @param _minor The minor version.
+    /// @param _patch The patch version.
+    /// @return packedProtocolVersion The packed protocol version.
+    function packSemVer(
+        uint32 _major,
+        uint32 _minor,
+        uint32 _patch
+    ) internal pure returns (uint96 packedProtocolVersion) {
+        packedProtocolVersion = uint96(_patch) | (uint96(_minor) << SEMVER_MINOR_OFFSET) | (uint96(_major) << SEMVER_MAJOR_OFFSET);
+    }
 }

--- a/l1-contracts/contracts/common/libraries/SemVer.sol
+++ b/l1-contracts/contracts/common/libraries/SemVer.sol
@@ -8,13 +8,9 @@ uint256 constant SEMVER_MINOR_OFFSET = 32;
 uint256 constant SEMVER_MAJOR_OFFSET = 64;
 
 library SemVer {
-    function unpackSemVer(uint256 _packedProtocolVersion) returns (uint32 major, uint32 minor, uint32 patch) {
-        patch = (_packedProtocolVersion & UINT32_MASK);
-        minor = (_packedProtocolVersion >> SEMVER_MINOR_OFFSET) & UINT32_MASK;
-        major = (_packedProtocolVersion >> SEMVER_MAJOR_OFFSET) & UINT32_MASK;
-    }
-
-    function packSemVer(uint256 _major, uint256 _minor, uint256 _patch) returns (uint256) {
-        return (_major << SEMVER_MAJOR_OFFSET) | (_minor << SEMVER_MINOR_OFFSET) | (_patch);
+    function unpackSemVer(uint256 _packedProtocolVersion)internal pure returns (uint32 major, uint32 minor, uint32 patch)  {
+        patch = uint32(_packedProtocolVersion);
+        minor = uint32(_packedProtocolVersion >> SEMVER_MINOR_OFFSET);
+        major = uint32(_packedProtocolVersion >> SEMVER_MAJOR_OFFSET);
     }
 }

--- a/l1-contracts/contracts/common/libraries/SemVer.sol
+++ b/l1-contracts/contracts/common/libraries/SemVer.sol
@@ -2,7 +2,7 @@
 
 pragma solidity 0.8.24;
 
-import { SEMVER_MINOR_OFFSET, SEMVER_MAJOR_OFFSET } from "../Config.sol"; 
+import {SEMVER_MINOR_OFFSET, SEMVER_MAJOR_OFFSET} from "../Config.sol";
 
 library SemVer {
     function unpackSemVer(

--- a/l1-contracts/contracts/common/libraries/SemVer.sol
+++ b/l1-contracts/contracts/common/libraries/SemVer.sol
@@ -4,13 +4,12 @@ pragma solidity 0.8.24;
 
 uint256 constant UINT32_MASK = 0xFFFFFFFF;
 
-uint256 constant SEMVER_MINOR_OFFSET = 32;
-uint256 constant SEMVER_MAJOR_OFFSET = 64;
 
 library SemVer {
     function unpackSemVer(
         uint256 _packedProtocolVersion
     ) internal pure returns (uint32 major, uint32 minor, uint32 patch) {
+        require(_packedProtocolVersion <= uint256(uint96.max), "Semver: version is too large");
         patch = uint32(_packedProtocolVersion);
         minor = uint32(_packedProtocolVersion >> SEMVER_MINOR_OFFSET);
         major = uint32(_packedProtocolVersion >> SEMVER_MAJOR_OFFSET);

--- a/l1-contracts/contracts/dev-contracts/test/CustomUpgradeTest.sol
+++ b/l1-contracts/contracts/dev-contracts/test/CustomUpgradeTest.sol
@@ -28,16 +28,17 @@ contract CustomUpgradeTest is BaseZkSyncUpgrade {
     /// @notice The main function that will be called by the upgrade proxy.
     /// @param _proposedUpgrade The upgrade to be executed.
     function upgrade(ProposedUpgrade calldata _proposedUpgrade) public override returns (bytes32) {
-        _setNewProtocolVersion(_proposedUpgrade.newProtocolVersion);
+        (uint32 newMinorVersion, bool isPatchOnly) = _setNewProtocolVersion(_proposedUpgrade.newProtocolVersion);
         _upgradeL1Contract(_proposedUpgrade.l1ContractsUpgradeCalldata);
         _upgradeVerifier(_proposedUpgrade.verifier, _proposedUpgrade.verifierParams);
-        _setBaseSystemContracts(_proposedUpgrade.bootloaderHash, _proposedUpgrade.defaultAccountHash);
+        _setBaseSystemContracts(_proposedUpgrade.bootloaderHash, _proposedUpgrade.defaultAccountHash, isPatchOnly);
 
         bytes32 txHash;
         txHash = _setL2SystemContractUpgrade(
             _proposedUpgrade.l2ProtocolUpgradeTx,
             _proposedUpgrade.factoryDeps,
-            _proposedUpgrade.newProtocolVersion
+            newMinorVersion,
+            isPatchOnly
         );
 
         _postUpgrade(_proposedUpgrade.postUpgradeCalldata);

--- a/l1-contracts/contracts/state-transition/IStateTransitionManager.sol
+++ b/l1-contracts/contracts/state-transition/IStateTransitionManager.sol
@@ -131,4 +131,6 @@ interface IStateTransitionManager {
         uint256 _oldProtocolVersion,
         Diamond.DiamondCutData calldata _diamondCut
     ) external;
+
+    function getSemverProtocolVersion() external view returns (uint32, uint32, uint32);
 }

--- a/l1-contracts/contracts/state-transition/StateTransitionManager.sol
+++ b/l1-contracts/contracts/state-transition/StateTransitionManager.sol
@@ -287,6 +287,7 @@ contract StateTransitionManager is IStateTransitionManager, ReentrancyGuard, Own
         bytes[] memory bytesEmptyArray;
 
         uint256 cachedProtocolVersion = protocolVersion;
+        // slither-disable-next-line unused-return
         (, uint32 minorVersion, ) = SemVer.unpackSemVer(cachedProtocolVersion);
 
         L2CanonicalTransaction memory l2ProtocolUpgradeTx = L2CanonicalTransaction({

--- a/l1-contracts/contracts/state-transition/StateTransitionManager.sol
+++ b/l1-contracts/contracts/state-transition/StateTransitionManager.sol
@@ -293,7 +293,7 @@ contract StateTransitionManager is IStateTransitionManager, ReentrancyGuard, Own
             maxFeePerGas: uint256(0),
             maxPriorityFeePerGas: uint256(0),
             paymaster: uint256(0),
-            // Note, that the protocol version is used as "nonce" for system upgrade transactions
+            // Note, that the `minor` of the protocol version is used as "nonce" for system upgrade transactions
             nonce: uint256(minorVersion),
             value: 0,
             reserved: [uint256(0), 0, 0, 0],
@@ -318,7 +318,7 @@ contract StateTransitionManager is IStateTransitionManager, ReentrancyGuard, Own
             l1ContractsUpgradeCalldata: new bytes(0),
             postUpgradeCalldata: new bytes(0),
             upgradeTimestamp: 0,
-            newProtocolVersion: protocolVersion
+            newProtocolVersion: cachedProtocolVersion
         });
 
         Diamond.FacetCut[] memory emptyArray;
@@ -329,7 +329,7 @@ contract StateTransitionManager is IStateTransitionManager, ReentrancyGuard, Own
         });
 
         IAdmin(_chainContract).executeUpgrade(cutData);
-        emit SetChainIdUpgrade(_chainContract, l2ProtocolUpgradeTx, protocolVersion);
+        emit SetChainIdUpgrade(_chainContract, l2ProtocolUpgradeTx, cachedProtocolVersion);
     }
 
     /// @dev used to register already deployed hyperchain contracts

--- a/l1-contracts/contracts/state-transition/StateTransitionManager.sol
+++ b/l1-contracts/contracts/state-transition/StateTransitionManager.sol
@@ -87,7 +87,7 @@ contract StateTransitionManager is IStateTransitionManager, ReentrancyGuard, Own
 
     /// @return The tuple of (major, minor, patch) protocol version.
     function getSemverProtocolVersion() external view returns (uint32, uint32, uint32) {
-        return SemVer.unpackSemVer(protocolVersion);
+        return SemVer.unpackSemVer(uint96(protocolVersion));
     }
 
     /// @notice Returns all the registered hyperchain addresses

--- a/l1-contracts/contracts/state-transition/StateTransitionManager.sol
+++ b/l1-contracts/contracts/state-transition/StateTransitionManager.sol
@@ -3,6 +3,7 @@
 pragma solidity 0.8.24;
 
 import {EnumerableMap} from "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 import {Diamond} from "./libraries/Diamond.sol";
 import {DiamondProxy} from "./chain-deps/DiamondProxy.sol";
@@ -87,7 +88,7 @@ contract StateTransitionManager is IStateTransitionManager, ReentrancyGuard, Own
 
     /// @return The tuple of (major, minor, patch) protocol version.
     function getSemverProtocolVersion() external view returns (uint32, uint32, uint32) {
-        return SemVer.unpackSemVer(uint96(protocolVersion));
+        return SemVer.unpackSemVer(SafeCast.toUint96(protocolVersion));
     }
 
     /// @notice Returns all the registered hyperchain addresses
@@ -288,7 +289,7 @@ contract StateTransitionManager is IStateTransitionManager, ReentrancyGuard, Own
 
         uint256 cachedProtocolVersion = protocolVersion;
         // slither-disable-next-line unused-return
-        (, uint32 minorVersion, ) = SemVer.unpackSemVer(cachedProtocolVersion);
+        (, uint32 minorVersion, ) = SemVer.unpackSemVer(SafeCast.toUint96(cachedProtocolVersion));
 
         L2CanonicalTransaction memory l2ProtocolUpgradeTx = L2CanonicalTransaction({
             txType: SYSTEM_UPGRADE_L2_TX_TYPE,

--- a/l1-contracts/contracts/state-transition/StateTransitionManager.sol
+++ b/l1-contracts/contracts/state-transition/StateTransitionManager.sol
@@ -88,6 +88,7 @@ contract StateTransitionManager is IStateTransitionManager, ReentrancyGuard, Own
 
     /// @return The tuple of (major, minor, patch) protocol version.
     function getSemverProtocolVersion() external view returns (uint32, uint32, uint32) {
+        // slither-disable-next-line unused-return
         return SemVer.unpackSemVer(SafeCast.toUint96(protocolVersion));
     }
 

--- a/l1-contracts/contracts/state-transition/StateTransitionManager.sol
+++ b/l1-contracts/contracts/state-transition/StateTransitionManager.sol
@@ -48,7 +48,7 @@ contract StateTransitionManager is IStateTransitionManager, ReentrancyGuard, Own
     /// @dev The genesisUpgrade contract address, used to setChainId
     address public genesisUpgrade;
 
-    /// @dev The current protocolVersion
+    /// @dev The current packed protocolVersion. To access human-readable version, use `getSemverProtocolVersion` function.
     uint256 public protocolVersion;
 
     /// @dev The timestamp when protocolVersion can be last used
@@ -83,6 +83,11 @@ contract StateTransitionManager is IStateTransitionManager, ReentrancyGuard, Own
     modifier onlyOwnerOrAdmin() {
         require(msg.sender == admin || msg.sender == owner(), "STM: not owner or admin");
         _;
+    }
+
+    /// @return The tuple of (major, minor, patch) protocol version.
+    function getSemverProtocolVersion() external view returns (uint32, uint32, uint32) {
+        return SemVer.unpackSemVer(protocolVersion);
     }
 
     /// @notice Returns all the registered hyperchain addresses

--- a/l1-contracts/contracts/state-transition/StateTransitionManager.sol
+++ b/l1-contracts/contracts/state-transition/StateTransitionManager.sol
@@ -21,6 +21,7 @@ import {ProposedUpgrade} from "../upgrades/BaseZkSyncUpgrade.sol";
 import {ReentrancyGuard} from "../common/ReentrancyGuard.sol";
 import {REQUIRED_L2_GAS_PRICE_PER_PUBDATA, L2_TO_L1_LOG_SERIALIZE_SIZE, DEFAULT_L2_LOGS_TREE_ROOT_HASH, EMPTY_STRING_KECCAK, SYSTEM_UPGRADE_L2_TX_TYPE, PRIORITY_TX_MAX_GAS_LIMIT} from "../common/Config.sol";
 import {VerifierParams} from "./chain-interfaces/IVerifier.sol";
+import {SemVer} from "../common/libraries/SemVer.sol";
 
 /// @title State Transition Manager contract
 /// @author Matter Labs
@@ -280,6 +281,9 @@ contract StateTransitionManager is IStateTransitionManager, ReentrancyGuard, Own
         uint256[] memory uintEmptyArray;
         bytes[] memory bytesEmptyArray;
 
+        uint256 cachedProtocolVersion = protocolVersion;
+        (, uint32 minorVersion, ) = SemVer.unpackSemVer(cachedProtocolVersion);
+
         L2CanonicalTransaction memory l2ProtocolUpgradeTx = L2CanonicalTransaction({
             txType: SYSTEM_UPGRADE_L2_TX_TYPE,
             from: uint256(uint160(L2_FORCE_DEPLOYER_ADDR)),
@@ -290,7 +294,7 @@ contract StateTransitionManager is IStateTransitionManager, ReentrancyGuard, Own
             maxPriorityFeePerGas: uint256(0),
             paymaster: uint256(0),
             // Note, that the protocol version is used as "nonce" for system upgrade transactions
-            nonce: protocolVersion,
+            nonce: uint256(minorVersion),
             value: 0,
             reserved: [uint256(0), 0, 0, 0],
             data: systemContextCalldata,

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Getters.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Getters.sol
@@ -10,7 +10,7 @@ import {PriorityQueue, PriorityOperation} from "../../../state-transition/librar
 import {UncheckedMath} from "../../../common/libraries/UncheckedMath.sol";
 import {IGetters} from "../../chain-interfaces/IGetters.sol";
 import {ILegacyGetters} from "../../chain-interfaces/ILegacyGetters.sol";
-import {SemVer} from "../../../common/libraries/Semver.sol";
+import {SemVer} from "../../../common/libraries/SemVer.sol";
 
 // While formally the following import is not used, it is needed to inherit documentation from it
 import {IZkSyncHyperchainBase} from "../../chain-interfaces/IZkSyncHyperchainBase.sol";

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Getters.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Getters.sol
@@ -148,6 +148,7 @@ contract GettersFacet is ZkSyncHyperchainBase, IGetters, ILegacyGetters {
 
     /// @inheritdoc IGetters
     function getSemverProtocolVersion() external view returns (uint32, uint32, uint32) {
+        // slither-disable-next-line unused-return
         return SemVer.unpackSemVer(SafeCast.toUint96(s.protocolVersion));
     }
 

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Getters.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Getters.sol
@@ -141,10 +141,7 @@ contract GettersFacet is ZkSyncHyperchainBase, IGetters, ILegacyGetters {
 
     /// @inheritdoc IGetters
     function getProtocolVersion() external view returns (uint256) {
-        (uint32 major, uint32 minor, ) = SemVer.unpackSemVer(s.protocolVersion);
-        require(major == 0, "Only 0 major version is supported right now");
-
-        return uint256(minor);
+        return s.protocolVersion;
     }
 
     /// @inheritdoc IGetters

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Getters.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Getters.sol
@@ -2,6 +2,8 @@
 
 pragma solidity 0.8.24;
 
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
 import {ZkSyncHyperchainBase} from "./ZkSyncHyperchainBase.sol";
 import {PubdataPricingMode} from "../ZkSyncHyperchainStorage.sol";
 import {VerifierParams} from "../../../state-transition/chain-interfaces/IVerifier.sol";
@@ -146,7 +148,7 @@ contract GettersFacet is ZkSyncHyperchainBase, IGetters, ILegacyGetters {
 
     /// @inheritdoc IGetters
     function getSemverProtocolVersion() external view returns (uint32, uint32, uint32) {
-        return SemVer.unpackSemVer(s.protocolVersion);
+        return SemVer.unpackSemVer(SafeCast.toUint96(s.protocolVersion));
     }
 
     /// @inheritdoc IGetters

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Getters.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Getters.sol
@@ -10,6 +10,7 @@ import {PriorityQueue, PriorityOperation} from "../../../state-transition/librar
 import {UncheckedMath} from "../../../common/libraries/UncheckedMath.sol";
 import {IGetters} from "../../chain-interfaces/IGetters.sol";
 import {ILegacyGetters} from "../../chain-interfaces/ILegacyGetters.sol";
+import {SemVer} from "../../../common/libraries/Semver.sol";
 
 // While formally the following import is not used, it is needed to inherit documentation from it
 import {IZkSyncHyperchainBase} from "../../chain-interfaces/IZkSyncHyperchainBase.sol";
@@ -140,7 +141,15 @@ contract GettersFacet is ZkSyncHyperchainBase, IGetters, ILegacyGetters {
 
     /// @inheritdoc IGetters
     function getProtocolVersion() external view returns (uint256) {
-        return s.protocolVersion;
+        (uint32 major, uint32 minor, ) = SemVer.unpackSemVer(s.protocolVersion);
+        require(major == 0, "Only 0 major version is supported right now");
+
+        return uint256(minor);
+    }
+
+    /// @inheritdoc IGetters
+    function getSemverProtocolVersion() external view returns (uint32, uint32, uint32) {
+        return SemVer.unpackSemVer(s.protocolVersion);
     }
 
     /// @inheritdoc IGetters

--- a/l1-contracts/contracts/state-transition/chain-interfaces/IGetters.sol
+++ b/l1-contracts/contracts/state-transition/chain-interfaces/IGetters.sol
@@ -88,6 +88,9 @@ interface IGetters is IZkSyncHyperchainBase {
     /// @return The current protocol version
     function getProtocolVersion() external view returns (uint256);
 
+    /// @return The tuple of (patch, minor, major) protocol version.
+    function getSemverProtocolVersion() external view returns (uint256, uint256, uint256)
+
     /// @return The upgrade system contract transaction hash, 0 if the upgrade is not initialized
     function getL2SystemContractsUpgradeTxHash() external view returns (bytes32);
 

--- a/l1-contracts/contracts/state-transition/chain-interfaces/IGetters.sol
+++ b/l1-contracts/contracts/state-transition/chain-interfaces/IGetters.sol
@@ -89,7 +89,7 @@ interface IGetters is IZkSyncHyperchainBase {
     function getProtocolVersion() external view returns (uint256);
 
     /// @return The tuple of (patch, minor, major) protocol version.
-    function getSemverProtocolVersion() external view returns (uint256, uint256, uint256)
+    function getSemverProtocolVersion() external view returns (uint32, uint32, uint32);
 
     /// @return The upgrade system contract transaction hash, 0 if the upgrade is not initialized
     function getL2SystemContractsUpgradeTxHash() external view returns (bytes32);

--- a/l1-contracts/contracts/state-transition/chain-interfaces/IGetters.sol
+++ b/l1-contracts/contracts/state-transition/chain-interfaces/IGetters.sol
@@ -88,7 +88,7 @@ interface IGetters is IZkSyncHyperchainBase {
     /// @return The current protocol version
     function getProtocolVersion() external view returns (uint256);
 
-    /// @return The tuple of (patch, minor, major) protocol version.
+    /// @return The tuple of (major, minor, patch) protocol version.
     function getSemverProtocolVersion() external view returns (uint32, uint32, uint32);
 
     /// @return The upgrade system contract transaction hash, 0 if the upgrade is not initialized

--- a/l1-contracts/contracts/state-transition/chain-interfaces/IGetters.sol
+++ b/l1-contracts/contracts/state-transition/chain-interfaces/IGetters.sol
@@ -85,7 +85,7 @@ interface IGetters is IZkSyncHyperchainBase {
     /// @return Whether the diamond is frozen or not
     function isDiamondStorageFrozen() external view returns (bool);
 
-    /// @return The current protocol version
+    /// @return The current (minor) protocol version.
     function getProtocolVersion() external view returns (uint256);
 
     /// @return The tuple of (major, minor, patch) protocol version.

--- a/l1-contracts/contracts/state-transition/chain-interfaces/IGetters.sol
+++ b/l1-contracts/contracts/state-transition/chain-interfaces/IGetters.sol
@@ -85,7 +85,7 @@ interface IGetters is IZkSyncHyperchainBase {
     /// @return Whether the diamond is frozen or not
     function isDiamondStorageFrozen() external view returns (bool);
 
-    /// @return The current (minor) protocol version.
+    /// @return The current packed protocol version. To access human-readable version, use `getSemverProtocolVersion` function.
     function getProtocolVersion() external view returns (uint256);
 
     /// @return The tuple of (major, minor, patch) protocol version.

--- a/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
+++ b/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
@@ -265,7 +265,7 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
         uint32 newMajorVersion;
         // slither-disable-next-line unused-return
         (newMajorVersion, newMinorVersion, ) = SemVer.unpackSemVer(SafeCast.toUint96(_newProtocolVersion));
-        require(newMajorVersion == 0, "Major version change is not allowed");
+        require(newMajorVersion == 0, "Major must always be 0");
 
         // Since `_newProtocolVersion > previousProtocolVersion`, and both old and new major version is 0,
         // the difference between minor versions is >= 0.

--- a/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
+++ b/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
@@ -90,6 +90,7 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
 
     /// @notice Change default account bytecode hash, that is used on L2
     /// @param _l2DefaultAccountBytecodeHash The hash of default account L2 bytecode
+    /// @param _patchOnly Whether the patch part of the protocol version semver has changed
     function _setL2DefaultAccountBytecodeHash(bytes32 _l2DefaultAccountBytecodeHash, bool _patchOnly) private {
         if (_l2DefaultAccountBytecodeHash == bytes32(0)) {
             return;
@@ -109,6 +110,7 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
 
     /// @notice Change bootloader bytecode hash, that is used on L2
     /// @param _l2BootloaderBytecodeHash The hash of bootloader L2 bytecode
+    /// @param _patchOnly Whether the patch part of the protocol version semver has changed
     function _setL2BootloaderBytecodeHash(bytes32 _l2BootloaderBytecodeHash, bool _patchOnly) private {
         if (_l2BootloaderBytecodeHash == bytes32(0)) {
             return;
@@ -181,6 +183,10 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
     /// @notice Sets the hash of the L2 system contract upgrade transaction for the next batch to be committed
     /// @dev If the transaction is noop (i.e. its type is 0) it does nothing and returns 0.
     /// @param _l2ProtocolUpgradeTx The L2 system contract upgrade transaction.
+    /// @param _factoryDeps The factory dependencies that are used by the transaction.
+    /// @param _newMinorProtocolVersion The new minor protocol version. It must be used as the `nonce` field
+    /// of the `_l2ProtocolUpgradeTx`.
+    /// @param _patchOnly Whether the patch part of the protocol version semver has changed.
     /// @return System contracts upgrade transaction hash. Zero if no upgrade transaction is set.
     function _setL2SystemContractUpgrade(
         L2CanonicalTransaction calldata _l2ProtocolUpgradeTx,

--- a/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
+++ b/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
@@ -98,7 +98,7 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
             return;
         }
 
-        require(!_patchOnly, "Patch only upgrade can not set new bootloader");
+        require(!_patchOnly, "Patch only upgrade can not set new default account");
 
         L2ContractHelper.validateBytecodeHash(_l2DefaultAccountBytecodeHash);
 

--- a/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
+++ b/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
@@ -251,9 +251,11 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
         );
 
         uint32 newMajorVersion;
+        // slither-disable-next-line unused-return
         (newMajorVersion, newMinorVersion, ) = SemVer.unpackSemVer(_newProtocolVersion);
         require(newMajorVersion == 0, "Major version change is not allowed");
 
+        // slither-disable-next-line unused-return
         (uint32 majorDelta, uint32 minorDelta, ) = SemVer.unpackSemVer(_newProtocolVersion - previousProtocolVersion);
 
         if (minorDelta == 0) {

--- a/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
+++ b/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
@@ -2,6 +2,8 @@
 
 pragma solidity 0.8.24;
 
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
 import {ZkSyncHyperchainBase} from "../state-transition/chain-deps/facets/ZkSyncHyperchainBase.sol";
 import {VerifierParams} from "../state-transition/chain-interfaces/IVerifier.sol";
 import {IVerifier} from "../state-transition/chain-interfaces/IVerifier.sol";
@@ -258,11 +260,11 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
 
         uint32 newMajorVersion;
         // slither-disable-next-line unused-return
-        (newMajorVersion, newMinorVersion, ) = SemVer.unpackSemVer(_newProtocolVersion);
+        (newMajorVersion, newMinorVersion, ) = SemVer.unpackSemVer(SafeCast.toUint96(_newProtocolVersion));
         require(newMajorVersion == 0, "Major version change is not allowed");
 
         // slither-disable-next-line unused-return
-        (uint32 majorDelta, uint32 minorDelta, ) = SemVer.unpackSemVer(_newProtocolVersion - previousProtocolVersion);
+        (uint32 majorDelta, uint32 minorDelta, ) = SemVer.unpackSemVer(SafeCast.toUint96(_newProtocolVersion - previousProtocolVersion));
 
         if (minorDelta == 0) {
             patchOnly = true;

--- a/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
+++ b/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
@@ -9,6 +9,7 @@ import {L2ContractHelper} from "../common/libraries/L2ContractHelper.sol";
 import {TransactionValidator} from "../state-transition/libraries/TransactionValidator.sol";
 import {MAX_NEW_FACTORY_DEPS, SYSTEM_UPGRADE_L2_TX_TYPE, MAX_ALLOWED_PROTOCOL_VERSION_DELTA} from "../common/Config.sol";
 import {L2CanonicalTransaction} from "../common/Messaging.sol";
+import {SemVer} from "../common/libraries/SemVer.sol";
 
 /// @notice The struct that represents the upgrade proposal.
 /// @param l2ProtocolUpgradeTx The system upgrade transaction.
@@ -199,10 +200,13 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
 
         TransactionValidator.validateUpgradeTransaction(_l2ProtocolUpgradeTx);
 
+        // We expect that the upgrade transactions are only present when the minor version changes
+        (, uint32 minorVersion, ) = SemVer.unpackSemVer(_newProtocolVersion);
+
         // We want the hashes of l2 system upgrade transactions to be unique.
         // This is why we require that the `nonce` field is unique to each upgrade.
         require(
-            _l2ProtocolUpgradeTx.nonce == _newProtocolVersion,
+            _l2ProtocolUpgradeTx.nonce == minorVersion,
             "The new protocol version should be included in the L2 system upgrade tx"
         );
 

--- a/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
+++ b/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
@@ -264,7 +264,9 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
         require(newMajorVersion == 0, "Major version change is not allowed");
 
         // slither-disable-next-line unused-return
-        (uint32 majorDelta, uint32 minorDelta, ) = SemVer.unpackSemVer(SafeCast.toUint96(_newProtocolVersion - previousProtocolVersion));
+        (uint32 majorDelta, uint32 minorDelta, ) = SemVer.unpackSemVer(
+            SafeCast.toUint96(_newProtocolVersion - previousProtocolVersion)
+        );
 
         if (minorDelta == 0) {
             patchOnly = true;

--- a/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
+++ b/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
@@ -276,7 +276,7 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
 
         // If the minor version changes also, we need to ensure that the previous upgrade has been finalized.
         // In case the minor version does not change, we permit to keep the old upgrade transaction in the system, but it
-        // must be ensured in the other parts of the upgrade that the is not overriden.
+        // must be ensured in the other parts of the upgrade that the is not overridden.
         if (!patchOnly) {
             // If the previous upgrade had an L2 system upgrade transaction, we require that it is finalized.
             // Note it is important to keep this check, as otherwise hyperchains might skip upgrades by overwriting

--- a/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
+++ b/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
@@ -241,7 +241,9 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
 
     /// @notice Changes the protocol version
     /// @param _newProtocolVersion The new protocol version
-    function _setNewProtocolVersion(uint256 _newProtocolVersion) internal virtual returns (uint32 newMinorVersion, bool patchOnly) {
+    function _setNewProtocolVersion(
+        uint256 _newProtocolVersion
+    ) internal virtual returns (uint32 newMinorVersion, bool patchOnly) {
         uint256 previousProtocolVersion = s.protocolVersion;
         require(
             _newProtocolVersion > previousProtocolVersion,
@@ -249,10 +251,10 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
         );
 
         uint32 newMajorVersion;
-        (newMajorVersion, newMinorVersion,) = SemVer.unpackSemVer(_newProtocolVersion);
+        (newMajorVersion, newMinorVersion, ) = SemVer.unpackSemVer(_newProtocolVersion);
         require(newMajorVersion == 0, "Major version change is not allowed");
 
-        (uint32 majorDelta, uint32 minorDelta,) = SemVer.unpackSemVer(_newProtocolVersion - previousProtocolVersion);
+        (uint32 majorDelta, uint32 minorDelta, ) = SemVer.unpackSemVer(_newProtocolVersion - previousProtocolVersion);
 
         if (minorDelta == 0) {
             patchOnly = true;
@@ -263,9 +265,9 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
         require(minorDelta <= MAX_ALLOWED_MINOR_VERSION_DELTA, "Too big protocol version difference");
 
         // If the minor version changes also, we need to ensure that the previous upgrade has been finalized.
-        // In case the minor version does not change, we permit to keep the old upgrade transaction in the system, but it 
-        // must be ensured in the other parts of the upgrade that the is not overriden. 
-        if(!patchOnly) {
+        // In case the minor version does not change, we permit to keep the old upgrade transaction in the system, but it
+        // must be ensured in the other parts of the upgrade that the is not overriden.
+        if (!patchOnly) {
             // If the previous upgrade had an L2 system upgrade transaction, we require that it is finalized.
             // Note it is important to keep this check, as otherwise hyperchains might skip upgrades by overwriting
             require(s.l2SystemContractsUpgradeTxHash == bytes32(0), "Previous upgrade has not been finalized");

--- a/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
+++ b/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
@@ -257,6 +257,7 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
             _newProtocolVersion > previousProtocolVersion,
             "New protocol version is not greater than the current one"
         );
+        // slither-disable-next-line unused-return
         (uint32 previousMajorVersion, uint32 previousMinorVersion, ) = SemVer.unpackSemVer(
             SafeCast.toUint96(previousProtocolVersion)
         );

--- a/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
+++ b/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
@@ -7,7 +7,7 @@ import {VerifierParams} from "../state-transition/chain-interfaces/IVerifier.sol
 import {IVerifier} from "../state-transition/chain-interfaces/IVerifier.sol";
 import {L2ContractHelper} from "../common/libraries/L2ContractHelper.sol";
 import {TransactionValidator} from "../state-transition/libraries/TransactionValidator.sol";
-import {MAX_NEW_FACTORY_DEPS, SYSTEM_UPGRADE_L2_TX_TYPE, MAX_ALLOWED_PROTOCOL_VERSION_DELTA} from "../common/Config.sol";
+import {MAX_NEW_FACTORY_DEPS, SYSTEM_UPGRADE_L2_TX_TYPE, MAX_ALLOWED_PROTOCOL_VERSION_DELTA, MAX_ALLOWED_MINOR_VERSION_DELTA} from "../common/Config.sol";
 import {L2CanonicalTransaction} from "../common/Messaging.sol";
 import {SemVer} from "../common/libraries/SemVer.sol";
 
@@ -71,15 +71,16 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
         // as the permitted delay window is reduced in the future.
         require(block.timestamp >= _proposedUpgrade.upgradeTimestamp, "Upgrade is not ready yet");
 
-        _setNewProtocolVersion(_proposedUpgrade.newProtocolVersion);
+        bool isPatchOnly = _setNewProtocolVersion(_proposedUpgrade.newProtocolVersion);
         _upgradeL1Contract(_proposedUpgrade.l1ContractsUpgradeCalldata);
         _upgradeVerifier(_proposedUpgrade.verifier, _proposedUpgrade.verifierParams);
-        _setBaseSystemContracts(_proposedUpgrade.bootloaderHash, _proposedUpgrade.defaultAccountHash);
+        _setBaseSystemContracts(_proposedUpgrade.bootloaderHash, _proposedUpgrade.defaultAccountHash, isPatchOnly);
 
         txHash = _setL2SystemContractUpgrade(
             _proposedUpgrade.l2ProtocolUpgradeTx,
             _proposedUpgrade.factoryDeps,
-            _proposedUpgrade.newProtocolVersion
+            _proposedUpgrade.newProtocolVersion,
+            isPatchOnly
         );
 
         _postUpgrade(_proposedUpgrade.postUpgradeCalldata);
@@ -89,10 +90,12 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
 
     /// @notice Change default account bytecode hash, that is used on L2
     /// @param _l2DefaultAccountBytecodeHash The hash of default account L2 bytecode
-    function _setL2DefaultAccountBytecodeHash(bytes32 _l2DefaultAccountBytecodeHash) private {
+    function _setL2DefaultAccountBytecodeHash(bytes32 _l2DefaultAccountBytecodeHash, bool _patchOnly) private {
         if (_l2DefaultAccountBytecodeHash == bytes32(0)) {
             return;
         }
+
+        require(!_patchOnly, "Patch only upgrade can not set new bootloader");
 
         L2ContractHelper.validateBytecodeHash(_l2DefaultAccountBytecodeHash);
 
@@ -106,10 +109,12 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
 
     /// @notice Change bootloader bytecode hash, that is used on L2
     /// @param _l2BootloaderBytecodeHash The hash of bootloader L2 bytecode
-    function _setL2BootloaderBytecodeHash(bytes32 _l2BootloaderBytecodeHash) private {
+    function _setL2BootloaderBytecodeHash(bytes32 _l2BootloaderBytecodeHash, bool _patchOnly) private {
         if (_l2BootloaderBytecodeHash == bytes32(0)) {
             return;
         }
+
+        require(!_patchOnly, "Patch only upgrade can not set new bootloader");
 
         L2ContractHelper.validateBytecodeHash(_l2BootloaderBytecodeHash);
 
@@ -168,9 +173,9 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
     /// @notice Updates the bootloader hash and the hash of the default account
     /// @param _bootloaderHash The hash of the new bootloader bytecode. If zero, it will not be updated.
     /// @param _defaultAccountHash The hash of the new default account bytecode. If zero, it will not be updated.
-    function _setBaseSystemContracts(bytes32 _bootloaderHash, bytes32 _defaultAccountHash) internal {
-        _setL2BootloaderBytecodeHash(_bootloaderHash);
-        _setL2DefaultAccountBytecodeHash(_defaultAccountHash);
+    function _setBaseSystemContracts(bytes32 _bootloaderHash, bytes32 _defaultAccountHash, bool _patchOnly) internal {
+        _setL2BootloaderBytecodeHash(_bootloaderHash, _patchOnly);
+        _setL2DefaultAccountBytecodeHash(_defaultAccountHash, _patchOnly);
     }
 
     /// @notice Sets the hash of the L2 system contract upgrade transaction for the next batch to be committed
@@ -180,12 +185,15 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
     function _setL2SystemContractUpgrade(
         L2CanonicalTransaction calldata _l2ProtocolUpgradeTx,
         bytes[] calldata _factoryDeps,
-        uint256 _newProtocolVersion
+        uint256 _newProtocolVersion,
+        bool _patchOnly
     ) internal returns (bytes32) {
         // If the type is 0, it is considered as noop and so will not be required to be executed.
         if (_l2ProtocolUpgradeTx.txType == 0) {
             return bytes32(0);
         }
+
+        require(!_patchOnly, "Patch only upgrade can not set new transactions");
 
         require(_l2ProtocolUpgradeTx.txType == SYSTEM_UPGRADE_L2_TX_TYPE, "L2 system upgrade tx type is wrong");
 
@@ -236,24 +244,39 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
 
     /// @notice Changes the protocol version
     /// @param _newProtocolVersion The new protocol version
-    function _setNewProtocolVersion(uint256 _newProtocolVersion) internal virtual {
+    function _setNewProtocolVersion(uint256 _newProtocolVersion) internal virtual returns (bool patchOnly) {
         uint256 previousProtocolVersion = s.protocolVersion;
         require(
             _newProtocolVersion > previousProtocolVersion,
             "New protocol version is not greater than the current one"
         );
-        require(
-            _newProtocolVersion - previousProtocolVersion <= MAX_ALLOWED_PROTOCOL_VERSION_DELTA,
-            "Too big protocol version difference"
-        );
 
-        // If the previous upgrade had an L2 system upgrade transaction, we require that it is finalized.
-        // Note it is important to keep this check, as otherwise hyperchains might skip upgrades by overwriting
-        require(s.l2SystemContractsUpgradeTxHash == bytes32(0), "Previous upgrade has not been finalized");
-        require(
-            s.l2SystemContractsUpgradeBatchNumber == 0,
-            "The batch number of the previous upgrade has not been cleaned"
-        );
+        (uint32 newMajor,,) = SemVer.unpackSemVer(_newProtocolVersion);
+        require(newMajor == 0, "Major version change is not allowed");
+
+        (uint32 majorDelta, uint32 minorDelta, uint32 patchDelta) = SemVer.unpackSemVer(_newProtocolVersion - previousProtocolVersion);
+
+        if (minorDelta == 0) {
+            patchOnly = true;
+        }
+
+        require(minorDelta <= MAX_ALLOWED_MINOR_VERSION_DELTA, "Too big protocol version difference");
+
+        require(majorChange == 0, "Major version change is not allowed")
+        require(minorChange <= MAX_ALLOWED_MINOR_VERSION_DELTA, "Too big protocol version difference");
+
+        // If the minor version changes also, we need to ensure that the previous upgrade has been finalized.
+        // In case the minor version does not change, we permit to keep the old upgrade transaction in the system, but it 
+        // must be ensured in the other parts of the upgrade that the is not overriden. 
+        if(!patchOnly) {
+            // If the previous upgrade had an L2 system upgrade transaction, we require that it is finalized.
+            // Note it is important to keep this check, as otherwise hyperchains might skip upgrades by overwriting
+            require(s.l2SystemContractsUpgradeTxHash == bytes32(0), "Previous upgrade has not been finalized");
+            require(
+                s.l2SystemContractsUpgradeBatchNumber == 0,
+                "The batch number of the previous upgrade has not been cleaned"
+            );
+        }
 
         s.protocolVersion = _newProtocolVersion;
         emit NewProtocolVersion(previousProtocolVersion, _newProtocolVersion);

--- a/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
+++ b/l1-contracts/contracts/upgrades/BaseZkSyncUpgrade.sol
@@ -92,7 +92,7 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
 
     /// @notice Change default account bytecode hash, that is used on L2
     /// @param _l2DefaultAccountBytecodeHash The hash of default account L2 bytecode
-    /// @param _patchOnly Whether the patch part of the protocol version semver has changed
+    /// @param _patchOnly Whether only the patch part of the protocol version semver has changed
     function _setL2DefaultAccountBytecodeHash(bytes32 _l2DefaultAccountBytecodeHash, bool _patchOnly) private {
         if (_l2DefaultAccountBytecodeHash == bytes32(0)) {
             return;
@@ -112,7 +112,7 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
 
     /// @notice Change bootloader bytecode hash, that is used on L2
     /// @param _l2BootloaderBytecodeHash The hash of bootloader L2 bytecode
-    /// @param _patchOnly Whether the patch part of the protocol version semver has changed
+    /// @param _patchOnly Whether only the patch part of the protocol version semver has changed
     function _setL2BootloaderBytecodeHash(bytes32 _l2BootloaderBytecodeHash, bool _patchOnly) private {
         if (_l2BootloaderBytecodeHash == bytes32(0)) {
             return;
@@ -177,6 +177,7 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
     /// @notice Updates the bootloader hash and the hash of the default account
     /// @param _bootloaderHash The hash of the new bootloader bytecode. If zero, it will not be updated.
     /// @param _defaultAccountHash The hash of the new default account bytecode. If zero, it will not be updated.
+    /// @param _patchOnly Whether only the patch part of the protocol version semver has changed.
     function _setBaseSystemContracts(bytes32 _bootloaderHash, bytes32 _defaultAccountHash, bool _patchOnly) internal {
         _setL2BootloaderBytecodeHash(_bootloaderHash, _patchOnly);
         _setL2DefaultAccountBytecodeHash(_defaultAccountHash, _patchOnly);
@@ -188,7 +189,7 @@ abstract contract BaseZkSyncUpgrade is ZkSyncHyperchainBase {
     /// @param _factoryDeps The factory dependencies that are used by the transaction.
     /// @param _newMinorProtocolVersion The new minor protocol version. It must be used as the `nonce` field
     /// of the `_l2ProtocolUpgradeTx`.
-    /// @param _patchOnly Whether the patch part of the protocol version semver has changed.
+    /// @param _patchOnly Whether only the patch part of the protocol version semver has changed.
     /// @return System contracts upgrade transaction hash. Zero if no upgrade transaction is set.
     function _setL2SystemContractUpgrade(
         L2CanonicalTransaction calldata _l2ProtocolUpgradeTx,

--- a/l1-contracts/contracts/upgrades/BaseZkSyncUpgradeGenesis.sol
+++ b/l1-contracts/contracts/upgrades/BaseZkSyncUpgradeGenesis.sol
@@ -3,7 +3,7 @@
 pragma solidity 0.8.24;
 
 import {BaseZkSyncUpgrade} from "./BaseZkSyncUpgrade.sol";
-import {MAX_NEW_FACTORY_DEPS, SYSTEM_UPGRADE_L2_TX_TYPE, MAX_ALLOWED_MINOR_VERSION_DELTA} from "../common/Config.sol";
+import {MAX_ALLOWED_MINOR_VERSION_DELTA} from "../common/Config.sol";
 import {SemVer} from "../common/libraries/SemVer.sol";
 
 /// @author Matter Labs
@@ -12,7 +12,9 @@ import {SemVer} from "../common/libraries/SemVer.sol";
 abstract contract BaseZkSyncUpgradeGenesis is BaseZkSyncUpgrade {
     /// @notice Changes the protocol version
     /// @param _newProtocolVersion The new protocol version
-    function _setNewProtocolVersion(uint256 _newProtocolVersion) internal override returns (uint32 newMinorVersion, bool patchOnly) {
+    function _setNewProtocolVersion(
+        uint256 _newProtocolVersion
+    ) internal override returns (uint32 newMinorVersion, bool patchOnly) {
         uint256 previousProtocolVersion = s.protocolVersion;
         // IMPORTANT Genesis Upgrade difference: Note this is the only thing change > to >=
         require(
@@ -21,10 +23,10 @@ abstract contract BaseZkSyncUpgradeGenesis is BaseZkSyncUpgrade {
         );
 
         uint32 newMajorVersion;
-        (newMajorVersion, newMinorVersion,) = SemVer.unpackSemVer(_newProtocolVersion);
+        (newMajorVersion, newMinorVersion, ) = SemVer.unpackSemVer(_newProtocolVersion);
         require(newMajorVersion == 0, "Major version change is not allowed");
 
-        (uint32 majorDelta, uint32 minorDelta,) = SemVer.unpackSemVer(_newProtocolVersion - previousProtocolVersion);
+        (uint32 majorDelta, uint32 minorDelta, ) = SemVer.unpackSemVer(_newProtocolVersion - previousProtocolVersion);
 
         // IMPORTANT Genesis Upgrade difference: We never set patchOnly to `true` to allow to put a system upgrade transaction there.
         patchOnly = false;
@@ -34,9 +36,9 @@ abstract contract BaseZkSyncUpgradeGenesis is BaseZkSyncUpgrade {
         require(minorDelta <= MAX_ALLOWED_MINOR_VERSION_DELTA, "Too big protocol version difference");
 
         // If the minor version changes also, we need to ensure that the previous upgrade has been finalized.
-        // In case the minor version does not change, we permit to keep the old upgrade transaction in the system, but it 
-        // must be ensured in the other parts of the upgrade that the is not overriden. 
-        if(!patchOnly) {
+        // In case the minor version does not change, we permit to keep the old upgrade transaction in the system, but it
+        // must be ensured in the other parts of the upgrade that the is not overriden.
+        if (!patchOnly) {
             // If the previous upgrade had an L2 system upgrade transaction, we require that it is finalized.
             // Note it is important to keep this check, as otherwise hyperchains might skip upgrades by overwriting
             require(s.l2SystemContractsUpgradeTxHash == bytes32(0), "Previous upgrade has not been finalized");

--- a/l1-contracts/contracts/upgrades/BaseZkSyncUpgradeGenesis.sol
+++ b/l1-contracts/contracts/upgrades/BaseZkSyncUpgradeGenesis.sol
@@ -2,6 +2,8 @@
 
 pragma solidity 0.8.24;
 
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
 import {BaseZkSyncUpgrade} from "./BaseZkSyncUpgrade.sol";
 import {MAX_ALLOWED_MINOR_VERSION_DELTA} from "../common/Config.sol";
 import {SemVer} from "../common/libraries/SemVer.sol";
@@ -24,10 +26,10 @@ abstract contract BaseZkSyncUpgradeGenesis is BaseZkSyncUpgrade {
 
         uint32 newMajorVersion;
         // slither-disable-next-line unused-return
-        (newMajorVersion, newMinorVersion, ) = SemVer.unpackSemVer(_newProtocolVersion);
+        (newMajorVersion, newMinorVersion, ) = SemVer.unpackSemVer(SafeCast.toUint96(_newProtocolVersion));
         require(newMajorVersion == 0, "Major version change is not allowed");
 
-        (uint32 majorDelta, uint32 minorDelta, ) = SemVer.unpackSemVer(_newProtocolVersion - previousProtocolVersion);
+        (uint32 majorDelta, uint32 minorDelta, ) = SemVer.unpackSemVer(SafeCast.toUint96(_newProtocolVersion - previousProtocolVersion));
 
         // IMPORTANT Genesis Upgrade difference: We never set patchOnly to `true` to allow to put a system upgrade transaction there.
         patchOnly = false;

--- a/l1-contracts/contracts/upgrades/BaseZkSyncUpgradeGenesis.sol
+++ b/l1-contracts/contracts/upgrades/BaseZkSyncUpgradeGenesis.sol
@@ -29,7 +29,9 @@ abstract contract BaseZkSyncUpgradeGenesis is BaseZkSyncUpgrade {
         (newMajorVersion, newMinorVersion, ) = SemVer.unpackSemVer(SafeCast.toUint96(_newProtocolVersion));
         require(newMajorVersion == 0, "Major version change is not allowed");
 
-        (uint32 majorDelta, uint32 minorDelta, ) = SemVer.unpackSemVer(SafeCast.toUint96(_newProtocolVersion - previousProtocolVersion));
+        (uint32 majorDelta, uint32 minorDelta, ) = SemVer.unpackSemVer(
+            SafeCast.toUint96(_newProtocolVersion - previousProtocolVersion)
+        );
 
         // IMPORTANT Genesis Upgrade difference: We never set patchOnly to `true` to allow to put a system upgrade transaction there.
         patchOnly = false;

--- a/l1-contracts/contracts/upgrades/BaseZkSyncUpgradeGenesis.sol
+++ b/l1-contracts/contracts/upgrades/BaseZkSyncUpgradeGenesis.sol
@@ -11,24 +11,39 @@ import {BaseZkSyncUpgrade} from "./BaseZkSyncUpgrade.sol";
 abstract contract BaseZkSyncUpgradeGenesis is BaseZkSyncUpgrade {
     /// @notice Changes the protocol version
     /// @param _newProtocolVersion The new protocol version
-    function _setNewProtocolVersion(uint256 _newProtocolVersion) internal override {
+    function _setNewProtocolVersion(uint256 _newProtocolVersion) internal override returns (bool patchOnly) {
         uint256 previousProtocolVersion = s.protocolVersion;
+        // IMPORTANT Genesis Upgrade difference: Note this is the only thing change > to >=
         require(
-            // IMPORTANT Genesis Upgrade difference: Note this is the only thing change > to >=
             _newProtocolVersion >= previousProtocolVersion,
             "New protocol version is not greater than the current one"
         );
-        require(
-            _newProtocolVersion - previousProtocolVersion <= MAX_ALLOWED_PROTOCOL_VERSION_DELTA,
-            "Too big protocol version difference"
-        );
 
-        // If the previous upgrade had an L2 system upgrade transaction, we require that it is finalized.
-        require(s.l2SystemContractsUpgradeTxHash == bytes32(0), "Previous upgrade has not been finalized");
-        require(
-            s.l2SystemContractsUpgradeBatchNumber == 0,
-            "The batch number of the previous upgrade has not been cleaned"
-        );
+        (uint32 newMajor,,) = SemVer.unpackSemVer(_newProtocolVersion);
+        require(newMajor == 0, "Only major version of 0 is supported");
+
+        (uint32 majorDelta, uint32 minorDelta, uint32 patchDelta) = SemVer.unpackSemVer(_newProtocolVersion - previousProtocolVersion);
+
+        if (minorDelta == 0) {
+            patchOnly = true;
+        }
+
+        // While this is implicitly enforced by other checks above, we still double check just in case
+        require(majorDelta == 0, "Major version change is not allowed");
+        require(minorDelta <= MAX_ALLOWED_MINOR_VERSION_DELTA, "Too big protocol version difference");
+
+        // If the minor version changes also, we need to ensure that the previous upgrade has been finalized.
+        // In case the minor version does not change, we permit to keep the old upgrade transaction in the system, but it 
+        // must be ensured in the other parts of the upgrade that the is not overriden. 
+        if(!patchOnly) {
+            // If the previous upgrade had an L2 system upgrade transaction, we require that it is finalized.
+            // Note it is important to keep this check, as otherwise hyperchains might skip upgrades by overwriting
+            require(s.l2SystemContractsUpgradeTxHash == bytes32(0), "Previous upgrade has not been finalized");
+            require(
+                s.l2SystemContractsUpgradeBatchNumber == 0,
+                "The batch number of the previous upgrade has not been cleaned"
+            );
+        }
 
         s.protocolVersion = _newProtocolVersion;
         emit NewProtocolVersion(previousProtocolVersion, _newProtocolVersion);

--- a/l1-contracts/contracts/upgrades/BaseZkSyncUpgradeGenesis.sol
+++ b/l1-contracts/contracts/upgrades/BaseZkSyncUpgradeGenesis.sol
@@ -40,7 +40,7 @@ abstract contract BaseZkSyncUpgradeGenesis is BaseZkSyncUpgrade {
 
         // If the minor version changes also, we need to ensure that the previous upgrade has been finalized.
         // In case the minor version does not change, we permit to keep the old upgrade transaction in the system, but it
-        // must be ensured in the other parts of the upgrade that the is not overriden.
+        // must be ensured in the other parts of the upgrade that the is not overridden.
         if (!patchOnly) {
             // If the previous upgrade had an L2 system upgrade transaction, we require that it is finalized.
             // Note it is important to keep this check, as otherwise hyperchains might skip upgrades by overwriting

--- a/l1-contracts/contracts/upgrades/BaseZkSyncUpgradeGenesis.sol
+++ b/l1-contracts/contracts/upgrades/BaseZkSyncUpgradeGenesis.sol
@@ -23,6 +23,7 @@ abstract contract BaseZkSyncUpgradeGenesis is BaseZkSyncUpgrade {
         );
 
         uint32 newMajorVersion;
+        // slither-disable-next-line unused-return
         (newMajorVersion, newMinorVersion, ) = SemVer.unpackSemVer(_newProtocolVersion);
         require(newMajorVersion == 0, "Major version change is not allowed");
 

--- a/l1-contracts/contracts/upgrades/BaseZkSyncUpgradeGenesis.sol
+++ b/l1-contracts/contracts/upgrades/BaseZkSyncUpgradeGenesis.sol
@@ -23,21 +23,25 @@ abstract contract BaseZkSyncUpgradeGenesis is BaseZkSyncUpgrade {
             _newProtocolVersion >= previousProtocolVersion,
             "New protocol version is not greater than the current one"
         );
+        // slither-disable-next-line unused-return
+        (uint32 previousMajorVersion, uint32 previousMinorVersion, ) = SemVer.unpackSemVer(
+            SafeCast.toUint96(previousProtocolVersion)
+        );
+        require(previousMajorVersion == 0, "Implementation requires that the major version is 0 at all times");
 
         uint32 newMajorVersion;
         // slither-disable-next-line unused-return
         (newMajorVersion, newMinorVersion, ) = SemVer.unpackSemVer(SafeCast.toUint96(_newProtocolVersion));
-        require(newMajorVersion == 0, "Major version change is not allowed");
+        require(newMajorVersion == 0, "Major must always be 0");
 
-        (uint32 majorDelta, uint32 minorDelta, ) = SemVer.unpackSemVer(
-            SafeCast.toUint96(_newProtocolVersion - previousProtocolVersion)
-        );
+        // Since `_newProtocolVersion > previousProtocolVersion`, and both old and new major version is 0,
+        // the difference between minor versions is >= 0.
+        uint256 minorDelta = newMinorVersion - previousMinorVersion;
 
         // IMPORTANT Genesis Upgrade difference: We never set patchOnly to `true` to allow to put a system upgrade transaction there.
         patchOnly = false;
 
         // While this is implicitly enforced by other checks above, we still double check just in case
-        require(majorDelta == 0, "Major version change is not allowed");
         require(minorDelta <= MAX_ALLOWED_MINOR_VERSION_DELTA, "Too big protocol version difference");
 
         // If the minor version changes also, we need to ensure that the previous upgrade has been finalized.

--- a/l1-contracts/scripts/utils.ts
+++ b/l1-contracts/scripts/utils.ts
@@ -91,5 +91,5 @@ export function packSemver(major: number, minor: number, patch: number) {
     throw new Error("Major version must be 0");
   }
 
-  return (minor * SEMVER_MINOR_VERSION_MULTIPLIER) + patch;
+  return minor * SEMVER_MINOR_VERSION_MULTIPLIER + patch;
 }

--- a/l1-contracts/scripts/utils.ts
+++ b/l1-contracts/scripts/utils.ts
@@ -10,6 +10,9 @@ const warning = chalk.bold.yellow;
 export const L1_TO_L2_ALIAS_OFFSET = "0x1111000000000000000000000000000000001111";
 export const GAS_MULTIPLIER = 1;
 
+// Bit shift by 32 does not work in JS, so we have to multiply by 2^32
+const SEMVER_MINOR_VERSION_MULTIPLIER = 4294967296;
+
 interface SystemConfig {
   requiredL2GasPricePerPubdata: number;
   priorityTxMinimalGasPrice: number;
@@ -74,4 +77,19 @@ export function print(name: string, data: any) {
 
 export function getLowerCaseAddress(address: string) {
   return ethers.utils.getAddress(address).toLowerCase();
+}
+
+export function unpackStringSemVer(semver: string): [number, number, number] {
+  const [major, minor, patch] = semver.split(".");
+  console.log(major, minor, patch);
+  return [parseInt(major), parseInt(minor), parseInt(patch)];
+}
+
+// The major version is always 0 for now
+export function packSemver(major: number, minor: number, patch: number) {
+  if (major !== 0) {
+    throw new Error("Major version must be 0");
+  }
+
+  return (minor * SEMVER_MINOR_VERSION_MULTIPLIER) + patch;
 }

--- a/l1-contracts/scripts/utils.ts
+++ b/l1-contracts/scripts/utils.ts
@@ -81,7 +81,6 @@ export function getLowerCaseAddress(address: string) {
 
 export function unpackStringSemVer(semver: string): [number, number, number] {
   const [major, minor, patch] = semver.split(".");
-  console.log(major, minor, patch);
   return [parseInt(major), parseInt(minor), parseInt(patch)];
 }
 

--- a/l1-contracts/scripts/utils.ts
+++ b/l1-contracts/scripts/utils.ts
@@ -11,7 +11,7 @@ export const L1_TO_L2_ALIAS_OFFSET = "0x1111000000000000000000000000000000001111
 export const GAS_MULTIPLIER = 1;
 
 // Bit shift by 32 does not work in JS, so we have to multiply by 2^32
-const SEMVER_MINOR_VERSION_MULTIPLIER = 4294967296;
+export const SEMVER_MINOR_VERSION_MULTIPLIER = 4294967296;
 
 interface SystemConfig {
   requiredL2GasPricePerPubdata: number;
@@ -84,6 +84,13 @@ export function unpackStringSemVer(semver: string): [number, number, number] {
   return [parseInt(major), parseInt(minor), parseInt(patch)];
 }
 
+function unpackNumberSemVer(semver: number): [number, number, number] {
+  const major = 0;
+  const minor = Math.floor(semver / SEMVER_MINOR_VERSION_MULTIPLIER);
+  const patch = semver % SEMVER_MINOR_VERSION_MULTIPLIER;
+  return [major, minor, patch];
+}
+
 // The major version is always 0 for now
 export function packSemver(major: number, minor: number, patch: number) {
   if (major !== 0) {
@@ -91,4 +98,9 @@ export function packSemver(major: number, minor: number, patch: number) {
   }
 
   return minor * SEMVER_MINOR_VERSION_MULTIPLIER + patch;
+}
+
+export function addToProtocolVersion(packedProtocolVersion: number, minor: number, patch: number) {
+  const [major, minorVersion, patchVersion] = unpackNumberSemVer(packedProtocolVersion);
+  return packSemver(major, minorVersion + minor, patchVersion + patch);
 }

--- a/l1-contracts/scripts/verify.ts
+++ b/l1-contracts/scripts/verify.ts
@@ -123,8 +123,6 @@ async function main() {
   const diamondCut = await deployer.initialZkSyncHyperchainDiamondCut([]);
   const protocolVersion = packSemver(...unpackStringSemVer(process.env.CONTRACTS_GENESIS_PROTOCOL_VERSION));
 
-  console.log("applied protocovl version", protocolVersion);
-
   const initCalldata2 = stateTransitionManager.encodeFunctionData("initialize", [
     {
       owner: addresses.Governance,

--- a/l1-contracts/scripts/verify.ts
+++ b/l1-contracts/scripts/verify.ts
@@ -123,7 +123,7 @@ async function main() {
   const diamondCut = await deployer.initialZkSyncHyperchainDiamondCut([]);
   const protocolVersion = packSemver(...unpackStringSemVer(process.env.CONTRACTS_GENESIS_PROTOCOL_VERSION));
 
-  console.log('applied protocovl version', protocolVersion);
+  console.log("applied protocovl version", protocolVersion);
 
   const initCalldata2 = stateTransitionManager.encodeFunctionData("initialize", [
     {

--- a/l1-contracts/scripts/verify.ts
+++ b/l1-contracts/scripts/verify.ts
@@ -6,7 +6,7 @@ import { getNumberFromEnv, getHashFromEnv, getAddressFromEnv, ethTestConfig } fr
 import { Interface } from "ethers/lib/utils";
 import { Deployer } from "../src.ts/deploy";
 import { Wallet } from "ethers";
-import { web3Provider } from "./utils";
+import { packSemver, unpackStringSemVer, web3Provider } from "./utils";
 import { getTokens } from "../src.ts/deploy-token";
 
 const provider = web3Provider();
@@ -121,7 +121,9 @@ async function main() {
   const genesisRollupLeafIndex = getNumberFromEnv("CONTRACTS_GENESIS_ROLLUP_LEAF_INDEX");
   const genesisBatchCommitment = getHashFromEnv("CONTRACTS_GENESIS_BATCH_COMMITMENT");
   const diamondCut = await deployer.initialZkSyncHyperchainDiamondCut([]);
-  const protocolVersion = getNumberFromEnv("CONTRACTS_GENESIS_PROTOCOL_VERSION");
+  const protocolVersion = packSemver(...unpackStringSemVer(process.env.CONTRACTS_GENESIS_PROTOCOL_VERSION));
+
+  console.log('applied protocovl version', protocolVersion);
 
   const initCalldata2 = stateTransitionManager.encodeFunctionData("initialize", [
     {

--- a/l1-contracts/src.ts/deploy-test-process.ts
+++ b/l1-contracts/src.ts/deploy-test-process.ts
@@ -20,7 +20,7 @@ import {
 } from "./deploy-process";
 import { deployTokens, getTokens } from "./deploy-token";
 
-import { SYSTEM_CONFIG } from "../scripts/utils";
+import { SYSTEM_CONFIG, packSemver } from "../scripts/utils";
 import {
   testConfigPath,
   getNumberFromEnv,
@@ -38,7 +38,7 @@ const addressConfig = JSON.parse(fs.readFileSync(`${testConfigPath}/addresses.js
 const testnetTokenPath = `${testConfigPath}/hardhat.json`;
 
 export async function loadDefaultEnvVarsForTests(deployWallet: Wallet) {
-  process.env.CONTRACTS_GENESIS_PROTOCOL_VERSION = (21).toString();
+  process.env.CONTRACTS_GENESIS_PROTOCOL_VERSION = packSemver(0, 21, 0).toString();
   process.env.CONTRACTS_GENESIS_ROOT = ethers.constants.HashZero;
   process.env.CONTRACTS_GENESIS_ROLLUP_LEAF_INDEX = "0";
   process.env.CONTRACTS_GENESIS_BATCH_COMMITMENT = ethers.constants.HashZero;

--- a/l1-contracts/src.ts/deploy-test-process.ts
+++ b/l1-contracts/src.ts/deploy-test-process.ts
@@ -20,7 +20,7 @@ import {
 } from "./deploy-process";
 import { deployTokens, getTokens } from "./deploy-token";
 
-import { SYSTEM_CONFIG, packSemver } from "../scripts/utils";
+import { SYSTEM_CONFIG } from "../scripts/utils";
 import {
   testConfigPath,
   getNumberFromEnv,
@@ -38,7 +38,7 @@ const addressConfig = JSON.parse(fs.readFileSync(`${testConfigPath}/addresses.js
 const testnetTokenPath = `${testConfigPath}/hardhat.json`;
 
 export async function loadDefaultEnvVarsForTests(deployWallet: Wallet) {
-  process.env.CONTRACTS_GENESIS_PROTOCOL_VERSION = packSemver(0, 21, 0).toString();
+  process.env.CONTRACTS_GENESIS_PROTOCOL_VERSION = "0.21.0";
   process.env.CONTRACTS_GENESIS_ROOT = ethers.constants.HashZero;
   process.env.CONTRACTS_GENESIS_ROLLUP_LEAF_INDEX = "0";
   process.env.CONTRACTS_GENESIS_BATCH_COMMITMENT = ethers.constants.HashZero;

--- a/l1-contracts/src.ts/deploy.ts
+++ b/l1-contracts/src.ts/deploy.ts
@@ -6,7 +6,13 @@ import { ethers } from "ethers";
 import { hexlify, Interface } from "ethers/lib/utils";
 import type { DeployedAddresses } from "./deploy-utils";
 import { deployedAddressesFromEnv, deployBytecodeViaCreate2, deployViaCreate2 } from "./deploy-utils";
-import { packSemver, readBatchBootloaderBytecode, readSystemContractsBytecode, SYSTEM_CONFIG, unpackStringSemVer } from "../scripts/utils";
+import {
+  packSemver,
+  readBatchBootloaderBytecode,
+  readSystemContractsBytecode,
+  SYSTEM_CONFIG,
+  unpackStringSemVer,
+} from "../scripts/utils";
 import { getTokens } from "./deploy-token";
 import {
   ADDRESS_ONE,
@@ -308,10 +314,10 @@ export class Deployer {
     const genesisBatchCommitment = getHashFromEnv("CONTRACTS_GENESIS_BATCH_COMMITMENT");
     const diamondCut = await this.initialZkSyncHyperchainDiamondCut(extraFacets);
     const protocolVersion = packSemver(...unpackStringSemVer(process.env.CONTRACTS_GENESIS_PROTOCOL_VERSION));
-    
+
     console.log(packSemver(0, 1000, 5));
 
-    console.log('applied protocovl version', protocolVersion);
+    console.log("applied protocovl version", protocolVersion);
 
     const stateTransitionManager = new Interface(hardhat.artifacts.readArtifactSync("StateTransitionManager").abi);
 

--- a/l1-contracts/src.ts/deploy.ts
+++ b/l1-contracts/src.ts/deploy.ts
@@ -6,7 +6,7 @@ import { ethers } from "ethers";
 import { hexlify, Interface } from "ethers/lib/utils";
 import type { DeployedAddresses } from "./deploy-utils";
 import { deployedAddressesFromEnv, deployBytecodeViaCreate2, deployViaCreate2 } from "./deploy-utils";
-import { readBatchBootloaderBytecode, readSystemContractsBytecode, SYSTEM_CONFIG } from "../scripts/utils";
+import { packSemver, readBatchBootloaderBytecode, readSystemContractsBytecode, SYSTEM_CONFIG, unpackStringSemVer } from "../scripts/utils";
 import { getTokens } from "./deploy-token";
 import {
   ADDRESS_ONE,
@@ -307,7 +307,11 @@ export class Deployer {
     const genesisRollupLeafIndex = getNumberFromEnv("CONTRACTS_GENESIS_ROLLUP_LEAF_INDEX");
     const genesisBatchCommitment = getHashFromEnv("CONTRACTS_GENESIS_BATCH_COMMITMENT");
     const diamondCut = await this.initialZkSyncHyperchainDiamondCut(extraFacets);
-    const protocolVersion = getNumberFromEnv("CONTRACTS_GENESIS_PROTOCOL_VERSION");
+    const protocolVersion = packSemver(...unpackStringSemVer(process.env.CONTRACTS_GENESIS_PROTOCOL_VERSION));
+    
+    console.log(packSemver(0, 1000, 5));
+
+    console.log('applied protocovl version', protocolVersion);
 
     const stateTransitionManager = new Interface(hardhat.artifacts.readArtifactSync("StateTransitionManager").abi);
 

--- a/l1-contracts/src.ts/deploy.ts
+++ b/l1-contracts/src.ts/deploy.ts
@@ -315,10 +315,6 @@ export class Deployer {
     const diamondCut = await this.initialZkSyncHyperchainDiamondCut(extraFacets);
     const protocolVersion = packSemver(...unpackStringSemVer(process.env.CONTRACTS_GENESIS_PROTOCOL_VERSION));
 
-    console.log(packSemver(0, 1000, 5));
-
-    console.log("applied protocovl version", protocolVersion);
-
     const stateTransitionManager = new Interface(hardhat.artifacts.readArtifactSync("StateTransitionManager").abi);
 
     const initCalldata = stateTransitionManager.encodeFunctionData("initialize", [

--- a/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/facets/Admin/ExecuteUpgrade.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/facets/Admin/ExecuteUpgrade.t.sol
@@ -9,7 +9,7 @@ import {Utils} from "../../../../Utils/Utils.sol";
 import {VerifierParams} from "contracts/state-transition/chain-interfaces/IVerifier.sol";
 import {Diamond} from "contracts/state-transition/libraries/Diamond.sol";
 import {DefaultUpgrade} from "contracts/upgrades/DefaultUpgrade.sol";
-import {SemVer} from "contracts/common/libraries/Semver.sol";
+import {SemVer} from "contracts/common/libraries/SemVer.sol";
 import {ProposedUpgrade} from "contracts/upgrades/BaseZkSyncUpgrade.sol";
 
 contract ExecuteUpgradeTest is AdminTest {

--- a/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/facets/Admin/ExecuteUpgrade.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/facets/Admin/ExecuteUpgrade.t.sol
@@ -60,7 +60,6 @@ contract ExecuteUpgradeTest is AdminTest {
             initCalldata: abi.encodeCall(upgrade.upgrade, (proposedUpgrade))
         });
 
-
         address stm = utilsFacet.util_getStateTransitionManager();
         vm.startPrank(stm);
 

--- a/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/facets/Admin/ExecuteUpgrade.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/facets/Admin/ExecuteUpgrade.t.sol
@@ -4,8 +4,13 @@ pragma solidity 0.8.24;
 
 import {AdminTest} from "./_Admin_Shared.t.sol";
 import {ERROR_ONLY_STATE_TRANSITION_MANAGER} from "../Base/_Base_Shared.t.sol";
+import {Utils} from "../../../../Utils/Utils.sol";
 
+import {VerifierParams} from "contracts/state-transition/chain-interfaces/IVerifier.sol";
 import {Diamond} from "contracts/state-transition/libraries/Diamond.sol";
+import {DefaultUpgrade} from "contracts/upgrades/DefaultUpgrade.sol";
+import {SemVer} from "contracts/common/libraries/Semver.sol";
+import {ProposedUpgrade} from "contracts/upgrades/BaseZkSyncUpgrade.sol";
 
 contract ExecuteUpgradeTest is AdminTest {
     event ExecuteUpgrade(Diamond.DiamondCutData diamondCut);
@@ -21,6 +26,44 @@ contract ExecuteUpgradeTest is AdminTest {
         vm.expectRevert(ERROR_ONLY_STATE_TRANSITION_MANAGER);
 
         vm.startPrank(nonStateTransitionManager);
+        adminFacet.executeUpgrade(diamondCutData);
+    }
+
+    function test_migrateToSemVerApproach() public {
+        // Setting minor protocol version manually
+        utilsFacet.util_setProtocolVersion(22);
+
+        VerifierParams memory verifierParams = VerifierParams({
+            recursionNodeLevelVkHash: bytes32(0),
+            recursionLeafLevelVkHash: bytes32(0),
+            recursionCircuitsSetVksHash: bytes32(0)
+        });
+
+        ProposedUpgrade memory proposedUpgrade = ProposedUpgrade({
+            l2ProtocolUpgradeTx: Utils.makeEmptyL2CanonicalTransaction(),
+            factoryDeps: new bytes[](0),
+            bootloaderHash: bytes32(0),
+            defaultAccountHash: bytes32(0),
+            verifier: address(0),
+            verifierParams: verifierParams,
+            l1ContractsUpgradeCalldata: hex"",
+            postUpgradeCalldata: hex"",
+            upgradeTimestamp: 0,
+            newProtocolVersion: SemVer.packSemVer(0, 24, 0)
+        });
+
+        DefaultUpgrade upgrade = new DefaultUpgrade();
+
+        Diamond.DiamondCutData memory diamondCutData = Diamond.DiamondCutData({
+            facetCuts: new Diamond.FacetCut[](0),
+            initAddress: address(upgrade),
+            initCalldata: abi.encodeCall(upgrade.upgrade, (proposedUpgrade))
+        });
+
+
+        address stm = utilsFacet.util_getStateTransitionManager();
+        vm.startPrank(stm);
+
         adminFacet.executeUpgrade(diamondCutData);
     }
 }

--- a/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/facets/Admin/ExecuteUpgrade.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/facets/Admin/ExecuteUpgrade.t.sol
@@ -29,6 +29,7 @@ contract ExecuteUpgradeTest is AdminTest {
         adminFacet.executeUpgrade(diamondCutData);
     }
 
+    /// TODO: This test should be removed after the migration to the semver is complete everywhere.
     function test_migrateToSemVerApproach() public {
         // Setting minor protocol version manually
         utilsFacet.util_setProtocolVersion(22);
@@ -49,7 +50,7 @@ contract ExecuteUpgradeTest is AdminTest {
             l1ContractsUpgradeCalldata: hex"",
             postUpgradeCalldata: hex"",
             upgradeTimestamp: 0,
-            newProtocolVersion: SemVer.packSemVer(0, 24, 0)
+            newProtocolVersion: SemVer.packSemVer(0, 22, 0)
         });
 
         DefaultUpgrade upgrade = new DefaultUpgrade();

--- a/l1-contracts/test/test_config/constant/hardhat.json
+++ b/l1-contracts/test/test_config/constant/hardhat.json
@@ -3,96 +3,96 @@
     "name": "DAI",
     "symbol": "DAI",
     "decimals": 18,
-    "address": "0x833C5ce14E47b8d41249E4286FCd59057BD22333"
+    "address": "0xD6E49dd4fb0CA1549566869725d1820aDEb92Ae9"
   },
   {
     "name": "wBTC",
     "symbol": "wBTC",
     "decimals": 8,
-    "address": "0x99e642bF43b529458b149bef9137CB7dA11CF1cD"
+    "address": "0xcee1f75F30B6908286Cd003C4228A5D9a2851FA4"
   },
   {
     "name": "BAT",
     "symbol": "BAT",
     "decimals": 18,
-    "address": "0x8B12E0BED758bd29ACac0aD13BB6412a32299bA3"
+    "address": "0x0Bc76A4EfE0748f1697F237fB100741ea6Ceda2d"
   },
   {
     "name": "GNT",
     "symbol": "GNT",
     "decimals": 18,
-    "address": "0xEC6A2198500fA521586740Dd8ec320826525a5b5"
+    "address": "0x51ae50BcCEE10ac5BEFFA1E4a64106a5f83bc3F8"
   },
   {
     "name": "MLTT",
     "symbol": "MLTT",
     "decimals": 18,
-    "address": "0xC8E7e7236eF6fE54FDe05744552Bf75eAa65c8d6"
+    "address": "0xa9c7fEEf8586E17D93A05f873BA65f28f48ED259"
   },
   {
     "name": "DAIK",
     "symbol": "DAIK",
     "decimals": 18,
-    "address": "0x8521Dea5D57b452007FdDB9c68B2D23077c6FD72"
+    "address": "0x99Efb27598804Aa408A1066550e9d01c45f21b05"
   },
   {
     "name": "wBTCK",
     "symbol": "wBTCK",
     "decimals": 8,
-    "address": "0x70C560a9066710d06450785AA930BeC28DC689f5"
+    "address": "0x4B701928Da6B3e72775b462A15b8b76ba2d16BbD"
   },
   {
     "name": "BATK",
     "symbol": "BATS",
     "decimals": 18,
-    "address": "0x58E1Ae315c130302Ec6E48A9d8E69E8dEa690537"
+    "address": "0xf7B03c921dfefB4286b13075BA0335099708368D"
   },
   {
     "name": "GNTK",
     "symbol": "GNTS",
     "decimals": 18,
-    "address": "0xFAC80988B9d5320261150A4B4ec119FB1C133580"
+    "address": "0xc0581Ee28c519533B06cc0aAC1ace98cF63C817b"
   },
   {
     "name": "MLTTK",
     "symbol": "MLTTS",
     "decimals": 18,
-    "address": "0x9F5d1DA449A6c22CCCCE139acD98adD82797fEec"
+    "address": "0xeB6394F2E8DA607b94dBa2Cf345A965d6D9b3aCD"
   },
   {
     "name": "DAIL",
     "symbol": "DAIL",
     "decimals": 18,
-    "address": "0x275E5aa56a705c8726eE35B3DC6530DE0a0e5f6c"
+    "address": "0x4311643C5eD7cD0813B4E3Ff5428de71c7d7b8bB"
   },
   {
     "name": "wBTCL",
     "symbol": "wBTCP",
     "decimals": 8,
-    "address": "0x18d8b7878Ee8D1cf3c32b177e0B0EC2379084B11"
+    "address": "0x6b3fbfC9Bb89Ab5F11BE782a1f67c1615c2A5fc3"
   },
   {
     "name": "BATL",
     "symbol": "BATW",
     "decimals": 18,
-    "address": "0xe4B41b2c8e3831cbEdC8b3D82047fA30B6B22946"
+    "address": "0xE003698b7831829843B69D3fB4f9a3133d97b257"
   },
   {
     "name": "GNTL",
     "symbol": "GNTW",
     "decimals": 18,
-    "address": "0xe8c976ce9F855825e52015bd1E88Fc84Da1946d2"
+    "address": "0x2417626170675Ccf6022d9db1eFC8f3c59836368"
   },
   {
     "name": "MLTTL",
     "symbol": "MLTTW",
     "decimals": 18,
-    "address": "0xd012f213dDD34858A1357e30B4c491dbFCba8Ee3"
+    "address": "0x28106C39BE5E51C31D9a289313361D86C9bb7C8E"
   },
   {
     "name": "Wrapped Ether",
     "symbol": "WETH",
     "decimals": 18,
-    "address": "0x8fbdf8cEAf04E3cc9ac53C90b344c0c2489a0645"
+    "address": "0x51E83b811930bb4a3aAb3494894ec237Cb6cEc49"
   }
 ]

--- a/l1-contracts/test/test_config/constant/hardhat.json
+++ b/l1-contracts/test/test_config/constant/hardhat.json
@@ -3,96 +3,96 @@
     "name": "DAI",
     "symbol": "DAI",
     "decimals": 18,
-    "address": "0xD6E49dd4fb0CA1549566869725d1820aDEb92Ae9"
+    "address": "0x833C5ce14E47b8d41249E4286FCd59057BD22333"
   },
   {
     "name": "wBTC",
     "symbol": "wBTC",
     "decimals": 8,
-    "address": "0xcee1f75F30B6908286Cd003C4228A5D9a2851FA4"
+    "address": "0x99e642bF43b529458b149bef9137CB7dA11CF1cD"
   },
   {
     "name": "BAT",
     "symbol": "BAT",
     "decimals": 18,
-    "address": "0x0Bc76A4EfE0748f1697F237fB100741ea6Ceda2d"
+    "address": "0x8B12E0BED758bd29ACac0aD13BB6412a32299bA3"
   },
   {
     "name": "GNT",
     "symbol": "GNT",
     "decimals": 18,
-    "address": "0x51ae50BcCEE10ac5BEFFA1E4a64106a5f83bc3F8"
+    "address": "0xEC6A2198500fA521586740Dd8ec320826525a5b5"
   },
   {
     "name": "MLTT",
     "symbol": "MLTT",
     "decimals": 18,
-    "address": "0xa9c7fEEf8586E17D93A05f873BA65f28f48ED259"
+    "address": "0xC8E7e7236eF6fE54FDe05744552Bf75eAa65c8d6"
   },
   {
     "name": "DAIK",
     "symbol": "DAIK",
     "decimals": 18,
-    "address": "0x99Efb27598804Aa408A1066550e9d01c45f21b05"
+    "address": "0x8521Dea5D57b452007FdDB9c68B2D23077c6FD72"
   },
   {
     "name": "wBTCK",
     "symbol": "wBTCK",
     "decimals": 8,
-    "address": "0x4B701928Da6B3e72775b462A15b8b76ba2d16BbD"
+    "address": "0x70C560a9066710d06450785AA930BeC28DC689f5"
   },
   {
     "name": "BATK",
     "symbol": "BATS",
     "decimals": 18,
-    "address": "0xf7B03c921dfefB4286b13075BA0335099708368D"
+    "address": "0x58E1Ae315c130302Ec6E48A9d8E69E8dEa690537"
   },
   {
     "name": "GNTK",
     "symbol": "GNTS",
     "decimals": 18,
-    "address": "0xc0581Ee28c519533B06cc0aAC1ace98cF63C817b"
+    "address": "0xFAC80988B9d5320261150A4B4ec119FB1C133580"
   },
   {
     "name": "MLTTK",
     "symbol": "MLTTS",
     "decimals": 18,
-    "address": "0xeB6394F2E8DA607b94dBa2Cf345A965d6D9b3aCD"
+    "address": "0x9F5d1DA449A6c22CCCCE139acD98adD82797fEec"
   },
   {
     "name": "DAIL",
     "symbol": "DAIL",
     "decimals": 18,
-    "address": "0x4311643C5eD7cD0813B4E3Ff5428de71c7d7b8bB"
+    "address": "0x275E5aa56a705c8726eE35B3DC6530DE0a0e5f6c"
   },
   {
     "name": "wBTCL",
     "symbol": "wBTCP",
     "decimals": 8,
-    "address": "0x6b3fbfC9Bb89Ab5F11BE782a1f67c1615c2A5fc3"
+    "address": "0x18d8b7878Ee8D1cf3c32b177e0B0EC2379084B11"
   },
   {
     "name": "BATL",
     "symbol": "BATW",
     "decimals": 18,
-    "address": "0xE003698b7831829843B69D3fB4f9a3133d97b257"
+    "address": "0xe4B41b2c8e3831cbEdC8b3D82047fA30B6B22946"
   },
   {
     "name": "GNTL",
     "symbol": "GNTW",
     "decimals": 18,
-    "address": "0x2417626170675Ccf6022d9db1eFC8f3c59836368"
+    "address": "0xe8c976ce9F855825e52015bd1E88Fc84Da1946d2"
   },
   {
     "name": "MLTTL",
     "symbol": "MLTTW",
     "decimals": 18,
-    "address": "0x28106C39BE5E51C31D9a289313361D86C9bb7C8E"
+    "address": "0xd012f213dDD34858A1357e30B4c491dbFCba8Ee3"
   },
   {
     "name": "Wrapped Ether",
     "symbol": "WETH",
     "decimals": 18,
-    "address": "0x51E83b811930bb4a3aAb3494894ec237Cb6cEc49"
+    "address": "0x8fbdf8cEAf04E3cc9ac53C90b344c0c2489a0645"
   }
 ]

--- a/l1-contracts/test/unit_tests/l2-upgrade.test.spec.ts
+++ b/l1-contracts/test/unit_tests/l2-upgrade.test.spec.ts
@@ -208,6 +208,24 @@ describe.only("L2 upgrade test", function () {
     expect(bootloaderRevertReason).to.equal("Patch only upgrade can not set upgrade transaction");
   });
 
+  it("Should not allow major version change", async () => {
+    // 2**64 is the offset for a major version change
+    const newVersion = ethers.BigNumber.from(2).pow(64);
+
+    const someTx = buildL2CanonicalTransaction({
+      txType: 254,
+      nonce: 0,
+    });
+
+    const bootloaderRevertReason = await getCallRevertReason(
+      executeUpgrade(chainId, proxyGetters, stateTransitionManager, proxyAdmin, {
+        newProtocolVersion: newVersion,
+        l2ProtocolUpgradeTx: someTx,
+      })
+    );
+    expect(bootloaderRevertReason).to.equal("Major must always be 0");
+  });
+
   it("Timestamp should behave correctly", async () => {
     // Upgrade was scheduled for now should work fine
     const timeNow = (await hardhat.ethers.provider.getBlock("latest")).timestamp;

--- a/l1-contracts/test/unit_tests/l2-upgrade.test.spec.ts
+++ b/l1-contracts/test/unit_tests/l2-upgrade.test.spec.ts
@@ -40,6 +40,7 @@ import {
   makeExecutedEqualCommitted,
   getBatchStoredInfo,
 } from "./utils";
+import { packSemver, unpackStringSemVer } from "../../scripts/utils";
 
 describe("L2 upgrade test", function () {
   let proxyExecutor: ExecutorFacet;
@@ -92,7 +93,7 @@ describe("L2 upgrade test", function () {
     const transferOwnershipTx = await ownable.acceptOwnership();
     await transferOwnershipTx.wait();
 
-    initialProtocolVersion = parseInt(process.env.CONTRACTS_GENESIS_PROTOCOL_VERSION);
+    initialProtocolVersion = packSemver(...unpackStringSemVer(process.env.CONTRACTS_GENESIS_PROTOCOL_VERSION));
 
     chainId = deployer.chainId;
     verifier = deployer.addresses.StateTransition.Verifier;

--- a/l1-contracts/test/unit_tests/l2-upgrade.test.spec.ts
+++ b/l1-contracts/test/unit_tests/l2-upgrade.test.spec.ts
@@ -93,14 +93,14 @@ describe.only("L2 upgrade test", function () {
     const transferOwnershipTx = await ownable.acceptOwnership();
     await transferOwnershipTx.wait();
 
-    const [initialMajor, initalMinor, initialPatch] = unpackStringSemVer(
+    const [initialMajor, initialMinor, initialPatch] = unpackStringSemVer(
       process.env.CONTRACTS_GENESIS_PROTOCOL_SEMANTIC_VERSION
     );
     if (initialMajor !== 0 || initialPatch !== 0) {
       throw new Error("Initial protocol version must be 0.x.0");
     }
-    initialProtocolVersion = packSemver(initialMajor, initalMinor, initialPatch);
-    initialMinorProtocolVersion = initalMinor;
+    initialProtocolVersion = packSemver(initialMajor, initialMinor, initialPatch);
+    initialMinorProtocolVersion = initialMinor;
 
     chainId = deployer.chainId;
     verifier = deployer.addresses.StateTransition.Verifier;

--- a/l1-contracts/test/unit_tests/utils.ts
+++ b/l1-contracts/test/unit_tests/utils.ts
@@ -14,7 +14,7 @@ import type { FeeParams, L2CanonicalTransaction } from "../../src.ts/utils";
 import { ADDRESS_ONE, PubdataPricingMode, EMPTY_STRING_KECCAK } from "../../src.ts/utils";
 import { packSemver } from "../../scripts/utils";
 
-export const CONTRACTS_GENESIS_PROTOCOL_VERSION = packSemver(0,21,0).toString();
+export const CONTRACTS_GENESIS_PROTOCOL_VERSION = packSemver(0, 21, 0).toString();
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 export const IERC20_INTERFACE = require("@openzeppelin/contracts/build/contracts/IERC20");
 export const DEFAULT_REVERT_REASON = "VM did not revert";

--- a/l1-contracts/test/unit_tests/utils.ts
+++ b/l1-contracts/test/unit_tests/utils.ts
@@ -12,8 +12,9 @@ import type { ExecutorFacet } from "../../typechain";
 
 import type { FeeParams, L2CanonicalTransaction } from "../../src.ts/utils";
 import { ADDRESS_ONE, PubdataPricingMode, EMPTY_STRING_KECCAK } from "../../src.ts/utils";
+import { packSemver } from "../../scripts/utils";
 
-export const CONTRACTS_GENESIS_PROTOCOL_VERSION = (21).toString();
+export const CONTRACTS_GENESIS_PROTOCOL_VERSION = packSemver(0,21,0).toString();
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 export const IERC20_INTERFACE = require("@openzeppelin/contracts/build/contracts/IERC20");
 export const DEFAULT_REVERT_REASON = "VM did not revert";


### PR DESCRIPTION
# What ❔

Storing `protocolVersion` as a packed semver value. 

Two potential improvements:

- Store it as `struct` in storage. It gives us more explicit description of what it is. However it causes a much bigger diff code and generally packing will still be needed for the `protocolVersionDeadline` map in STM.
- Store it as 100 * minor + patch. It is more human readable, but not "standard", though we can consider it due to better usability   

Fixes: EVM-637

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
