### PR TITLE
Use `CONTRACTS_GENESIS_PROTOCOL_SEMANTIC_VERSION` variable

### DIFF
--- a/l1-contracts/scripts/verify.ts
+++ b/l1-contracts/scripts/verify.ts
@@ -121,7 +121,7 @@ async function main() {
   const genesisRollupLeafIndex = getNumberFromEnv("CONTRACTS_GENESIS_ROLLUP_LEAF_INDEX");
   const genesisBatchCommitment = getHashFromEnv("CONTRACTS_GENESIS_BATCH_COMMITMENT");
   const diamondCut = await deployer.initialZkSyncHyperchainDiamondCut([]);
-  const protocolVersion = packSemver(...unpackStringSemVer(process.env.CONTRACTS_GENESIS_PROTOCOL_VERSION));
+  const protocolVersion = packSemver(...unpackStringSemVer(process.env.CONTRACTS_GENESIS_PROTOCOL_SEMANTIC_VERSION));
 
   const initCalldata2 = stateTransitionManager.encodeFunctionData("initialize", [
     {

--- a/l1-contracts/src.ts/deploy-test-process.ts
+++ b/l1-contracts/src.ts/deploy-test-process.ts
@@ -38,7 +38,7 @@ const addressConfig = JSON.parse(fs.readFileSync(`${testConfigPath}/addresses.js
 const testnetTokenPath = `${testConfigPath}/hardhat.json`;
 
 export async function loadDefaultEnvVarsForTests(deployWallet: Wallet) {
-  process.env.CONTRACTS_GENESIS_PROTOCOL_VERSION = "0.21.0";
+  process.env.CONTRACTS_GENESIS_PROTOCOL_SEMANTIC_VERSION = "0.21.0";
   process.env.CONTRACTS_GENESIS_ROOT = ethers.constants.HashZero;
   process.env.CONTRACTS_GENESIS_ROLLUP_LEAF_INDEX = "0";
   process.env.CONTRACTS_GENESIS_BATCH_COMMITMENT = ethers.constants.HashZero;

--- a/l1-contracts/src.ts/deploy.ts
+++ b/l1-contracts/src.ts/deploy.ts
@@ -313,7 +313,7 @@ export class Deployer {
     const genesisRollupLeafIndex = getNumberFromEnv("CONTRACTS_GENESIS_ROLLUP_LEAF_INDEX");
     const genesisBatchCommitment = getHashFromEnv("CONTRACTS_GENESIS_BATCH_COMMITMENT");
     const diamondCut = await this.initialZkSyncHyperchainDiamondCut(extraFacets);
-    const protocolVersion = packSemver(...unpackStringSemVer(process.env.CONTRACTS_GENESIS_PROTOCOL_VERSION));
+    const protocolVersion = packSemver(...unpackStringSemVer(process.env.CONTRACTS_GENESIS_PROTOCOL_SEMANTIC_VERSION));
 
     const stateTransitionManager = new Interface(hardhat.artifacts.readArtifactSync("StateTransitionManager").abi);
 

--- a/l1-contracts/test/unit_tests/l2-upgrade.test.spec.ts
+++ b/l1-contracts/test/unit_tests/l2-upgrade.test.spec.ts
@@ -94,7 +94,7 @@ describe("L2 upgrade test", function () {
     await transferOwnershipTx.wait();
 
     const [initialMajor, initalMinor, initialPatch] = unpackStringSemVer(
-      process.env.CONTRACTS_GENESIS_PROTOCOL_VERSION
+      process.env.CONTRACTS_GENESIS_PROTOCOL_SEMANTIC_VERSION
     );
     if (initialMajor !== 0 || initialPatch !== 0) {
       throw new Error("Initial protocol version must be 0.x.0");


### PR DESCRIPTION
# What ❔

Uses `CONTRACTS_GENESIS_PROTOCOL_SEMANTIC_VERSION` variable in scripts

## Why ❔

We introduce new env variable to keep server config schema backward compatible

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
