### PR TITLE
Increase test coverage and exclude dummy contracts

### DIFF
--- a/.github/workflows/slither.yaml
+++ b/.github/workflows/slither.yaml
@@ -41,6 +41,7 @@ jobs:
           rm -rf ./l1-contracts/contracts/state-transition/TestnetVerifier.sol
           rm -rf ./l1-contracts/contracts/dev-contracts/test/VerifierTest.sol
           rm -rf ./l1-contracts/contracts/dev-contracts/test/VerifierRecursiveTest.sol
+          rm -rf ./l1-contracts/contracts/dev-contracts/test/DummyTestnetVerifier.sol
 
       - name: Run Slither
         run: |

--- a/l1-contracts/contracts/dev-contracts/DummyL1ERC20Bridge.sol
+++ b/l1-contracts/contracts/dev-contracts/DummyL1ERC20Bridge.sol
@@ -6,6 +6,9 @@ import {L1ERC20Bridge} from "../bridge/L1ERC20Bridge.sol";
 import {IL1SharedBridge} from "../bridge/interfaces/IL1SharedBridge.sol";
 
 contract DummyL1ERC20Bridge is L1ERC20Bridge {
+    // add this to be excluded from coverage report
+    function test() internal virtual {}
+
     constructor(IL1SharedBridge _l1SharedBridge) L1ERC20Bridge(_l1SharedBridge) {}
 
     function setValues(address _l2Bridge, address _l2TokenBeacon, bytes32 _l2TokenProxyBytecodeHash) external {

--- a/l1-contracts/contracts/dev-contracts/test/AddressAliasHelperTest.sol
+++ b/l1-contracts/contracts/dev-contracts/test/AddressAliasHelperTest.sol
@@ -5,6 +5,9 @@ pragma solidity 0.8.24;
 import {AddressAliasHelper} from "../../vendor/AddressAliasHelper.sol";
 
 contract AddressAliasHelperTest {
+    // add this to be excluded from coverage report
+    function test() internal virtual {}
+
     function applyL1ToL2Alias(address _l1Address) external pure returns (address) {
         return AddressAliasHelper.applyL1ToL2Alias(_l1Address);
     }

--- a/l1-contracts/contracts/dev-contracts/test/DiamondCutTestContract.sol
+++ b/l1-contracts/contracts/dev-contracts/test/DiamondCutTestContract.sol
@@ -6,6 +6,9 @@ import {Diamond} from "../../state-transition/libraries/Diamond.sol";
 import {GettersFacet} from "../../state-transition/chain-deps/facets/Getters.sol";
 
 contract DiamondCutTestContract is GettersFacet {
+    // add this to be excluded from coverage report
+    function test() internal virtual {}
+
     function diamondCut(Diamond.DiamondCutData memory _diamondCut) external {
         Diamond.diamondCut(_diamondCut);
     }

--- a/l1-contracts/contracts/dev-contracts/test/DummyHyperchain.sol
+++ b/l1-contracts/contracts/dev-contracts/test/DummyHyperchain.sol
@@ -5,6 +5,9 @@ import {MailboxFacet} from "../../state-transition/chain-deps/facets/Mailbox.sol
 import {FeeParams, PubdataPricingMode} from "../../state-transition/chain-deps/ZkSyncHyperchainStorage.sol";
 
 contract DummyHyperchain is MailboxFacet {
+    // add this to be excluded from coverage report
+    function test() internal virtual {}
+
     constructor(address bridgeHubAddress, uint256 _eraChainId) MailboxFacet(_eraChainId) {
         s.bridgehub = bridgeHubAddress;
     }

--- a/l1-contracts/contracts/dev-contracts/test/DummySharedBridge.sol
+++ b/l1-contracts/contracts/dev-contracts/test/DummySharedBridge.sol
@@ -13,6 +13,9 @@ import {IL2Bridge} from "../../bridge/interfaces/IL2Bridge.sol";
 contract DummySharedBridge is PausableUpgradeable {
     using SafeERC20 for IERC20;
 
+    // add this to be excluded from coverage report
+    function test() internal virtual {}
+
     event BridgehubDepositBaseTokenInitiated(
         uint256 indexed chainId,
         address indexed from,

--- a/l1-contracts/contracts/dev-contracts/test/DummyStateTransitionManagerWithBridgeHubAddress.sol
+++ b/l1-contracts/contracts/dev-contracts/test/DummyStateTransitionManagerWithBridgeHubAddress.sol
@@ -10,6 +10,8 @@ import {StateTransitionManager} from "../../state-transition/StateTransitionMana
 /// @notice A test smart contract implementing the IExecutor interface to simulate Executor behavior for testing purposes.
 contract DummyStateTransitionManagerWBH is StateTransitionManager {
     using EnumerableMap for EnumerableMap.UintToAddressMap;
+    // add this to be excluded from coverage report
+    function test() internal virtual {}
 
     /// @notice Constructor
     constructor(address bridgeHub) StateTransitionManager(bridgeHub, type(uint256).max) {}

--- a/l1-contracts/contracts/dev-contracts/test/DummyTestnetVerifier.sol
+++ b/l1-contracts/contracts/dev-contracts/test/DummyTestnetVerifier.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.24;
 
 import {TestnetVerifier} from "../../state-transition/TestnetVerifier.sol";
 
-/// @author Matter Labs
 contract DummyTestnetVerifier is TestnetVerifier {
     // add this to be excluded from coverage report
     function test() internal virtual {}

--- a/l1-contracts/contracts/dev-contracts/test/DummyTestnetVerifier.sol
+++ b/l1-contracts/contracts/dev-contracts/test/DummyTestnetVerifier.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+import {TestnetVerifier} from "../../state-transition/TestnetVerifier.sol";
+
+/// @author Matter Labs
+contract DummyTestnetVerifier is TestnetVerifier {
+    // add this to be excluded from coverage report
+    function test() internal virtual {}
+
+    function _loadVerificationKey() internal pure override {
+        assembly {
+            // gate setup commitments
+            mstore(VK_GATE_SETUP_0_X_SLOT, 0x046e45fd137982bd0f6cf731b4650d2d520e8d675827744e1edf1308583599bb)
+            mstore(VK_GATE_SETUP_0_Y_SLOT, 0x177f14d16b716d4298be5e07b83add3fb61ff1ee08dce19f9a54fa8f04937f7e)
+            mstore(VK_GATE_SETUP_1_X_SLOT, 0x169ad5156d25b56f7b67ea6382f88b845ed5bae5b91aacfe51d8f0716afff2fb)
+            mstore(VK_GATE_SETUP_1_Y_SLOT, 0x2406e3268e4d5fa672142998ecf834034638a4a6f8b5e90205552c6aa1dde163)
+            mstore(VK_GATE_SETUP_2_X_SLOT, 0x05fd0ce0fdc590938d29c738c8dc956b32ca8e69c3babfbb49dc1c13a6d9a8d4)
+            mstore(VK_GATE_SETUP_2_Y_SLOT, 0x0a27dac323a04dd319d9805be879875c95063d0a55c96214cd45c913fba84460)
+            mstore(VK_GATE_SETUP_3_X_SLOT, 0x0d58a2a86b208a4976beb9bfd918514d448656e0ee66175eb344a4a17bba99f8)
+            mstore(VK_GATE_SETUP_3_Y_SLOT, 0x215fa609a1a425b84c9dc218c6cf999596d9eba6d35597ad7aaf2d077a6616ed)
+            mstore(VK_GATE_SETUP_4_X_SLOT, 0x1a26e6deccf91174ab13613363eb4939680828f0c6031f5039f9e6f264afa68c)
+            mstore(VK_GATE_SETUP_4_Y_SLOT, 0x1f5b2d6bffac1839edfd02cd0e41acc411f0ecbf6c5c4b1da0e12b68b99cb25d)
+            mstore(VK_GATE_SETUP_5_X_SLOT, 0x09b71be2e8a45dcbe7654cf369c4f1f2e7eab4b97869a469fb7a149d989f7226)
+            mstore(VK_GATE_SETUP_5_Y_SLOT, 0x197e1e2cefbd4f99558b89ca875e01fec0f14f05e5128bd869c87d6bf2f307fa)
+            mstore(VK_GATE_SETUP_6_X_SLOT, 0x0d7cef745da686fd44760403d452d72be504bb41b0a7f4fbe973a07558893871)
+            mstore(VK_GATE_SETUP_6_Y_SLOT, 0x1e9a863307cdfd3fdcf119f72279ddfda08b6f23c3672e8378dbb9d548734c29)
+            mstore(VK_GATE_SETUP_7_X_SLOT, 0x16af3f5d978446fdb37d84f5cf12e59f5c1088bde23f8260c0bb6792c5f78e99)
+            mstore(VK_GATE_SETUP_7_Y_SLOT, 0x167d3aeee50c0e53fd1e8a33941a806a34cfae5dc8b66578486e5d7207b5d546)
+
+            // gate selectors commitments
+            mstore(VK_GATE_SELECTORS_0_X_SLOT, 0x1addc8e154c74bed403dc19558096ce22f1ceb2c656a2a5e85e56d2be6580ed1)
+            mstore(VK_GATE_SELECTORS_0_Y_SLOT, 0x1420d38f0ef206828efc36d0f5ad2b4d85fe768097f358fc671b7b3ec0239234)
+            mstore(VK_GATE_SELECTORS_1_X_SLOT, 0x2d5c06d0c8aa6a3520b8351f82341affcbb1a0bf27bceb9bab175e3e1d38cf47)
+            mstore(VK_GATE_SELECTORS_1_Y_SLOT, 0x0ff8d923a0374308147f6dd4fc513f6d0640f5df699f4836825ef460df3f8d6a)
+
+            // permutation commitments
+            mstore(VK_PERMUTATION_0_X_SLOT, 0x1de8943a8f67d9f6fcbda10a1f37a82de9e9ffd0a0102ea5ce0ce6dd13b4031b)
+            mstore(VK_PERMUTATION_0_Y_SLOT, 0x1e04b0824853ab5d7c3412a217a1c5b88a2b4011be7e7e849485be8ed7332e41)
+            mstore(VK_PERMUTATION_1_X_SLOT, 0x2aa1817b9cc40b6cc7a7b3f832f3267580f9fb8e539666c00541e1a77e34a3da)
+            mstore(VK_PERMUTATION_1_Y_SLOT, 0x0edb3cde226205b01212fc1861303c49ef3ff66f060b5833dc9a3f661ef31dd9)
+            mstore(VK_PERMUTATION_2_X_SLOT, 0x13f5ae93c8eccc1455a0095302923442d4b0b3c8233d66ded99ffcf2ad641c27)
+            mstore(VK_PERMUTATION_2_Y_SLOT, 0x2dd42d42ccdea8b1901435ace12bc9e52c7dbbeb409d20c517ba942ed0cc7519)
+            mstore(VK_PERMUTATION_3_X_SLOT, 0x1a15a70a016be11af71e46e9c8a8d31ece32a7e657ae90356dd9535e6566645f)
+            mstore(VK_PERMUTATION_3_Y_SLOT, 0x0381d23e115521c6fc233c5346f79a6777bfa8871b7ee623d990cdcb5d8c3ce1)
+
+            // lookup tables commitments
+            mstore(VK_LOOKUP_TABLE_0_X_SLOT, 0x2c513ed74d9d57a5ec901e074032741036353a2c4513422e96e7b53b302d765b)
+            mstore(VK_LOOKUP_TABLE_0_Y_SLOT, 0x04dd964427e430f16004076d708c0cb21e225056cc1d57418cfbd3d472981468)
+            mstore(VK_LOOKUP_TABLE_1_X_SLOT, 0x1ea83e5e65c6f8068f4677e2911678cf329b28259642a32db1f14b8347828aac)
+            mstore(VK_LOOKUP_TABLE_1_Y_SLOT, 0x1d22bc884a2da4962a893ba8de13f57aaeb785ed52c5e686994839cab8f7475d)
+            mstore(VK_LOOKUP_TABLE_2_X_SLOT, 0x0b2e7212d0d9cff26d0bdf3d79b2cac029a25dfeb1cafdf49e2349d7db348d89)
+            mstore(VK_LOOKUP_TABLE_2_Y_SLOT, 0x1301f9b252419ea240eb67fda720ca0b16d92364027285f95e9b1349490fa283)
+            mstore(VK_LOOKUP_TABLE_3_X_SLOT, 0x02f7b99fdfa5b418548c2d777785820e02383cfc87e7085e280a375a358153bf)
+            mstore(VK_LOOKUP_TABLE_3_Y_SLOT, 0x09d004fe08dc4d19c382df36fad22ef676185663543703e6a4b40203e50fd8a6)
+
+            // lookup selector commitment
+            mstore(VK_LOOKUP_SELECTOR_X_SLOT, 0x1641f5d312e6f62720b1e6cd1d1be5bc0e69d10d20a12dc97ff04e2107e10ccc)
+            mstore(VK_LOOKUP_SELECTOR_Y_SLOT, 0x277f435d376acc3261ef9d5748e6705086214daf46d04edc80fbd657f8d9e73d)
+
+            // table type commitment
+            mstore(VK_LOOKUP_TABLE_TYPE_X_SLOT, 0x1b5f1cfddd6713cf25d9e6850a1b3fe80d6ef7fe2c67248f25362d5f9b31893c)
+            mstore(VK_LOOKUP_TABLE_TYPE_Y_SLOT, 0x0945076de03a0d240067e5f02b8fc11eaa589df3343542576eb59fdb3ecb57e0)
+
+            // flag for using recursive part
+            mstore(VK_RECURSIVE_FLAG_SLOT, 0)
+        }
+    }
+}

--- a/l1-contracts/contracts/dev-contracts/test/ExecutorProvingTest.sol
+++ b/l1-contracts/contracts/dev-contracts/test/ExecutorProvingTest.sol
@@ -8,6 +8,9 @@ import {LogProcessingOutput} from "../../state-transition/chain-interfaces/IExec
 import {LogProcessingOutput} from "../../state-transition/chain-interfaces/IExecutor.sol";
 
 contract ExecutorProvingTest is ExecutorFacet {
+    // add this to be excluded from coverage report
+    function test() internal virtual {}
+
     function getBatchProofPublicInput(
         bytes32 _prevBatchCommitment,
         bytes32 _currentBatchCommitment

--- a/l1-contracts/contracts/dev-contracts/test/MerkleTest.sol
+++ b/l1-contracts/contracts/dev-contracts/test/MerkleTest.sol
@@ -5,6 +5,9 @@ pragma solidity 0.8.24;
 import {Merkle} from "../../state-transition/libraries/Merkle.sol";
 
 contract MerkleTest {
+    // add this to be excluded from coverage report
+    function test() internal virtual {}
+
     function calculateRoot(
         bytes32[] calldata _path,
         uint256 _index,

--- a/l1-contracts/contracts/dev-contracts/test/PriorityQueueTest.sol
+++ b/l1-contracts/contracts/dev-contracts/test/PriorityQueueTest.sol
@@ -5,6 +5,9 @@ pragma solidity 0.8.24;
 import {PriorityQueue, PriorityOperation} from "../../state-transition/libraries/PriorityQueue.sol";
 
 contract PriorityQueueTest {
+    // add this to be excluded from coverage report
+    function test() internal virtual {}
+
     PriorityQueue.Queue priorityQueue;
 
     function getFirstUnprocessedPriorityTx() external view returns (uint256) {

--- a/l1-contracts/contracts/dev-contracts/test/TestExecutor.sol
+++ b/l1-contracts/contracts/dev-contracts/test/TestExecutor.sol
@@ -5,6 +5,9 @@ import {ExecutorFacet} from "../../state-transition/chain-deps/facets/Executor.s
 pragma solidity 0.8.24;
 
 contract TestExecutor is ExecutorFacet {
+    // add this to be excluded from coverage report
+    function test() internal virtual {}
+
     /// @dev Since we want to test the blob functionality we want mock the calls to the blobhash opcode.
     function _getBlobVersionedHash(uint256 _index) internal view virtual override returns (bytes32 versionedHash) {
         (bool success, bytes memory data) = s.blobVersionedHashRetriever.staticcall(abi.encode(_index));

--- a/l1-contracts/contracts/dev-contracts/test/UncheckedMathTest.sol
+++ b/l1-contracts/contracts/dev-contracts/test/UncheckedMathTest.sol
@@ -5,6 +5,9 @@ pragma solidity 0.8.24;
 import {UncheckedMath} from "../../common/libraries/UncheckedMath.sol";
 
 contract UncheckedMathTest {
+    // add this to be excluded from coverage report
+    function test() internal virtual {}
+
     function uncheckedInc(uint256 _number) external pure returns (uint256) {
         return UncheckedMath.uncheckedInc(_number);
     }

--- a/l1-contracts/test/foundry/unit/concrete/Bridges/L1Erc20Bridge/Deposit.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Bridges/L1Erc20Bridge/Deposit.t.sol
@@ -56,7 +56,8 @@ contract DepositTest is L1Erc20BridgeTest {
             _l1Token: makeAddr("EOA"),
             _amount: 1,
             _l2TxGasLimit: 0,
-            _l2TxGasPerPubdataByte: 0
+            _l2TxGasPerPubdataByte: 0,
+            _refundRecipient: address(0)
         });
     }
 
@@ -78,7 +79,8 @@ contract DepositTest is L1Erc20BridgeTest {
             _l1Token: address(token),
             _amount: 1,
             _l2TxGasLimit: 0,
-            _l2TxGasPerPubdataByte: 0
+            _l2TxGasPerPubdataByte: 0,
+            _refundRecipient: address(0)
         });
     }
 
@@ -108,7 +110,8 @@ contract DepositTest is L1Erc20BridgeTest {
             _l1Token: address(feeOnTransferToken),
             _amount: amount,
             _l2TxGasLimit: 0,
-            _l2TxGasPerPubdataByte: 0
+            _l2TxGasPerPubdataByte: 0,
+            _refundRecipient: address(0)
         });
     }
 

--- a/l1-contracts/test/foundry/unit/concrete/Bridges/L1Erc20Bridge/TransferTokenToSharedBridge.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Bridges/L1Erc20Bridge/TransferTokenToSharedBridge.t.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+import {L1Erc20BridgeTest} from "./_L1Erc20Bridge_Shared.t.sol";
+
+contract TransferTokenToSharedBridgeTest is L1Erc20BridgeTest {
+    function test_RevertWhen_SharedBridgeIsNotSender() public {
+        address randomSigner = makeAddr("randomSigner");
+
+        vm.prank(randomSigner);
+        vm.expectRevert(bytes("Not shared bridge"));
+        bridge.transferTokenToSharedBridge(address(token));
+    }
+
+    function test_SuccessfullyTransferTokenToSharedBridge() public {
+        token.mint(address(bridge), 1 ether);
+
+        assertEq(token.balanceOf(address(dummySharedBridge)), 0);
+        assertEq(token.balanceOf(address(bridge)), 1 ether);
+
+        vm.prank(address(dummySharedBridge));
+        bridge.transferTokenToSharedBridge(address(token));
+
+        assertEq(token.balanceOf(address(dummySharedBridge)), 1 ether);
+        assertEq(token.balanceOf(address(bridge)), 0);
+    }
+}

--- a/l1-contracts/test/foundry/unit/concrete/Bridges/L1Erc20Bridge/TransferTokenToSharedBridge.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Bridges/L1Erc20Bridge/TransferTokenToSharedBridge.t.sol
@@ -3,26 +3,27 @@
 pragma solidity 0.8.24;
 
 import {L1Erc20BridgeTest} from "./_L1Erc20Bridge_Shared.t.sol";
+import {Unauthorized} from "contracts/common/L1ContractErrors.sol";
 
 contract TransferTokenToSharedBridgeTest is L1Erc20BridgeTest {
     function test_RevertWhen_SharedBridgeIsNotSender() public {
         address randomSigner = makeAddr("randomSigner");
 
         vm.prank(randomSigner);
-        vm.expectRevert(bytes("Not shared bridge"));
+        vm.expectRevert(abi.encodeWithSelector(Unauthorized.selector, randomSigner));
         bridge.transferTokenToSharedBridge(address(token));
     }
 
     function test_SuccessfullyTransferTokenToSharedBridge() public {
         token.mint(address(bridge), 1 ether);
 
-        assertEq(token.balanceOf(address(dummySharedBridge)), 0);
+        assertEq(token.balanceOf(sharedBridgeAddress), 0);
         assertEq(token.balanceOf(address(bridge)), 1 ether);
 
-        vm.prank(address(dummySharedBridge));
+        vm.prank(sharedBridgeAddress);
         bridge.transferTokenToSharedBridge(address(token));
 
-        assertEq(token.balanceOf(address(dummySharedBridge)), 1 ether);
+        assertEq(token.balanceOf(sharedBridgeAddress), 1 ether);
         assertEq(token.balanceOf(address(bridge)), 0);
     }
 }

--- a/l1-contracts/test/foundry/unit/concrete/Bridges/L1Erc20Bridge/_L1Erc20Bridge_Shared.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Bridges/L1Erc20Bridge/_L1Erc20Bridge_Shared.t.sol
@@ -36,8 +36,8 @@ contract L1Erc20BridgeTest is Test {
 
         token = new TestnetERC20Token("TestnetERC20Token", "TET", 18);
         feeOnTransferToken = new FeeOnTransferToken("FeeOnTransferToken", "FOT", 18);
-        token.mint(alice, type(uint256).max);
-        feeOnTransferToken.mint(alice, type(uint256).max);
+        token.mint(alice, 10 ether);
+        feeOnTransferToken.mint(alice, 10 ether);
     }
 
     // add this to be excluded from coverage report

--- a/l1-contracts/test/foundry/unit/concrete/Bridges/L1SharedBridge/_L1SharedBridge_Shared.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Bridges/L1SharedBridge/_L1SharedBridge_Shared.t.sol
@@ -160,4 +160,7 @@ contract L1SharedBridgeTest is Test {
             .with_key(_token)
             .checked_write(_value);
     }
+
+    // add this to be excluded from coverage report
+    function test() internal virtual {}
 }

--- a/l1-contracts/test/foundry/unit/concrete/DiamondCut/FacetCut.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/DiamondCut/FacetCut.t.sol
@@ -9,7 +9,7 @@ import {ExecutorFacet} from "contracts/state-transition/chain-deps/facets/Execut
 import {GettersFacet} from "contracts/state-transition/chain-deps/facets/Getters.sol";
 import {MailboxFacet} from "contracts/state-transition/chain-deps/facets/Mailbox.sol";
 import {Diamond} from "contracts/state-transition/libraries/Diamond.sol";
-import {ReplaceFunctionFacetAddressZero, RemoveFunctionFacetAddressNotZero, FacetExists, SelectorsMustAllHaveSameFreezability, AddressHasNoCode, NonZeroAddress, ZeroAddress} from "contracts/common/L1ContractErrors.sol";
+import {ReplaceFunctionFacetAddressZero, RemoveFunctionFacetAddressNotZero, FacetExists, SelectorsMustAllHaveSameFreezability, AddressHasNoCode, NonZeroAddress, RemoveFunctionFacetAddressZero, ZeroAddress, NoFunctionsForDiamondCut} from "contracts/common/L1ContractErrors.sol";
 
 contract FacetCutTest is DiamondCutTest {
     MailboxFacet private mailboxFacet;
@@ -87,7 +87,7 @@ contract FacetCutTest is DiamondCutTest {
             initCalldata: bytes("")
         });
 
-        vm.expectRevert(abi.encodePacked("B"));
+        vm.expectRevert(NoFunctionsForDiamondCut.selector);
         diamondCutTestContract.diamondCut(diamondCutData);
     }
 
@@ -186,7 +186,7 @@ contract FacetCutTest is DiamondCutTest {
             initCalldata: bytes("")
         });
 
-        vm.expectRevert(abi.encodePacked("a2"));
+        vm.expectRevert(RemoveFunctionFacetAddressZero.selector);
         diamondCutTestContract.diamondCut(diamondCutData);
     }
 

--- a/l1-contracts/test/foundry/unit/concrete/DiamondCut/FacetCut.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/DiamondCut/FacetCut.t.sol
@@ -72,6 +72,25 @@ contract FacetCutTest is DiamondCutTest {
         assertEq(numOfFacetsBefore + facetCuts.length, numOfFacetsAfter, "wrong number of facets added");
     }
 
+    function test_revertWhen_NoFunctionsForDiamondCut() public {
+        Diamond.FacetCut[] memory facetCuts = new Diamond.FacetCut[](1);
+        facetCuts[0] = Diamond.FacetCut({
+            facet: address(0),
+            action: Diamond.Action.Add,
+            isFreezable: false,
+            selectors: new bytes4[](0)
+        });
+
+        Diamond.DiamondCutData memory diamondCutData = Diamond.DiamondCutData({
+            facetCuts: facetCuts,
+            initAddress: address(0),
+            initCalldata: bytes("")
+        });
+
+        vm.expectRevert(abi.encodePacked("B"));
+        diamondCutTestContract.diamondCut(diamondCutData);
+    }
+
     function test_RevertWhen_AddingFacetToOccupiedSelector() public {
         Diamond.FacetCut[] memory facetCuts = new Diamond.FacetCut[](1);
         facetCuts[0] = Diamond.FacetCut({
@@ -149,6 +168,25 @@ contract FacetCutTest is DiamondCutTest {
         });
 
         vm.expectRevert(abi.encodeWithSelector(RemoveFunctionFacetAddressNotZero.selector, address(mailboxFacet)));
+        diamondCutTestContract.diamondCut(diamondCutData);
+    }
+
+    function test_RevertWhen_RemovingFacetWithOldFacetAddressAsZero() public {
+        Diamond.FacetCut[] memory facetCuts = new Diamond.FacetCut[](1);
+        facetCuts[0] = Diamond.FacetCut({
+            facet: address(0),
+            action: Diamond.Action.Remove,
+            isFreezable: false,
+            selectors: Utils.getMailboxSelectors()
+        });
+
+        Diamond.DiamondCutData memory diamondCutData = Diamond.DiamondCutData({
+            facetCuts: facetCuts,
+            initAddress: address(0),
+            initCalldata: bytes("")
+        });
+
+        vm.expectRevert(abi.encodePacked("a2"));
         diamondCutTestContract.diamondCut(diamondCutData);
     }
 

--- a/l1-contracts/test/foundry/unit/concrete/DiamondCut/Initialization.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/DiamondCut/Initialization.t.sol
@@ -7,6 +7,8 @@ import {ReturnSomething} from "contracts/dev-contracts/ReturnSomething.sol";
 import {DiamondCutTestContract} from "contracts/dev-contracts/test/DiamondCutTestContract.sol";
 import {Diamond} from "contracts/state-transition/libraries/Diamond.sol";
 import {DelegateCallFailed, BadReturnData, MalformedCalldata, NonEmptyCalldata} from "contracts/common/L1ContractErrors.sol";
+import {Utils} from "../Utils/Utils.sol";
+import {DiamondInit} from "contracts/state-transition/chain-deps/DiamondInit.sol";
 
 contract InitializationTest is DiamondCutTest {
     address private revertFallbackAddress;
@@ -30,6 +32,24 @@ contract InitializationTest is DiamondCutTest {
         });
         bytes memory emptyBytes;
         vm.expectRevert(abi.encodeWithSelector(DelegateCallFailed.selector, emptyBytes));
+        diamondCutTestContract.diamondCut(diamondCutData);
+    }
+
+    function test_RevertWhen_DelegateCallWithWrongInitializeData() public {
+        DiamondInit diamondInit = new DiamondInit();
+        bytes memory diamondInitData = abi.encodeWithSelector(
+            diamondInit.initialize.selector,
+            Utils.makeInitializeData(address(0))
+        );
+        Diamond.FacetCut[] memory facetCuts = new Diamond.FacetCut[](0);
+
+        Diamond.DiamondCutData memory diamondCutData = Diamond.DiamondCutData({
+            facetCuts: facetCuts,
+            initAddress: address(diamondInit),
+            initCalldata: diamondInitData
+        });
+
+        vm.expectRevert();
         diamondCutTestContract.diamondCut(diamondCutData);
     }
 

--- a/l1-contracts/test/foundry/unit/concrete/ValidatorTimelock/ValidatorTimelock.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/ValidatorTimelock/ValidatorTimelock.t.sol
@@ -55,6 +55,13 @@ contract ValidatorTimelockTest is Test {
         validator.addValidator(eraChainId, dan);
     }
 
+    function test_SuccessfulConstruction() public {
+        ValidatorTimelock validator = new ValidatorTimelock(owner, executionDelay, eraChainId);
+
+        assertEq(validator.owner(), owner);
+        assertEq(validator.executionDelay(), executionDelay);
+    }
+
     function test_addValidator() public {
         assert(validator.validators(chainId, bob) == false);
 

--- a/l1-contracts/test/foundry/unit/concrete/Verifier/TestnetVerifier.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/Verifier/TestnetVerifier.t.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {VerifierTestTest} from "./Verifier.t.sol";
+import {DummyTestnetVerifier} from "contracts/dev-contracts/test/DummyTestnetVerifier.sol";
+
+contract TestnetVerifierTest is VerifierTestTest {
+    DummyTestnetVerifier testnetVerifier;
+
+    function setUp() public override {
+        super.setUp();
+
+        testnetVerifier = new DummyTestnetVerifier();
+    }
+
+    function test_revertWhen_blockChainIdIsOne() public {
+        vm.chainId(1);
+
+        vm.expectRevert();
+        new DummyTestnetVerifier();
+    }
+
+    function test_SucceedsWhen_proofIsEmpty() public {
+        uint256[] memory publicInputs = new uint256[](1);
+        uint256[] memory proof = new uint256[](0);
+        uint256[] memory recursiveAggregationInput = new uint256[](0);
+
+        bool result = testnetVerifier.verify(publicInputs, proof, recursiveAggregationInput);
+
+        assertTrue(result);
+    }
+
+    function test_SuccessfullyVerifiesProofIfIsNotEmpty() public {
+        bool result = testnetVerifier.verify(publicInputs, serializedProof, recursiveAggregationInput);
+
+        assertTrue(result);
+    }
+}

--- a/l1-contracts/test/foundry/unit/concrete/common/libraries/L2ContractHelper/L2ContractHelper.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/common/libraries/L2ContractHelper/L2ContractHelper.t.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {L2ContractHelper} from "contracts/common/libraries/L2ContractHelper.sol";
+
+contract L2ContractHelperTest is Test {
+    address daiOnEthereum = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+    address daiOnEra = 0x4B9eb6c0b6ea15176BBF62841C6B2A8a398cb656;
+
+    address l2Bridge = 0x11f943b2c77b743AB90f4A0Ae7d5A4e7FCA3E102;
+    address l2TokenBeacon = 0x1Eb710030273e529A6aD7E1e14D4e601765Ba3c6;
+    bytes32 l2TokenProxyBytecodeHash = 0x01000121a363b3fbec270986067c1b553bf540c30a6f186f45313133ff1a1019;
+
+    // Bytecode must be provided in 32-byte words
+    function test_RevertWhen_BytecodeLengthIsNotMultipleOf32() public {
+        bytes memory bytecode = new bytes(63);
+
+        vm.expectRevert(bytes("pq"));
+        bytes32 hash = L2ContractHelper.hashL2Bytecode(bytecode);
+    }
+
+    // Bytecode length must be less than 2^16 words
+    function test_RevertWhen_BytecodeLengthIsTooLarge() public {
+        bytes memory bytecode = new bytes(2 ** 16 * 32);
+
+        vm.expectRevert(bytes("pp"));
+        bytes32 hash = L2ContractHelper.hashL2Bytecode(bytecode);
+    }
+
+    // Bytecode length in words must be odd
+    function test_RevertWhen_BytecodeLengthIsNotOdd() public {
+        bytes memory bytecode = new bytes(64);
+
+        vm.expectRevert(bytes("ps"));
+        bytes32 hash = L2ContractHelper.hashL2Bytecode(bytecode);
+    }
+
+    function test_SuccessfulHashing() public {
+        bytes memory bytecode = new bytes(32);
+        bytes32 hash = L2ContractHelper.hashL2Bytecode(bytecode);
+
+        assertEq(hash, bytes32(0x01000001f862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925));
+    }
+
+    // Incorrectly formatted bytecodeHash
+    function test_RevertWhen_BytecodeHashVersionIsNotOne() public {
+        bytes32 bytecodeHash = bytes32(0x02000001f862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+
+        vm.expectRevert(bytes("zf"));
+        L2ContractHelper.validateBytecodeHash(bytecodeHash);
+    }
+
+    // Code length in words must be odd
+    function test_RevertWhen_CodeLengthInWordsIsNotOdd() public {
+        bytes32 bytecodeHash = bytes32(0x01000002f862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+
+        vm.expectRevert(bytes("uy"));
+        L2ContractHelper.validateBytecodeHash(bytecodeHash);
+    }
+
+    function test_SuccessfulValidation() public {
+        bytes32 bytecodeHash = bytes32(0x01000001f862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
+
+        L2ContractHelper.validateBytecodeHash(bytecodeHash);
+    }
+
+    // computeCreate2Address
+    function test_ComputeCreate2Address() public {
+        bytes32 constructorInputHash = keccak256(abi.encode(l2TokenBeacon, ""));
+        bytes32 salt = bytes32(uint256(uint160(daiOnEthereum)));
+
+        address computedAddress = L2ContractHelper.computeCreate2Address(
+            l2Bridge,
+            salt,
+            l2TokenProxyBytecodeHash,
+            constructorInputHash
+        );
+
+        assertEq(computedAddress, daiOnEra);
+    }
+}

--- a/l1-contracts/test/foundry/unit/concrete/common/libraries/L2ContractHelper/L2ContractHelper.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/common/libraries/L2ContractHelper/L2ContractHelper.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 import {L2ContractHelper} from "contracts/common/libraries/L2ContractHelper.sol";
+import {MalformedBytecode, BytecodeError, LengthIsNotDivisibleBy32} from "contracts/common/L1ContractErrors.sol";
 
 contract L2ContractHelperTest is Test {
     address daiOnEthereum = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
@@ -17,7 +18,7 @@ contract L2ContractHelperTest is Test {
     function test_RevertWhen_BytecodeLengthIsNotMultipleOf32() public {
         bytes memory bytecode = new bytes(63);
 
-        vm.expectRevert(bytes("pq"));
+        vm.expectRevert(abi.encodeWithSelector(LengthIsNotDivisibleBy32.selector, 63));
         bytes32 hash = L2ContractHelper.hashL2Bytecode(bytecode);
     }
 
@@ -25,7 +26,7 @@ contract L2ContractHelperTest is Test {
     function test_RevertWhen_BytecodeLengthIsTooLarge() public {
         bytes memory bytecode = new bytes(2 ** 16 * 32);
 
-        vm.expectRevert(bytes("pp"));
+        vm.expectRevert(abi.encodeWithSelector(MalformedBytecode.selector, BytecodeError.NumberOfWords));
         bytes32 hash = L2ContractHelper.hashL2Bytecode(bytecode);
     }
 
@@ -33,7 +34,7 @@ contract L2ContractHelperTest is Test {
     function test_RevertWhen_BytecodeLengthIsNotOdd() public {
         bytes memory bytecode = new bytes(64);
 
-        vm.expectRevert(bytes("ps"));
+        vm.expectRevert(abi.encodeWithSelector(MalformedBytecode.selector, BytecodeError.WordsMustBeOdd));
         bytes32 hash = L2ContractHelper.hashL2Bytecode(bytecode);
     }
 
@@ -48,7 +49,7 @@ contract L2ContractHelperTest is Test {
     function test_RevertWhen_BytecodeHashVersionIsNotOne() public {
         bytes32 bytecodeHash = bytes32(0x02000001f862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
 
-        vm.expectRevert(bytes("zf"));
+        vm.expectRevert(abi.encodeWithSelector(MalformedBytecode.selector, BytecodeError.Version));
         L2ContractHelper.validateBytecodeHash(bytecodeHash);
     }
 
@@ -56,7 +57,7 @@ contract L2ContractHelperTest is Test {
     function test_RevertWhen_CodeLengthInWordsIsNotOdd() public {
         bytes32 bytecodeHash = bytes32(0x01000002f862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925);
 
-        vm.expectRevert(bytes("uy"));
+        vm.expectRevert(abi.encodeWithSelector(MalformedBytecode.selector, BytecodeError.WordsMustBeOdd));
         L2ContractHelper.validateBytecodeHash(bytecodeHash);
     }
 

--- a/l1-contracts/test/foundry/unit/concrete/governance/Governance/Constructor.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/governance/Governance/Constructor.t.sol
@@ -6,7 +6,7 @@ import {GovernanceTest} from "./_Governance_Shared.t.sol";
 import {Governance} from "contracts/governance/Governance.sol";
 
 contract ConstructorTest is GovernanceTest {
-    function test_ReverWhen_AdminAddressIsZero() public {
+    function test_RevertWhen_AdminAddressIsZero() public {
         vm.expectRevert("Admin should be non zero address");
         new Governance(address(0), securityCouncil, 0);
     }

--- a/l1-contracts/test/foundry/unit/concrete/governance/Governance/Constructor.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/governance/Governance/Constructor.t.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+import {GovernanceTest} from "./_Governance_Shared.t.sol";
+import {Governance} from "contracts/governance/Governance.sol";
+
+contract ConstructorTest is GovernanceTest {
+    function test_ReverWhen_AdminAddressIsZero() public {
+        vm.expectRevert("Admin should be non zero address");
+        new Governance(address(0), securityCouncil, 0);
+    }
+
+    function test_SuccessfulConstruction() public {
+        Governance governance = new Governance(owner, securityCouncil, 0);
+
+        assertEq(governance.securityCouncil(), securityCouncil);
+        assertEq(governance.minDelay(), 0);
+        assertEq(governance.owner(), owner);
+    }
+}

--- a/l1-contracts/test/foundry/unit/concrete/governance/Governance/Constructor.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/governance/Governance/Constructor.t.sol
@@ -4,10 +4,11 @@ pragma solidity 0.8.24;
 
 import {GovernanceTest} from "./_Governance_Shared.t.sol";
 import {Governance} from "contracts/governance/Governance.sol";
+import {ZeroAddress} from "contracts/common/L1ContractErrors.sol";
 
 contract ConstructorTest is GovernanceTest {
     function test_RevertWhen_AdminAddressIsZero() public {
-        vm.expectRevert("Admin should be non zero address");
+        vm.expectRevert(ZeroAddress.selector);
         new Governance(address(0), securityCouncil, 0);
     }
 

--- a/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/facets/Getters/_Getters_Shared.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/facets/Getters/_Getters_Shared.t.sol
@@ -11,7 +11,7 @@ import {IVerifier} from "contracts/state-transition/chain-interfaces/IVerifier.s
 import {PriorityOperation} from "contracts/state-transition/libraries/PriorityQueue.sol";
 import {VerifierParams} from "contracts/state-transition/chain-interfaces/IVerifier.sol";
 
-contract GettersFacetWrapper is GettersFacet {
+contract GettersFacetWrapper is GettersFacet, Test {
     function util_setVerifier(address _verifier) external {
         s.verifier = IVerifier(_verifier);
     }
@@ -170,6 +170,9 @@ contract GettersFacetWrapper is GettersFacet {
         Diamond.DiamondStorage storage ds = Diamond.getDiamondStorage();
         ds.selectorToFacet[_selector].facetAddress = _facet;
     }
+
+    // add this to be excluded from coverage report
+    function test() internal virtual {}
 }
 
 contract GettersFacetTest is Test {

--- a/l1-contracts/test/foundry/unit/concrete/state-transition/libraries/TransactionValidator/ValidateUpgradeTransaction.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/state-transition/libraries/TransactionValidator/ValidateUpgradeTransaction.t.sol
@@ -53,7 +53,7 @@ contract ValidateUpgradeTxTest is TransactionValidatorSharedTest {
         TransactionValidator.validateUpgradeTransaction(testTx);
     }
 
-    function test_ReverWhen_MaxPriorityFeePerGasIsNotZero() public {
+    function test_RevertWhen_MaxPriorityFeePerGasIsNotZero() public {
         L2CanonicalTransaction memory testTx = createUpgradeTransaction();
         // MaxPriorityFeePerGas must be 0 - otherwise we revert.
         testTx.maxPriorityFeePerGas = 1;

--- a/l1-contracts/test/foundry/unit/concrete/state-transition/libraries/TransactionValidator/ValidateUpgradeTransaction.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/state-transition/libraries/TransactionValidator/ValidateUpgradeTransaction.t.sol
@@ -49,7 +49,7 @@ contract ValidateUpgradeTxTest is TransactionValidatorSharedTest {
         L2CanonicalTransaction memory testTx = createUpgradeTransaction();
         // MaxFeePerGas must be 0 - otherwise we revert.
         testTx.maxFeePerGas = 1;
-        vm.expectRevert(bytes("uq"));
+        vm.expectRevert(abi.encodeWithSelector(InvalidUpgradeTxn.selector, UpgradeTxVerifyParam.MaxFeePerGas));
         TransactionValidator.validateUpgradeTransaction(testTx);
     }
 
@@ -57,7 +57,7 @@ contract ValidateUpgradeTxTest is TransactionValidatorSharedTest {
         L2CanonicalTransaction memory testTx = createUpgradeTransaction();
         // MaxPriorityFeePerGas must be 0 - otherwise we revert.
         testTx.maxPriorityFeePerGas = 1;
-        vm.expectRevert(bytes("ux"));
+        vm.expectRevert(abi.encodeWithSelector(InvalidUpgradeTxn.selector, UpgradeTxVerifyParam.MaxPriorityFeePerGas));
         TransactionValidator.validateUpgradeTransaction(testTx);
     }
 

--- a/l1-contracts/test/foundry/unit/concrete/state-transition/libraries/TransactionValidator/ValidateUpgradeTransaction.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/state-transition/libraries/TransactionValidator/ValidateUpgradeTransaction.t.sol
@@ -45,6 +45,22 @@ contract ValidateUpgradeTxTest is TransactionValidatorSharedTest {
         TransactionValidator.validateUpgradeTransaction(testTx);
     }
 
+    function test_RevertWhen_MaxFeePerGasIsNotZero() public {
+        L2CanonicalTransaction memory testTx = createUpgradeTransaction();
+        // MaxFeePerGas must be 0 - otherwise we revert.
+        testTx.maxFeePerGas = 1;
+        vm.expectRevert(bytes("uq"));
+        TransactionValidator.validateUpgradeTransaction(testTx);
+    }
+
+    function test_ReverWhen_MaxPriorityFeePerGasIsNotZero() public {
+        L2CanonicalTransaction memory testTx = createUpgradeTransaction();
+        // MaxPriorityFeePerGas must be 0 - otherwise we revert.
+        testTx.maxPriorityFeePerGas = 1;
+        vm.expectRevert(bytes("ux"));
+        TransactionValidator.validateUpgradeTransaction(testTx);
+    }
+
     function test_RevertWhen_Reserved0IsNonZero() public {
         L2CanonicalTransaction memory testTx = createUpgradeTransaction();
         // reserved 0 must be 0 - otherwise we revert.


### PR DESCRIPTION
## What?
This PR increases the test coverage for the following contracts:

- L1Erc20Bridge
- L2ContractHelper
 - TransactionValidator
 - Diamond
 - TestnetVerifier

It also excludes dummy contracts from the ```foundry``` coverage summary.