### PR TITLE
feat(system-contracts): remove unecessary methods from L2BaseToken.sol

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -9,7 +9,7 @@
     "const-name-snakecase": "off",
     "contract-name-camelcase": "off",
     "gas-calldata-parameters": "error",
-    "gas-custom-errors": "error",
+    "gas-custom-errors": "warn",
     "gas-increment-by-one": "error",
     "gas-length-in-loops": "error",
     "gas-struct-packing": "error",

--- a/.solhint.json
+++ b/.solhint.json
@@ -9,7 +9,7 @@
     "const-name-snakecase": "off",
     "contract-name-camelcase": "off",
     "gas-calldata-parameters": "error",
-    "gas-custom-errors": "off",
+    "gas-custom-errors": "error",
     "gas-increment-by-one": "error",
     "gas-length-in-loops": "error",
     "gas-struct-packing": "error",

--- a/.solhint.json
+++ b/.solhint.json
@@ -9,7 +9,7 @@
     "const-name-snakecase": "off",
     "contract-name-camelcase": "off",
     "gas-calldata-parameters": "error",
-    "gas-custom-errors": "warn",
+    "gas-custom-errors": "off",
     "gas-increment-by-one": "error",
     "gas-length-in-loops": "error",
     "gas-struct-packing": "error",

--- a/system-contracts/SystemContractsHashes.json
+++ b/system-contracts/SystemContractsHashes.json
@@ -80,8 +80,8 @@
     "contractName": "L2BaseToken",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/L2BaseToken.sol/L2BaseToken.json",
     "sourceCodePath": "contracts-preprocessed/L2BaseToken.sol",
-    "bytecodeHash": "0x010000dbdb5905473134016b4d74cbe41ae3d8e298ebda1417332055396c6777",
-    "sourceCodeHash": "0x08db89769ec9ba099dca93b5d5118625d4da76fa4c1752c74c239d7549c6cf2e"
+    "bytecodeHash": "0x010000db7dbc0d4e3577a4866dd39d96d79f34070ee9c9aa1b3c182bc7204070",
+    "sourceCodeHash": "0xdea518b1ea16718b0f0ec6155b227a8bc8f51374a9eebf7bc17cfe84433df740"
   },
   {
     "contractName": "MsgValueSimulator",

--- a/system-contracts/SystemContractsHashes.json
+++ b/system-contracts/SystemContractsHashes.json
@@ -3,112 +3,112 @@
     "contractName": "AccountCodeStorage",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/AccountCodeStorage.sol/AccountCodeStorage.json",
     "sourceCodePath": "contracts-preprocessed/AccountCodeStorage.sol",
-    "bytecodeHash": "0x01000059ba97f0173b0942d393e8068e009d3f8d59ce7f94612cfe79aa1b4511",
+    "bytecodeHash": "0x01000059e8dff1f7b5f2d89b85e5dd0f8af0c6a6c40cf0e4e5dd525bb4576e77",
     "sourceCodeHash": "0x2e0e09d57a04bd1e722d8bf8c6423fdf3f8bca44e5e8c4f6684f987794be066e"
   },
   {
     "contractName": "BootloaderUtilities",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/BootloaderUtilities.sol/BootloaderUtilities.json",
     "sourceCodePath": "contracts-preprocessed/BootloaderUtilities.sol",
-    "bytecodeHash": "0x010006e941f9fc11b8db4b4b10a8dde913609f8664cd203abb94bc2744452d2b",
+    "bytecodeHash": "0x010006df421c055eac170f590f52ab7f43e22c513dd724b4b1c939f5842ccf02",
     "sourceCodeHash": "0x0f1213c4b95acb71f4ab5d4082cc1aeb2bd5017e1cccd46afc66e53268609d85"
   },
   {
     "contractName": "ComplexUpgrader",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/ComplexUpgrader.sol/ComplexUpgrader.json",
     "sourceCodePath": "contracts-preprocessed/ComplexUpgrader.sol",
-    "bytecodeHash": "0x01000047a6c56ceb0de1b1afef360c3fb70a63bd0f7228cdc8e22bdb08496935",
+    "bytecodeHash": "0x010000478fa72dac9eff50e0cce3b200f11a506d4649eb621b100b1d7afe5b9d",
     "sourceCodeHash": "0x796046a914fb676ba2bbd337b2924311ee2177ce54571c18a2c3945755c83614"
   },
   {
     "contractName": "Compressor",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/Compressor.sol/Compressor.json",
     "sourceCodePath": "contracts-preprocessed/Compressor.sol",
-    "bytecodeHash": "0x01000141a01e6a355f0e50a34891161528f8e99773bfd5153be3127e81d548eb",
+    "bytecodeHash": "0x0100013fe9cacee0324f0b7de2e94a65a4c87b782514723075d835687da36bd6",
     "sourceCodeHash": "0xc6f7cd8b21aae52ed3dd5083c09b438a7af142a4ecda6067c586770e8be745a5"
   },
   {
     "contractName": "ContractDeployer",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/ContractDeployer.sol/ContractDeployer.json",
     "sourceCodePath": "contracts-preprocessed/ContractDeployer.sol",
-    "bytecodeHash": "0x0100044fe2f7731a714ef6d7fdc56fd79f9e5060f1ae40c216c9f521d9f93a78",
+    "bytecodeHash": "0x0100042d3c6d16ebea6d0cb473965f18f45f09d0f71b15fada97e606eab65a06",
     "sourceCodeHash": "0x82f81fbf5fb007a9cac97462d50907ca5d7a1af62d82d2645e093ed8647a5209"
   },
   {
     "contractName": "Create2Factory",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/Create2Factory.sol/Create2Factory.json",
     "sourceCodePath": "contracts-preprocessed/Create2Factory.sol",
-    "bytecodeHash": "0x0100004fddab99843218be36079de485cb351449cef13f8e39c75b1ca72a5e5d",
+    "bytecodeHash": "0x0100003fed8b9742c17b0d2a287f4bc7d6e080fbad4236ab9ad52fdf4a8e892a",
     "sourceCodeHash": "0x114d9322a9ca654989f3e0b3b21f1311dbc4db84f443d054cd414f6414d84de3"
   },
   {
     "contractName": "DefaultAccount",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/DefaultAccount.sol/DefaultAccount.json",
     "sourceCodePath": "contracts-preprocessed/DefaultAccount.sol",
-    "bytecodeHash": "0x010004f167c45b6e81411a8e211c2f5c4473bae83fc1d0dda9144f3664d38c39",
+    "bytecodeHash": "0x010004db0973d6635333d6cd2132a2d99044c5e2077135e9e2a360620d3926e0",
     "sourceCodeHash": "0xebffe840ebbd9329edb1ebff8ca50f6935e7dabcc67194a896fcc2e968d46dfb"
   },
   {
     "contractName": "EmptyContract",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/EmptyContract.sol/EmptyContract.json",
     "sourceCodePath": "contracts-preprocessed/EmptyContract.sol",
-    "bytecodeHash": "0x0100000743ffcb544c82053c5d33a4bedff4f8cc71a9c4c322a1b7bd30167bb5",
+    "bytecodeHash": "0x01000007947dfd1aab45b52e5998b442bfbd4d565af494fb8082a810c6ed0b50",
     "sourceCodeHash": "0xcac36c5afafbcff83601f4fbfdff660aa66d8c80ed97b9322d3011c1926b554d"
   },
   {
     "contractName": "ImmutableSimulator",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/ImmutableSimulator.sol/ImmutableSimulator.json",
     "sourceCodePath": "contracts-preprocessed/ImmutableSimulator.sol",
-    "bytecodeHash": "0x01000033a7ecf34d087b9df93d49191a489c1d286b3d32bc789dd893e5d046fc",
+    "bytecodeHash": "0x010000336f093aca5141fd8924f3d15ed85c23c0e9c94850155d7d75787750a5",
     "sourceCodeHash": "0x9659e69f7db09e8f60a8bb95314b1ed26afcc689851665cf27f5408122f60c98"
   },
   {
     "contractName": "KnownCodesStorage",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/KnownCodesStorage.sol/KnownCodesStorage.json",
     "sourceCodePath": "contracts-preprocessed/KnownCodesStorage.sol",
-    "bytecodeHash": "0x01000069d61b1ddcde888e85fa8c1c3482cea49b791f23398b5a5c9744e85c72",
+    "bytecodeHash": "0x010000696c0f2f9698c9a8aca059305df822a62d2cdd58145c8b94381c262ddc",
     "sourceCodeHash": "0xb39b5b81168653e0c5062f7b8e1d6d15a4e186df3317f192f0cb2fc3a74f5448"
   },
   {
     "contractName": "L1Messenger",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/L1Messenger.sol/L1Messenger.json",
     "sourceCodePath": "contracts-preprocessed/L1Messenger.sol",
-    "bytecodeHash": "0x010002756785d06d4f5e36d9d0995481e4a5e3d0931272a37ff5dfca34d1d798",
+    "bytecodeHash": "0x01000261e4a17d750009866862df7d1f6400752ce204fc489cdefd95089efca2",
     "sourceCodeHash": "0xa8768fdaac6d8804782f14e2a51bbe2b6be31dee9103b6d02d149ea8dc46eb6a"
   },
   {
     "contractName": "L2BaseToken",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/L2BaseToken.sol/L2BaseToken.json",
     "sourceCodePath": "contracts-preprocessed/L2BaseToken.sol",
-    "bytecodeHash": "0x010000dbdbcf834f42eef13f9694d23b52e554d421d52692ab327fe5df851864",
+    "bytecodeHash": "0x010000dbdb5905473134016b4d74cbe41ae3d8e298ebda1417332055396c6777",
     "sourceCodeHash": "0x08db89769ec9ba099dca93b5d5118625d4da76fa4c1752c74c239d7549c6cf2e"
   },
   {
     "contractName": "MsgValueSimulator",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/MsgValueSimulator.sol/MsgValueSimulator.json",
     "sourceCodePath": "contracts-preprocessed/MsgValueSimulator.sol",
-    "bytecodeHash": "0x01000063a1b7a7d1c5fb131c7dfa1bfa67b2510637eecbe6e720d98500331e56",
+    "bytecodeHash": "0x010000590dbb07ab08067502a8668b91ca1d71cc79c66c571f3e8324d835b38b",
     "sourceCodeHash": "0x082f3dcbc2fe4d93706c86aae85faa683387097d1b676e7ebd00f71ee0f13b71"
   },
   {
     "contractName": "NonceHolder",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/NonceHolder.sol/NonceHolder.json",
     "sourceCodePath": "contracts-preprocessed/NonceHolder.sol",
-    "bytecodeHash": "0x010000d9bf1aaac6705e22d12e3d34120e2c21977f4e006846caa4fd84efe4a8",
+    "bytecodeHash": "0x010000cf4013a7b83219b99fc665d1f22b579ef2d36f3928d6ee06e1be0862e0",
     "sourceCodeHash": "0xcd0c0366effebf2c98c58cf96322cc242a2d1c675620ef5514b7ed1f0a869edc"
   },
   {
     "contractName": "PubdataChunkPublisher",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/PubdataChunkPublisher.sol/PubdataChunkPublisher.json",
     "sourceCodePath": "contracts-preprocessed/PubdataChunkPublisher.sol",
-    "bytecodeHash": "0x0100004156c259612f51ce25b2fc176ec5b850f7533f0773b4dd30b35c86b740",
+    "bytecodeHash": "0x01000041ac82adc2e9de2e330918e70ac94fdf151f173c7bfff59170d6b90812",
     "sourceCodeHash": "0xd7161e2c8092cf57b43c6220bc605c0e7e540bddcde1af24e2d90f75633b098e"
   },
   {
     "contractName": "SystemContext",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/SystemContext.sol/SystemContext.json",
     "sourceCodePath": "contracts-preprocessed/SystemContext.sol",
-    "bytecodeHash": "0x010001aba1c00077a3f59df8dd99556e5975a3569aab404ae0ceaa973b51b3ab",
+    "bytecodeHash": "0x010001a58ea92274152ff90546a630bd47ed923131fa1d3469bd12689009760d",
     "sourceCodeHash": "0xf308743981ef5cea2f7a3332b8e51695a5e47e811a63974437fc1cceee475e7a"
   },
   {

--- a/system-contracts/SystemContractsHashes.json
+++ b/system-contracts/SystemContractsHashes.json
@@ -3,112 +3,112 @@
     "contractName": "AccountCodeStorage",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/AccountCodeStorage.sol/AccountCodeStorage.json",
     "sourceCodePath": "contracts-preprocessed/AccountCodeStorage.sol",
-    "bytecodeHash": "0x01000059c988dac86a1fe9ff2d929f118eaf640d2c073a7e089f33cda3183784",
+    "bytecodeHash": "0x01000059ba97f0173b0942d393e8068e009d3f8d59ce7f94612cfe79aa1b4511",
     "sourceCodeHash": "0x2e0e09d57a04bd1e722d8bf8c6423fdf3f8bca44e5e8c4f6684f987794be066e"
   },
   {
     "contractName": "BootloaderUtilities",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/BootloaderUtilities.sol/BootloaderUtilities.json",
     "sourceCodePath": "contracts-preprocessed/BootloaderUtilities.sol",
-    "bytecodeHash": "0x010006dfcc723139e24b127181ad5cec6c4b57935c944548ad2e7b65505bdedd",
+    "bytecodeHash": "0x010006e941f9fc11b8db4b4b10a8dde913609f8664cd203abb94bc2744452d2b",
     "sourceCodeHash": "0x0f1213c4b95acb71f4ab5d4082cc1aeb2bd5017e1cccd46afc66e53268609d85"
   },
   {
     "contractName": "ComplexUpgrader",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/ComplexUpgrader.sol/ComplexUpgrader.json",
     "sourceCodePath": "contracts-preprocessed/ComplexUpgrader.sol",
-    "bytecodeHash": "0x01000047171b9f2496e91fedc2a691b926d67c664718e09e7741abb936356ce8",
+    "bytecodeHash": "0x01000047a6c56ceb0de1b1afef360c3fb70a63bd0f7228cdc8e22bdb08496935",
     "sourceCodeHash": "0x796046a914fb676ba2bbd337b2924311ee2177ce54571c18a2c3945755c83614"
   },
   {
     "contractName": "Compressor",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/Compressor.sol/Compressor.json",
     "sourceCodePath": "contracts-preprocessed/Compressor.sol",
-    "bytecodeHash": "0x0100013f5629aea4f024a0391184de582368e27eb00fd4e4f04d38285127e04f",
+    "bytecodeHash": "0x01000141a01e6a355f0e50a34891161528f8e99773bfd5153be3127e81d548eb",
     "sourceCodeHash": "0xc6f7cd8b21aae52ed3dd5083c09b438a7af142a4ecda6067c586770e8be745a5"
   },
   {
     "contractName": "ContractDeployer",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/ContractDeployer.sol/ContractDeployer.json",
     "sourceCodePath": "contracts-preprocessed/ContractDeployer.sol",
-    "bytecodeHash": "0x0100042db9e3c6a96189306802a818ad22ceac9beb9750d184a17be348efc5b9",
+    "bytecodeHash": "0x0100044fe2f7731a714ef6d7fdc56fd79f9e5060f1ae40c216c9f521d9f93a78",
     "sourceCodeHash": "0x82f81fbf5fb007a9cac97462d50907ca5d7a1af62d82d2645e093ed8647a5209"
   },
   {
     "contractName": "Create2Factory",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/Create2Factory.sol/Create2Factory.json",
     "sourceCodePath": "contracts-preprocessed/Create2Factory.sol",
-    "bytecodeHash": "0x0100003f67bf604cec81253c6d5876dfc05255da12ad83ee32f56a2e3233fb8f",
+    "bytecodeHash": "0x0100004fddab99843218be36079de485cb351449cef13f8e39c75b1ca72a5e5d",
     "sourceCodeHash": "0x114d9322a9ca654989f3e0b3b21f1311dbc4db84f443d054cd414f6414d84de3"
   },
   {
     "contractName": "DefaultAccount",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/DefaultAccount.sol/DefaultAccount.json",
     "sourceCodePath": "contracts-preprocessed/DefaultAccount.sol",
-    "bytecodeHash": "0x010004dbb7b5d17f1013d67de0409a8fa3bc84af9226b5c759b9a0a1d0a2e8dc",
+    "bytecodeHash": "0x010004f167c45b6e81411a8e211c2f5c4473bae83fc1d0dda9144f3664d38c39",
     "sourceCodeHash": "0xebffe840ebbd9329edb1ebff8ca50f6935e7dabcc67194a896fcc2e968d46dfb"
   },
   {
     "contractName": "EmptyContract",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/EmptyContract.sol/EmptyContract.json",
     "sourceCodePath": "contracts-preprocessed/EmptyContract.sol",
-    "bytecodeHash": "0x01000007947dfd1aab45b52e5998b442bfbd4d565af494fb8082a810c6ed0b50",
+    "bytecodeHash": "0x0100000743ffcb544c82053c5d33a4bedff4f8cc71a9c4c322a1b7bd30167bb5",
     "sourceCodeHash": "0xcac36c5afafbcff83601f4fbfdff660aa66d8c80ed97b9322d3011c1926b554d"
   },
   {
     "contractName": "ImmutableSimulator",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/ImmutableSimulator.sol/ImmutableSimulator.json",
     "sourceCodePath": "contracts-preprocessed/ImmutableSimulator.sol",
-    "bytecodeHash": "0x01000033962f4c689f265e804df8ae9ab06f1ab8d044e72385e41bcd411d04a2",
+    "bytecodeHash": "0x01000033a7ecf34d087b9df93d49191a489c1d286b3d32bc789dd893e5d046fc",
     "sourceCodeHash": "0x9659e69f7db09e8f60a8bb95314b1ed26afcc689851665cf27f5408122f60c98"
   },
   {
     "contractName": "KnownCodesStorage",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/KnownCodesStorage.sol/KnownCodesStorage.json",
     "sourceCodePath": "contracts-preprocessed/KnownCodesStorage.sol",
-    "bytecodeHash": "0x0100006916feb836433c433d6e82f97fb159fe1feb3dd2523de09b23a2335a79",
+    "bytecodeHash": "0x01000069d61b1ddcde888e85fa8c1c3482cea49b791f23398b5a5c9744e85c72",
     "sourceCodeHash": "0xb39b5b81168653e0c5062f7b8e1d6d15a4e186df3317f192f0cb2fc3a74f5448"
   },
   {
     "contractName": "L1Messenger",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/L1Messenger.sol/L1Messenger.json",
     "sourceCodePath": "contracts-preprocessed/L1Messenger.sol",
-    "bytecodeHash": "0x010002619d1a0168c99f201cac7ff8b787f1975e1dd6aaf6baba68aade3d3c52",
+    "bytecodeHash": "0x010002756785d06d4f5e36d9d0995481e4a5e3d0931272a37ff5dfca34d1d798",
     "sourceCodeHash": "0xa8768fdaac6d8804782f14e2a51bbe2b6be31dee9103b6d02d149ea8dc46eb6a"
   },
   {
     "contractName": "L2BaseToken",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/L2BaseToken.sol/L2BaseToken.json",
     "sourceCodePath": "contracts-preprocessed/L2BaseToken.sol",
-    "bytecodeHash": "0x010000f3b310a8c54b771dc7ee43e1f6da2efa3a2b470c511a3039c130cd63cb",
-    "sourceCodeHash": "0x8bdd2b4d0b53dba84c9f0af250bbaa2aad10b3de6747bba957f0bd3721090dfa"
+    "bytecodeHash": "0x010000dbdbcf834f42eef13f9694d23b52e554d421d52692ab327fe5df851864",
+    "sourceCodeHash": "0x08db89769ec9ba099dca93b5d5118625d4da76fa4c1752c74c239d7549c6cf2e"
   },
   {
     "contractName": "MsgValueSimulator",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/MsgValueSimulator.sol/MsgValueSimulator.json",
     "sourceCodePath": "contracts-preprocessed/MsgValueSimulator.sol",
-    "bytecodeHash": "0x0100005983e6e523fc73e5326d31e0e96fa440fec2818e923fe57a48688617aa",
+    "bytecodeHash": "0x01000063a1b7a7d1c5fb131c7dfa1bfa67b2510637eecbe6e720d98500331e56",
     "sourceCodeHash": "0x082f3dcbc2fe4d93706c86aae85faa683387097d1b676e7ebd00f71ee0f13b71"
   },
   {
     "contractName": "NonceHolder",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/NonceHolder.sol/NonceHolder.json",
     "sourceCodePath": "contracts-preprocessed/NonceHolder.sol",
-    "bytecodeHash": "0x010000cfd785169945521d4d3bece055ed7c88b79eabdc7bda73f62583bd844c",
+    "bytecodeHash": "0x010000d9bf1aaac6705e22d12e3d34120e2c21977f4e006846caa4fd84efe4a8",
     "sourceCodeHash": "0xcd0c0366effebf2c98c58cf96322cc242a2d1c675620ef5514b7ed1f0a869edc"
   },
   {
     "contractName": "PubdataChunkPublisher",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/PubdataChunkPublisher.sol/PubdataChunkPublisher.json",
     "sourceCodePath": "contracts-preprocessed/PubdataChunkPublisher.sol",
-    "bytecodeHash": "0x010000411cea63a93f499cb4b434c13c9c0300126fe1c2714e1755c10889072c",
+    "bytecodeHash": "0x0100004156c259612f51ce25b2fc176ec5b850f7533f0773b4dd30b35c86b740",
     "sourceCodeHash": "0xd7161e2c8092cf57b43c6220bc605c0e7e540bddcde1af24e2d90f75633b098e"
   },
   {
     "contractName": "SystemContext",
     "bytecodePath": "artifacts-zk/contracts-preprocessed/SystemContext.sol/SystemContext.json",
     "sourceCodePath": "contracts-preprocessed/SystemContext.sol",
-    "bytecodeHash": "0x010001a5d85e6baddaf82e2d7a43974ab3ad285facf4c3e28844adfc0125a0ce",
+    "bytecodeHash": "0x010001aba1c00077a3f59df8dd99556e5975a3569aab404ae0ceaa973b51b3ab",
     "sourceCodeHash": "0xf308743981ef5cea2f7a3332b8e51695a5e47e811a63974437fc1cceee475e7a"
   },
   {

--- a/system-contracts/contracts/L2BaseToken.sol
+++ b/system-contracts/contracts/L2BaseToken.sol
@@ -128,21 +128,4 @@ contract L2BaseToken is IBaseToken, SystemContractBase {
         return abi.encodePacked(IMailbox.finalizeEthWithdrawal.selector, _to, _amount, _sender, _additionalData);
     }
 
-    /// @dev This method has not been stabilized and might be
-    /// removed later on.
-    function name() external pure override returns (string memory) {
-        return "Ether";
-    }
-
-    /// @dev This method has not been stabilized and might be
-    /// removed later on.
-    function symbol() external pure override returns (string memory) {
-        return "ETH";
-    }
-
-    /// @dev This method has not been stabilized and might be
-    /// removed later on.
-    function decimals() external pure override returns (uint8) {
-        return 18;
-    }
 }

--- a/system-contracts/contracts/L2BaseToken.sol
+++ b/system-contracts/contracts/L2BaseToken.sol
@@ -127,5 +127,4 @@ contract L2BaseToken is IBaseToken, SystemContractBase {
         // solhint-disable-next-line func-named-parameters
         return abi.encodePacked(IMailbox.finalizeEthWithdrawal.selector, _to, _amount, _sender, _additionalData);
     }
-
 }

--- a/system-contracts/contracts/interfaces/IBaseToken.sol
+++ b/system-contracts/contracts/interfaces/IBaseToken.sol
@@ -9,12 +9,6 @@ interface IBaseToken {
 
     function totalSupply() external view returns (uint256);
 
-    function name() external pure returns (string memory);
-
-    function symbol() external pure returns (string memory);
-
-    function decimals() external pure returns (uint8);
-
     function mint(address _account, uint256 _amount) external;
 
     function withdraw(address _l1Receiver) external payable;

--- a/system-contracts/test/L2BaseToken.spec.ts
+++ b/system-contracts/test/L2BaseToken.spec.ts
@@ -146,27 +146,6 @@ describe("L2BaseToken tests", () => {
     });
   });
 
-  describe("name", () => {
-    it("correct name", async () => {
-      const name = await L2BaseToken.name();
-      expect(name).to.equal("Ether");
-    });
-  });
-
-  describe("symbol", () => {
-    it("correct symbol", async () => {
-      const symbol = await L2BaseToken.symbol();
-      expect(symbol).to.equal("ETH");
-    });
-  });
-
-  describe("decimals", () => {
-    it("correct decimals", async () => {
-      const decimals = await L2BaseToken.decimals();
-      expect(decimals).to.equal(18);
-    });
-  });
-
   describe("withdraw", () => {
     it("event, balance, totalsupply", async () => {
       const amountToWithdraw: BigNumber = ethers.utils.parseEther("1.0");


### PR DESCRIPTION
# What ❔

Remove Name, Symbol and Decimal from L2BaseToken.sol



## Why ❔

Multiple issues with those methods :

1- For hyperchains that does not use ETH as base token, the values returned by those methods are wrong so it should not be hardcoded. I couldnt find a good way to make them variable without heavy changes on the initialisation process

2- L2BaseToken IS not an ERC20 as it does not implement IERC20 interface (no approval or allowance) but it looks like it which confuse some explorers

One example is on https://era.zksync.network/

The value of ETH is counted twices as it is also recorded as an ERC20
https://era.zksync.network/address/0xd0c511bdbf219e3d5793e47b9ad559c9f69b3404

We should remove all confusion and make "symbol" and "name" agnostics as it is done on Ethereum

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
