### PR TITLE
Bridgehub Test Coverage Increase

### DIFF
--- a/l1-contracts/contracts/bridgehub/Bridgehub.sol
+++ b/l1-contracts/contracts/bridgehub/Bridgehub.sol
@@ -314,6 +314,11 @@ contract Bridgehub is IBridgehub, ReentrancyGuard, Ownable2StepUpgradeable, Paus
 
         address hyperchain = getHyperchain(_request.chainId);
 
+        require(
+            _request.secondBridgeAddress > BRIDGEHUB_MIN_SECOND_BRIDGE_ADDRESS,
+            "Bridgehub: second bridge address too low"
+        ); // to avoid calls to precompiles
+
         // slither-disable-next-line arbitrary-send-eth
         L2TransactionRequestTwoBridgesInner memory outputRequest = IL1SharedBridge(_request.secondBridgeAddress)
             .bridgehubDeposit{value: _request.secondBridgeValue}(
@@ -327,10 +332,6 @@ contract Bridgehub is IBridgehub, ReentrancyGuard, Ownable2StepUpgradeable, Paus
 
         address refundRecipient = AddressAliasHelper.actualRefundRecipient(_request.refundRecipient, msg.sender);
 
-        require(
-            _request.secondBridgeAddress > BRIDGEHUB_MIN_SECOND_BRIDGE_ADDRESS,
-            "Bridgehub: second bridge address too low"
-        ); // to avoid calls to precompiles
         canonicalTxHash = IZkSyncHyperchain(hyperchain).bridgehubRequestL2Transaction(
             BridgehubL2TransactionRequest({
                 sender: _request.secondBridgeAddress,

--- a/l1-contracts/contracts/bridgehub/Bridgehub.sol
+++ b/l1-contracts/contracts/bridgehub/Bridgehub.sol
@@ -314,11 +314,6 @@ contract Bridgehub is IBridgehub, ReentrancyGuard, Ownable2StepUpgradeable, Paus
 
         address hyperchain = getHyperchain(_request.chainId);
 
-        require(
-            _request.secondBridgeAddress > BRIDGEHUB_MIN_SECOND_BRIDGE_ADDRESS,
-            "Bridgehub: second bridge address too low"
-        ); // to avoid calls to precompiles
-
         // slither-disable-next-line arbitrary-send-eth
         L2TransactionRequestTwoBridgesInner memory outputRequest = IL1SharedBridge(_request.secondBridgeAddress)
             .bridgehubDeposit{value: _request.secondBridgeValue}(
@@ -332,6 +327,10 @@ contract Bridgehub is IBridgehub, ReentrancyGuard, Ownable2StepUpgradeable, Paus
 
         address refundRecipient = AddressAliasHelper.actualRefundRecipient(_request.refundRecipient, msg.sender);
 
+        require(
+            _request.secondBridgeAddress > BRIDGEHUB_MIN_SECOND_BRIDGE_ADDRESS,
+            "Bridgehub: second bridge address too low"
+        ); // to avoid calls to precompiles
         canonicalTxHash = IZkSyncHyperchain(hyperchain).bridgehubRequestL2Transaction(
             BridgehubL2TransactionRequest({
                 sender: _request.secondBridgeAddress,

--- a/l1-contracts/test/foundry/unit/concrete/Bridges/L1Erc20Bridge/ClaimFailedDeposit.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Bridges/L1Erc20Bridge/ClaimFailedDeposit.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.24;
 
 import {L1Erc20BridgeTest} from "./_L1Erc20Bridge_Shared.t.sol";
 import {StdStorage, stdStorage} from "forge-std/Test.sol";
+import {IL1SharedBridge} from "contracts/bridge/interfaces/IL1SharedBridge.sol";
 
 contract ClaimFailedDepositTest is L1Erc20BridgeTest {
     using stdStorage for StdStorage;
@@ -17,7 +18,7 @@ contract ClaimFailedDepositTest is L1Erc20BridgeTest {
         bridge.claimFailedDeposit({
             _depositSender: randomSigner,
             _l1Token: address(token),
-            _l2TxHash: dummyL2DepositTxHash,
+            _l2TxHash: bytes32(""),
             _l2BatchNumber: 0,
             _l2MessageIndex: 0,
             _l2TxNumberInBatch: 0,
@@ -26,37 +27,56 @@ contract ClaimFailedDepositTest is L1Erc20BridgeTest {
     }
 
     function test_claimFailedDepositSuccessfully() public {
-        uint256 depositedAmountBefore = bridge.depositAmount(alice, address(token), dummyL2DepositTxHash);
+        uint256 amount = 16;
+        bytes32 l2DepositTxHash = keccak256("l2tx");
+        bytes32[] memory merkleProof;
+
+        uint256 depositedAmountBefore = bridge.depositAmount(alice, address(token), l2DepositTxHash);
         assertEq(depositedAmountBefore, 0);
 
-        uint256 amount = 16;
         stdstore
             .target(address(bridge))
             .sig("depositAmount(address,address,bytes32)")
             .with_key(alice)
             .with_key(address(token))
-            .with_key(dummyL2DepositTxHash)
+            .with_key(l2DepositTxHash)
             .checked_write(amount);
 
-        uint256 depositedAmountAfterDeposit = bridge.depositAmount(alice, address(token), dummyL2DepositTxHash);
+        uint256 depositedAmountAfterDeposit = bridge.depositAmount(alice, address(token), l2DepositTxHash);
         assertEq(depositedAmountAfterDeposit, amount);
+
+        vm.mockCall(
+            sharedBridgeAddress,
+            abi.encodeWithSelector(
+                IL1SharedBridge.claimFailedDepositLegacyErc20Bridge.selector,
+                alice,
+                address(token),
+                amount,
+                l2DepositTxHash,
+                0,
+                0,
+                0,
+                merkleProof
+            ),
+            abi.encode("")
+        );
 
         vm.prank(alice);
         // solhint-disable-next-line func-named-parameters
         vm.expectEmit(true, true, true, true, address(bridge));
         emit ClaimedFailedDeposit(alice, address(token), amount);
-        bytes32[] memory merkleProof;
+
         bridge.claimFailedDeposit({
             _depositSender: alice,
             _l1Token: address(token),
-            _l2TxHash: dummyL2DepositTxHash,
+            _l2TxHash: l2DepositTxHash,
             _l2BatchNumber: 0,
             _l2MessageIndex: 0,
             _l2TxNumberInBatch: 0,
             _merkleProof: merkleProof
         });
 
-        uint256 depositedAmountAfterWithdrawal = bridge.depositAmount(alice, address(token), dummyL2DepositTxHash);
+        uint256 depositedAmountAfterWithdrawal = bridge.depositAmount(alice, address(token), l2DepositTxHash);
         assertEq(depositedAmountAfterWithdrawal, 0);
     }
 }

--- a/l1-contracts/test/foundry/unit/concrete/Bridges/L1Erc20Bridge/Deposit.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Bridges/L1Erc20Bridge/Deposit.t.sol
@@ -3,6 +3,7 @@
 pragma solidity 0.8.24;
 
 import {L1Erc20BridgeTest} from "./_L1Erc20Bridge_Shared.t.sol";
+import {IL1SharedBridge} from "contracts/bridge/interfaces/IL1SharedBridge.sol";
 
 contract DepositTest is L1Erc20BridgeTest {
     event DepositInitiated(
@@ -112,13 +113,30 @@ contract DepositTest is L1Erc20BridgeTest {
 
     function test_depositSuccessfully() public {
         uint256 amount = 8;
+        bytes32 l2TxHash = keccak256("txHash");
+
+        vm.mockCall(
+            sharedBridgeAddress,
+            abi.encodeWithSelector(
+                IL1SharedBridge.depositLegacyErc20Bridge.selector,
+                alice,
+                randomSigner,
+                address(token),
+                amount,
+                0,
+                0,
+                address(0)
+            ),
+            abi.encode(l2TxHash)
+        );
+
         vm.prank(alice);
         token.approve(address(bridge), amount);
         vm.prank(alice);
         // solhint-disable-next-line func-named-parameters
         vm.expectEmit(true, true, true, true, address(bridge));
         // solhint-disable-next-line func-named-parameters
-        emit DepositInitiated(dummyL2DepositTxHash, alice, randomSigner, address(token), amount);
+        emit DepositInitiated(l2TxHash, alice, randomSigner, address(token), amount);
         bytes32 txHash = bridge.deposit({
             _l2Receiver: randomSigner,
             _l1Token: address(token),
@@ -127,24 +145,41 @@ contract DepositTest is L1Erc20BridgeTest {
             _l2TxGasPerPubdataByte: 0,
             _refundRecipient: address(0)
         });
-        assertEq(txHash, dummyL2DepositTxHash);
+        assertEq(txHash, l2TxHash);
 
-        uint256 depositedAmount = bridge.depositAmount(alice, address(token), dummyL2DepositTxHash);
+        uint256 depositedAmount = bridge.depositAmount(alice, address(token), l2TxHash);
         assertEq(amount, depositedAmount);
     }
 
     function test_legacyDepositSuccessfully() public {
-        uint256 depositedAmountBefore = bridge.depositAmount(alice, address(token), dummyL2DepositTxHash);
+        uint256 amount = 8;
+        bytes32 l2TxHash = keccak256("txHash");
+
+        uint256 depositedAmountBefore = bridge.depositAmount(alice, address(token), l2TxHash);
         assertEq(depositedAmountBefore, 0);
 
-        uint256 amount = 8;
+        vm.mockCall(
+            sharedBridgeAddress,
+            abi.encodeWithSelector(
+                IL1SharedBridge.depositLegacyErc20Bridge.selector,
+                alice,
+                randomSigner,
+                address(token),
+                amount,
+                0,
+                0,
+                address(0)
+            ),
+            abi.encode(l2TxHash)
+        );
+
         vm.prank(alice);
         token.approve(address(bridge), amount);
         vm.prank(alice);
         // solhint-disable-next-line func-named-parameters
         vm.expectEmit(true, true, true, true, address(bridge));
         // solhint-disable-next-line func-named-parameters
-        emit DepositInitiated(dummyL2DepositTxHash, alice, randomSigner, address(token), amount);
+        emit DepositInitiated(l2TxHash, alice, randomSigner, address(token), amount);
         bytes32 txHash = bridge.deposit({
             _l2Receiver: randomSigner,
             _l1Token: address(token),
@@ -152,9 +187,9 @@ contract DepositTest is L1Erc20BridgeTest {
             _l2TxGasLimit: 0,
             _l2TxGasPerPubdataByte: 0
         });
-        assertEq(txHash, dummyL2DepositTxHash);
+        assertEq(txHash, l2TxHash);
 
-        uint256 depositedAmount = bridge.depositAmount(alice, address(token), dummyL2DepositTxHash);
+        uint256 depositedAmount = bridge.depositAmount(alice, address(token), l2TxHash);
         assertEq(amount, depositedAmount);
     }
 }

--- a/l1-contracts/test/foundry/unit/concrete/Bridges/L1Erc20Bridge/Reentrancy.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Bridges/L1Erc20Bridge/Reentrancy.t.sol
@@ -49,7 +49,7 @@ contract ReentrancyTest is L1Erc20BridgeTest {
             .sig("depositAmount(address,address,bytes32)")
             .with_key(alice)
             .with_key(address(token))
-            .with_key(dummyL2DepositTxHash)
+            .with_key(bytes32(""))
             .checked_write(amount);
 
         vm.prank(alice);
@@ -58,7 +58,7 @@ contract ReentrancyTest is L1Erc20BridgeTest {
         bridgeReenterItself.claimFailedDeposit({
             _depositSender: alice,
             _l1Token: address(token),
-            _l2TxHash: dummyL2DepositTxHash,
+            _l2TxHash: bytes32(""),
             _l2BatchNumber: 0,
             _l2MessageIndex: 0,
             _l2TxNumberInBatch: 0,

--- a/l1-contracts/test/foundry/unit/concrete/Bridges/L1Erc20Bridge/_L1Erc20Bridge_Shared.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Bridges/L1Erc20Bridge/_L1Erc20Bridge_Shared.t.sol
@@ -8,13 +8,11 @@ import {L1ERC20Bridge} from "contracts/bridge/L1ERC20Bridge.sol";
 import {IL1SharedBridge} from "contracts/bridge/interfaces/IL1SharedBridge.sol";
 import {TestnetERC20Token} from "contracts/dev-contracts/TestnetERC20Token.sol";
 import {FeeOnTransferToken} from "contracts/dev-contracts/FeeOnTransferToken.sol";
-import {DummySharedBridge} from "contracts/dev-contracts/test/DummySharedBridge.sol";
 import {ReenterL1ERC20Bridge} from "contracts/dev-contracts/test/ReenterL1ERC20Bridge.sol";
 import {Utils} from "../../Utils/Utils.sol";
 
 contract L1Erc20BridgeTest is Test {
     L1ERC20Bridge internal bridge;
-    DummySharedBridge internal dummySharedBridge;
 
     ReenterL1ERC20Bridge internal reenterL1ERC20Bridge;
     L1ERC20Bridge internal bridgeReenterItself;
@@ -23,15 +21,14 @@ contract L1Erc20BridgeTest is Test {
     TestnetERC20Token internal feeOnTransferToken;
     address internal randomSigner;
     address internal alice;
-    bytes32 internal dummyL2DepositTxHash;
+    address sharedBridgeAddress;
 
     constructor() {
         randomSigner = makeAddr("randomSigner");
-        dummyL2DepositTxHash = Utils.randomBytes32("dummyL2DepositTxHash");
         alice = makeAddr("alice");
 
-        dummySharedBridge = new DummySharedBridge(dummyL2DepositTxHash);
-        bridge = new L1ERC20Bridge(IL1SharedBridge(address(dummySharedBridge)));
+        sharedBridgeAddress = makeAddr("shared bridge");
+        bridge = new L1ERC20Bridge(IL1SharedBridge(sharedBridgeAddress));
 
         reenterL1ERC20Bridge = new ReenterL1ERC20Bridge();
         bridgeReenterItself = new L1ERC20Bridge(IL1SharedBridge(address(reenterL1ERC20Bridge)));


### PR DESCRIPTION
# What ❔

Increased coverage in bridgehub unit tests, add some cases for two bridges deposit.
Changed order of assert in Bridgehub contract.

## Why ❔

Previous tests had low coverage on branches, asserts and types of deposits, theirs permutations. 

## Checklist

- [x] overall tests to increase coverage
- [x] deposit eth using second bridge to non eth base chain
- [x] deposit nonbase  token using second bridge to some erc20 base chain
