### PR TITLE
[EVM-Equivalence-YUL] Fix compiler tester bugs

### DIFF
--- a/system-contracts/contracts/EvmInterpreter.template.yul
+++ b/system-contracts/contracts/EvmInterpreter.template.yul
@@ -141,7 +141,7 @@ object "EVMInterpreter" {
             if eq(isCallerEVM, 1) {
                 // Includes gas
                 returnOffset := sub(returnOffset, 32)
-                checkOverflow(returnLen, 32)
+                checkOverflow(returnLen, 32, evmGasLeft)
                 returnLen := add(returnLen, 32)
 
                 mstore(returnOffset, evmGasLeft)

--- a/system-contracts/contracts/EvmInterpreter.template.yul
+++ b/system-contracts/contracts/EvmInterpreter.template.yul
@@ -141,6 +141,7 @@ object "EVMInterpreter" {
             if eq(isCallerEVM, 1) {
                 // Includes gas
                 returnOffset := sub(returnOffset, 32)
+                checkOverflow(returnLen, 32)
                 returnLen := add(returnLen, 32)
 
                 mstore(returnOffset, evmGasLeft)

--- a/system-contracts/contracts/EvmInterpreterFunctions.template.yul
+++ b/system-contracts/contracts/EvmInterpreterFunctions.template.yul
@@ -1204,7 +1204,7 @@ function genericCreate(addr, offset, size, sp, value, evmGasLeftOld) -> result, 
 
     let gasForTheCall := capGas(evmGasLeftOld,INF_PASS_GAS())
 
-    if lt(balance(addr),value) {
+    if lt(selfbalance(),value) {
         revertWithGas(evmGasLeftOld)
     }
 

--- a/system-contracts/contracts/EvmInterpreterFunctions.template.yul
+++ b/system-contracts/contracts/EvmInterpreterFunctions.template.yul
@@ -1216,13 +1216,6 @@ function genericCreate(addr, offset, size, sp, value, evmGasLeftOld) -> result, 
         revertWithGas(evmGasLeftOld)
     }
 
-    let nonceNewAddr := getNonce(addr)
-    let bytecodeNewAddr := extcodesize(addr)
-    if or(gt(nonceNewAddr, 0), gt(bytecodeNewAddr, 0)) {
-        incrementNonce(address())
-        revertWithGas(evmGasLeftOld)
-    }
-
     offset := add(MEM_OFFSET_INNER(), offset)
 
     sp := pushStackItem(sp, mload(sub(offset, 0x80)), evmGasLeft)

--- a/system-contracts/contracts/EvmInterpreterFunctions.template.yul
+++ b/system-contracts/contracts/EvmInterpreterFunctions.template.yul
@@ -795,7 +795,7 @@ function getEVMGas() -> evmGas {
     if lt(sub(_gas,shl(30,1)), requiredGas) {
         // This cheks if enough zkevm gas was provided, we are substracting 2^30 since that's the stipend, 
         // and we need to make sure that the gas provided over that is enough for security reasons
-        // revert(0, 0)
+        revert(0, 0)
     }
     evmGas := div(sub(_gas, requiredGas), GAS_DIVISOR())
 }

--- a/system-contracts/contracts/EvmInterpreterFunctions.template.yul
+++ b/system-contracts/contracts/EvmInterpreterFunctions.template.yul
@@ -1052,6 +1052,8 @@ function delegateCall(oldSp, oldIsStatic, evmGasLeft) -> sp, isStatic, extraCost
     retOffset, sp := popStackItem(sp)
     retSize, sp := popStackItem(sp)
 
+    // addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
+
     checkMultipleOverflow(argsOffset,argsSize,MEM_OFFSET_INNER(), evmGasLeft)
     checkMultipleOverflow(retOffset, retSize,MEM_OFFSET_INNER(), evmGasLeft)
 

--- a/system-contracts/contracts/EvmInterpreterFunctions.template.yul
+++ b/system-contracts/contracts/EvmInterpreterFunctions.template.yul
@@ -129,10 +129,10 @@ function swapStackItem(sp, evmGas, position) ->  evmGasLeft {
     mstore(tempSp, s2)
 }
 
-function popStackItem(sp) -> a, newSp {
+function popStackItem(sp, evmGasLeft) -> a, newSp {
     // We can not return any error here, because it would break compatibility
     if lt(sp, STACK_OFFSET()) {
-        revert(0, 0)
+        revertWithGas(evmGasLeft)
     }
 
     a := mload(sp)
@@ -861,12 +861,12 @@ function _saveReturndataAfterZkEVMCall() {
 function performStaticCall(oldSp,evmGasLeft) -> extraCost, sp {
     let gasToPass,addr, argsOffset, argsSize, retOffset, retSize
 
-    gasToPass, sp := popStackItem(oldSp)
-    addr, sp := popStackItem(sp)
-    argsOffset, sp := popStackItem(sp)
-    argsSize, sp := popStackItem(sp)
-    retOffset, sp := popStackItem(sp)
-    retSize, sp := popStackItem(sp)
+    gasToPass, sp := popStackItem(oldSp, evmGasLeft)
+    addr, sp := popStackItem(sp, evmGasLeft)
+    argsOffset, sp := popStackItem(sp, evmGasLeft)
+    argsSize, sp := popStackItem(sp, evmGasLeft)
+    retOffset, sp := popStackItem(sp, evmGasLeft)
+    retSize, sp := popStackItem(sp, evmGasLeft)
 
     addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
 
@@ -983,13 +983,13 @@ function _performCall(addr,gasToPass,value,argsOffset,argsSize,retOffset,retSize
 function performCall(oldSp, evmGasLeft, isStatic) -> extraCost, sp {
     let gasToPass,addr,value,argsOffset,argsSize,retOffset,retSize
 
-    gasToPass, sp := popStackItem(oldSp)
-    addr, sp := popStackItem(sp)
-    value, sp := popStackItem(sp)
-    argsOffset, sp := popStackItem(sp)
-    argsSize, sp := popStackItem(sp)
-    retOffset, sp := popStackItem(sp)
-    retSize, sp := popStackItem(sp)
+    gasToPass, sp := popStackItem(oldSp, evmGasLeft)
+    addr, sp := popStackItem(sp, evmGasLeft)
+    value, sp := popStackItem(sp, evmGasLeft)
+    argsOffset, sp := popStackItem(sp, evmGasLeft)
+    argsSize, sp := popStackItem(sp, evmGasLeft)
+    retOffset, sp := popStackItem(sp, evmGasLeft)
+    retSize, sp := popStackItem(sp, evmGasLeft)
 
     addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
 
@@ -1051,12 +1051,12 @@ function delegateCall(oldSp, oldIsStatic, evmGasLeft) -> sp, isStatic, extraCost
     sp := oldSp
     isStatic := oldIsStatic
 
-    gasToPass, sp := popStackItem(sp)
-    addr, sp := popStackItem(sp)
-    argsOffset, sp := popStackItem(sp)
-    argsSize, sp := popStackItem(sp)
-    retOffset, sp := popStackItem(sp)
-    retSize, sp := popStackItem(sp)
+    gasToPass, sp := popStackItem(sp, evmGasLeft)
+    addr, sp := popStackItem(sp, evmGasLeft)
+    argsOffset, sp := popStackItem(sp, evmGasLeft)
+    argsSize, sp := popStackItem(sp, evmGasLeft)
+    retOffset, sp := popStackItem(sp, evmGasLeft)
+    retSize, sp := popStackItem(sp, evmGasLeft)
 
     // addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
 
@@ -1255,13 +1255,13 @@ function genericCreate(addr, offset, size, sp, value, evmGasLeftOld) -> result, 
 
     let back
 
-    back, sp := popStackItem(sp)
+    back, sp := popStackItem(sp, evmGasLeft)
     mstore(sub(offset, 0x20), back)
-    back, sp := popStackItem(sp)
+    back, sp := popStackItem(sp, evmGasLeft)
     mstore(sub(offset, 0x40), back)
-    back, sp := popStackItem(sp)
+    back, sp := popStackItem(sp, evmGasLeft)
     mstore(sub(offset, 0x60), back)
-    back, sp := popStackItem(sp)
+    back, sp := popStackItem(sp, evmGasLeft)
     mstore(sub(offset, 0x80), back)
 }
 
@@ -1269,10 +1269,10 @@ function performExtCodeCopy(evmGas,oldSp) -> evmGasLeft, sp {
     evmGasLeft := chargeGas(evmGas, 100)
 
     let addr, dest, offset, len
-    addr, sp := popStackItem(oldSp)
-    dest, sp := popStackItem(sp)
-    offset, sp := popStackItem(sp)
-    len, sp := popStackItem(sp)
+    addr, sp := popStackItem(oldSp, evmGasLeft)
+    dest, sp := popStackItem(sp, evmGasLeft)
+    offset, sp := popStackItem(sp, evmGasLeft)
+    len, sp := popStackItem(sp, evmGasLeft)
 
     // dynamicGas = 3 * minimum_word_size + memory_expansion_cost + address_access_cost
     // minimum_word_size = (size + 31) / 32
@@ -1312,9 +1312,9 @@ function performCreate(evmGas,oldSp,isStatic) -> evmGasLeft, sp {
 
     let value, offset, size
 
-    value, sp := popStackItem(oldSp)
-    offset, sp := popStackItem(sp)
-    size, sp := popStackItem(sp)
+    value, sp := popStackItem(oldSp, evmGasLeft)
+    offset, sp := popStackItem(sp, evmGasLeft)
+    size, sp := popStackItem(sp, evmGasLeft)
 
     checkMultipleOverflow(offset, size, MEM_OFFSET_INNER(), evmGasLeft)
 
@@ -1357,10 +1357,10 @@ function performCreate2(evmGas, oldSp, isStatic) -> evmGasLeft, sp, result, addr
 
     let value, offset, size, salt
 
-    value, sp := popStackItem(oldSp)
-    offset, sp := popStackItem(sp)
-    size, sp := popStackItem(sp)
-    salt, sp := popStackItem(sp)
+    value, sp := popStackItem(oldSp, evmGasLeft)
+    offset, sp := popStackItem(sp, evmGasLeft)
+    size, sp := popStackItem(sp, evmGasLeft)
+    salt, sp := popStackItem(sp, evmGasLeft)
 
     checkMultipleOverflow(offset, size, MEM_OFFSET_INNER(), evmGasLeft)
 

--- a/system-contracts/contracts/EvmInterpreterFunctions.template.yul
+++ b/system-contracts/contracts/EvmInterpreterFunctions.template.yul
@@ -960,7 +960,7 @@ function _performCall(addr,gasToPass,value,argsOffset,argsSize,retOffset,retSize
 
     if and(is_evm, iszero(isStatic)) {
         _pushEVMFrame(gasToPassNew, isStatic)
-        success := call(gasToPassNew, addr, value, argsOffset, argsSize, 0, 0)
+        success := call(EVM_GAS_STIPEND(), addr, value, argsOffset, argsSize, 0, 0)
         frameGasLeft := _saveReturndataAfterEVMCall(retOffset, retSize)
         _popEVMFrame()
     }
@@ -1091,7 +1091,7 @@ function delegateCall(oldSp, oldIsStatic, evmGasLeft) -> sp, isStatic, extraCost
     _pushEVMFrame(gasToPass, isStatic)
     let success := delegatecall(
         // We can not just pass all gas here to prevert overflow of zkEVM gas counter
-        gasToPass,
+        EVM_GAS_STIPEND(),
         addr,
         add(MEM_OFFSET_INNER(), argsOffset),
         argsSize,
@@ -1153,7 +1153,7 @@ function _performStaticCall(
         _pushEVMFrame(_calleeGas, true)
         // TODO Check the following comment from zkSync .sol.
         // We can not just pass all gas here to prevert overflow of zkEVM gas counter
-        success := staticcall(_calleeGas, _callee, _inputOffset, _inputLen, 0, 0)
+        success := staticcall(EVM_GAS_STIPEND(), _callee, _inputOffset, _inputLen, 0, 0)
 
         _gasLeft := _saveReturndataAfterEVMCall(_outputOffset, _outputLen)
         _popEVMFrame()

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -351,6 +351,9 @@ for { } true { } {
         offset, sp := popStackItem(sp)
         size, sp := popStackItem(sp)
 
+        checkMultipleOverflow(offset,size,MEM_OFFSET_INNER())
+        checkMultipleOverflow(destOffset,size,MEM_OFFSET_INNER())
+
         checkMemOverflow(add(add(offset, size), MEM_OFFSET_INNER()))
         checkMemOverflow(add(add(destOffset, size), MEM_OFFSET_INNER()))
 
@@ -386,6 +389,7 @@ for { } true { } {
         dst := add(dst, MEM_OFFSET_INNER())
         offset := add(add(offset, BYTECODE_OFFSET()), 32)
 
+        checkOverflow(dst,len)
         checkMemOverflow(add(dst, len))
         // Check bytecode overflow
         if gt(add(offset, len), sub(MEM_OFFSET(), 1)) {
@@ -446,6 +450,7 @@ for { } true { } {
         if gt(add(offset, len), LAST_RETURNDATA_SIZE_OFFSET()) {
             revert(0, 0)
         }
+        checkMultipleOverflow(offset,len,MEM_OFFSET_INNER())
         checkMemOverflow(add(add(dest, MEM_OFFSET_INNER()), len))
 
         // minimum_word_size = (size + 31) / 32
@@ -1048,6 +1053,8 @@ for { } true { } {
         offset, sp := popStackItem(sp)
         size, sp := popStackItem(sp)
 
+        checkMultipleOverflow(offset, size,MEM_OFFSET_INNER())
+
         checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size))
 
         // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
@@ -1068,6 +1075,8 @@ for { } true { } {
         size, sp := popStackItem(sp)
         topic1, sp := popStackItem(sp)
 
+        checkMultipleOverflow(offset, size,MEM_OFFSET_INNER())
+
         checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size))
 
         // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
@@ -1086,6 +1095,8 @@ for { } true { } {
         let offset, size
         offset, sp := popStackItem(sp)
         size, sp := popStackItem(sp)
+
+        checkMultipleOverflow(offset, size,MEM_OFFSET_INNER())
 
         checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size))
 
@@ -1112,6 +1123,8 @@ for { } true { } {
         offset, sp := popStackItem(sp)
         size, sp := popStackItem(sp)
 
+        checkMultipleOverflow(offset, size,MEM_OFFSET_INNER())
+
         checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size))
 
         // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
@@ -1137,6 +1150,8 @@ for { } true { } {
         let offset, size
         offset, sp := popStackItem(sp)
         size, sp := popStackItem(sp)
+
+        checkMultipleOverflow(offset, size,MEM_OFFSET_INNER())
 
         checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size))
 

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -21,8 +21,8 @@ for { } true { } {
 
         let a, b
 
-        a, sp := popStackItem(sp)
-        b, sp := popStackItem(sp)
+        a, sp := popStackItem(sp, evmGasLeft)
+        b, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, add(a, b), evmGasLeft)
     }
@@ -31,8 +31,8 @@ for { } true { } {
 
         let a, b
 
-        a, sp := popStackItem(sp)
-        b, sp := popStackItem(sp)
+        a, sp := popStackItem(sp, evmGasLeft)
+        b, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, mul(a, b), evmGasLeft)
     }
@@ -41,8 +41,8 @@ for { } true { } {
 
         let a, b
 
-        a, sp := popStackItem(sp)
-        b, sp := popStackItem(sp)
+        a, sp := popStackItem(sp, evmGasLeft)
+        b, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, sub(a, b), evmGasLeft)
     }
@@ -51,8 +51,8 @@ for { } true { } {
 
         let a, b
 
-        a, sp := popStackItem(sp)
-        b, sp := popStackItem(sp)
+        a, sp := popStackItem(sp, evmGasLeft)
+        b, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, div(a, b), evmGasLeft)
     }
@@ -61,8 +61,8 @@ for { } true { } {
 
         let a, b
 
-        a, sp := popStackItem(sp)
-        b, sp := popStackItem(sp)
+        a, sp := popStackItem(sp, evmGasLeft)
+        b, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, sdiv(a, b), evmGasLeft)
     }
@@ -71,8 +71,8 @@ for { } true { } {
 
         let a, b
 
-        a, sp := popStackItem(sp)
-        b, sp := popStackItem(sp)
+        a, sp := popStackItem(sp, evmGasLeft)
+        b, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, mod(a, b), evmGasLeft)
     }
@@ -81,8 +81,8 @@ for { } true { } {
 
         let a, b
 
-        a, sp := popStackItem(sp)
-        b, sp := popStackItem(sp)
+        a, sp := popStackItem(sp, evmGasLeft)
+        b, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, smod(a, b), evmGasLeft)
     }
@@ -91,9 +91,9 @@ for { } true { } {
 
         let a, b, N
 
-        a, sp := popStackItem(sp)
-        b, sp := popStackItem(sp)
-        N, sp := popStackItem(sp)
+        a, sp := popStackItem(sp, evmGasLeft)
+        b, sp := popStackItem(sp, evmGasLeft)
+        N, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, addmod(a, b, N), evmGasLeft)
     }
@@ -102,9 +102,9 @@ for { } true { } {
 
         let a, b, N
 
-        a, sp := popStackItem(sp)
-        b, sp := popStackItem(sp)
-        N, sp := popStackItem(sp)
+        a, sp := popStackItem(sp, evmGasLeft)
+        b, sp := popStackItem(sp, evmGasLeft)
+        N, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, mulmod(a, b, N), evmGasLeft)
     }
@@ -113,8 +113,8 @@ for { } true { } {
 
         let a, exponent
 
-        a, sp := popStackItem(sp)
-        exponent, sp := popStackItem(sp)
+        a, sp := popStackItem(sp, evmGasLeft)
+        exponent, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, exp(a, exponent), evmGasLeft)
 
@@ -130,8 +130,8 @@ for { } true { } {
 
         let b, x
 
-        b, sp := popStackItem(sp)
-        x, sp := popStackItem(sp)
+        b, sp := popStackItem(sp, evmGasLeft)
+        x, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, signextend(b, x), evmGasLeft)
     }
@@ -140,8 +140,8 @@ for { } true { } {
 
         let a, b
 
-        a, sp := popStackItem(sp)
-        b, sp := popStackItem(sp)
+        a, sp := popStackItem(sp, evmGasLeft)
+        b, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, lt(a, b), evmGasLeft)
     }
@@ -150,8 +150,8 @@ for { } true { } {
 
         let a, b
 
-        a, sp := popStackItem(sp)
-        b, sp := popStackItem(sp)
+        a, sp := popStackItem(sp, evmGasLeft)
+        b, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, gt(a, b), evmGasLeft)
     }
@@ -160,8 +160,8 @@ for { } true { } {
 
         let a, b
 
-        a, sp := popStackItem(sp)
-        b, sp := popStackItem(sp)
+        a, sp := popStackItem(sp, evmGasLeft)
+        b, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, slt(a, b), evmGasLeft)
     }
@@ -170,8 +170,8 @@ for { } true { } {
 
         let a, b
 
-        a, sp := popStackItem(sp)
-        b, sp := popStackItem(sp)
+        a, sp := popStackItem(sp, evmGasLeft)
+        b, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, sgt(a, b), evmGasLeft)
     }
@@ -180,8 +180,8 @@ for { } true { } {
 
         let a, b
 
-        a, sp := popStackItem(sp)
-        b, sp := popStackItem(sp)
+        a, sp := popStackItem(sp, evmGasLeft)
+        b, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, eq(a, b), evmGasLeft)
     }
@@ -190,7 +190,7 @@ for { } true { } {
 
         let a
 
-        a, sp := popStackItem(sp)
+        a, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, iszero(a), evmGasLeft)
     }
@@ -199,8 +199,8 @@ for { } true { } {
 
         let a, b
 
-        a, sp := popStackItem(sp)
-        b, sp := popStackItem(sp)
+        a, sp := popStackItem(sp, evmGasLeft)
+        b, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, and(a,b), evmGasLeft)
     }
@@ -209,8 +209,8 @@ for { } true { } {
 
         let a, b
 
-        a, sp := popStackItem(sp)
-        b, sp := popStackItem(sp)
+        a, sp := popStackItem(sp, evmGasLeft)
+        b, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, or(a,b), evmGasLeft)
     }
@@ -219,8 +219,8 @@ for { } true { } {
 
         let a, b
 
-        a, sp := popStackItem(sp)
-        b, sp := popStackItem(sp)
+        a, sp := popStackItem(sp, evmGasLeft)
+        b, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, xor(a, b), evmGasLeft)
     }
@@ -229,7 +229,7 @@ for { } true { } {
 
         let a
 
-        a, sp := popStackItem(sp)
+        a, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, not(a), evmGasLeft)
     }
@@ -238,8 +238,8 @@ for { } true { } {
 
         let i, x
 
-        i, sp := popStackItem(sp)
-        x, sp := popStackItem(sp)
+        i, sp := popStackItem(sp, evmGasLeft)
+        x, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, byte(i, x), evmGasLeft)
     }
@@ -248,8 +248,8 @@ for { } true { } {
 
         let shift, value
 
-        shift, sp := popStackItem(sp)
-        value, sp := popStackItem(sp)
+        shift, sp := popStackItem(sp, evmGasLeft)
+        value, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, shl(shift, value), evmGasLeft)
     }
@@ -258,8 +258,8 @@ for { } true { } {
 
         let shift, value
 
-        shift, sp := popStackItem(sp)
-        value, sp := popStackItem(sp)
+        shift, sp := popStackItem(sp, evmGasLeft)
+        value, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, shr(shift, value), evmGasLeft)
     }
@@ -268,8 +268,8 @@ for { } true { } {
 
         let shift, value
 
-        shift, sp := popStackItem(sp)
-        value, sp := popStackItem(sp)
+        shift, sp := popStackItem(sp, evmGasLeft)
+        value, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, sar(shift, value), evmGasLeft)
     }
@@ -278,8 +278,8 @@ for { } true { } {
 
         let offset, size
 
-        offset, sp := popStackItem(sp)
-        size, sp := popStackItem(sp)
+        offset, sp := popStackItem(sp, evmGasLeft)
+        size, sp := popStackItem(sp, evmGasLeft)
 
         checkMultipleOverflow(offset, size, MEM_OFFSET_INNER(), evmGasLeft)
         checkMemOverflow(add(MEM_OFFSET_INNER(), add(offset, size)), evmGasLeft)
@@ -304,7 +304,7 @@ for { } true { } {
 
         let addr
 
-        addr, sp := popStackItem(sp)
+        addr, sp := popStackItem(sp, evmGasLeft)
         addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
 
         if iszero(warmAddress(addr)) {
@@ -333,7 +333,7 @@ for { } true { } {
 
         let i
 
-        i, sp := popStackItem(sp)
+        i, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, calldataload(i), evmGasLeft)
     }
@@ -347,9 +347,9 @@ for { } true { } {
 
         let destOffset, offset, size
 
-        destOffset, sp := popStackItem(sp)
-        offset, sp := popStackItem(sp)
-        size, sp := popStackItem(sp)
+        destOffset, sp := popStackItem(sp, evmGasLeft)
+        offset, sp := popStackItem(sp, evmGasLeft)
+        size, sp := popStackItem(sp, evmGasLeft)
 
         checkMultipleOverflow(offset,size,MEM_OFFSET_INNER(), evmGasLeft)
         checkMultipleOverflow(destOffset,size,MEM_OFFSET_INNER(), evmGasLeft)
@@ -383,9 +383,9 @@ for { } true { } {
 
         let dst, offset, len
 
-        dst, sp := popStackItem(sp)
-        offset, sp := popStackItem(sp)
-        len, sp := popStackItem(sp)
+        dst, sp := popStackItem(sp, evmGasLeft)
+        offset, sp := popStackItem(sp, evmGasLeft)
+        len, sp := popStackItem(sp, evmGasLeft)
 
         // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
         // minimum_word_size = (size + 31) / 32
@@ -419,7 +419,7 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, 100)
 
         let addr
-        addr, sp := popStackItem(sp)
+        addr, sp := popStackItem(sp, evmGasLeft)
 
         addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
         if iszero(warmAddress(addr)) {
@@ -448,9 +448,9 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let dest, offset, len
-        dest, sp := popStackItem(sp)
-        offset, sp := popStackItem(sp)
-        len, sp := popStackItem(sp)
+        dest, sp := popStackItem(sp, evmGasLeft)
+        offset, sp := popStackItem(sp, evmGasLeft)
+        len, sp := popStackItem(sp, evmGasLeft)
 
         // TODO: check if these conditions are met
         // The addition offset + size overflows.
@@ -472,7 +472,7 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, 100)
 
         let addr
-        addr, sp := popStackItem(sp)
+        addr, sp := popStackItem(sp, evmGasLeft)
         addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
 
         if iszero(warmAddress(addr)) {
@@ -485,7 +485,7 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, 20)
 
         let blockNumber
-        blockNumber, sp := popStackItem(sp)
+        blockNumber, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, blockhash(blockNumber), evmGasLeft)
     }
@@ -526,14 +526,14 @@ for { } true { } {
 
         let _y
 
-        _y, sp := popStackItem(sp)
+        _y, sp := popStackItem(sp, evmGasLeft)
     }
     case 0x51 { // OP_MLOAD
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let offset
 
-        offset, sp := popStackItem(sp)
+        offset, sp := popStackItem(sp, evmGasLeft)
 
         checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
         let expansionGas := expandMemory(add(offset, 32))
@@ -548,8 +548,8 @@ for { } true { } {
 
         let offset, value
 
-        offset, sp := popStackItem(sp)
-        value, sp := popStackItem(sp)
+        offset, sp := popStackItem(sp, evmGasLeft)
+        value, sp := popStackItem(sp, evmGasLeft)
 
         checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
         let expansionGas := expandMemory(add(offset, 32))
@@ -563,8 +563,8 @@ for { } true { } {
 
         let offset, value
 
-        offset, sp := popStackItem(sp)
-        value, sp := popStackItem(sp)
+        offset, sp := popStackItem(sp, evmGasLeft)
+        value, sp := popStackItem(sp, evmGasLeft)
 
         checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
         let expansionGas := expandMemory(add(offset, 1))
@@ -579,7 +579,7 @@ for { } true { } {
 
         let key, value, isWarm
 
-        key, sp := popStackItem(sp)
+        key, sp := popStackItem(sp, evmGasLeft)
 
         let wasWarm := isSlotWarm(key)
 
@@ -605,8 +605,8 @@ for { } true { } {
 
         let key, value, gasSpent
 
-        key, sp := popStackItem(sp)
-        value, sp := popStackItem(sp)
+        key, sp := popStackItem(sp, evmGasLeft)
+        value, sp := popStackItem(sp, evmGasLeft)
 
         {
             // Here it is okay to read before we charge since we known anyway that
@@ -642,7 +642,7 @@ for { } true { } {
 
         let counter
 
-        counter, sp := popStackItem(sp)
+        counter, sp := popStackItem(sp, evmGasLeft)
 
         ip := add(add(BYTECODE_OFFSET(), 32), counter)
 
@@ -657,8 +657,8 @@ for { } true { } {
 
         let counter, b
 
-        counter, sp := popStackItem(sp)
-        b, sp := popStackItem(sp)
+        counter, sp := popStackItem(sp, evmGasLeft)
+        b, sp := popStackItem(sp, evmGasLeft)
 
         if iszero(b) {
             continue
@@ -700,7 +700,7 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, 100)
 
         let key
-        key, sp := popStackItem(sp)
+        key, sp := popStackItem(sp, evmGasLeft)
 
         sp := pushStackItem(sp, tload(key), evmGasLeft)
     }
@@ -712,16 +712,16 @@ for { } true { } {
         }
 
         let key, value
-        key, sp := popStackItem(sp)
-        value, sp := popStackItem(sp)
+        key, sp := popStackItem(sp, evmGasLeft)
+        value, sp := popStackItem(sp, evmGasLeft)
 
         tstore(key, value)
     }
     case 0x5E { // OP_MCOPY
         let destOffset, offset, size
-        destOffset, sp := popStackItem(sp)
-        offset, sp := popStackItem(sp)
-        size, sp := popStackItem(sp)
+        destOffset, sp := popStackItem(sp, evmGasLeft)
+        offset, sp := popStackItem(sp, evmGasLeft)
+        size, sp := popStackItem(sp, evmGasLeft)
 
         expandMemory(add(destOffset, size))
         expandMemory(add(offset, size))
@@ -1111,8 +1111,8 @@ for { } true { } {
         }
 
         let offset, size
-        offset, sp := popStackItem(sp)
-        size, sp := popStackItem(sp)
+        offset, sp := popStackItem(sp, evmGasLeft)
+        size, sp := popStackItem(sp, evmGasLeft)
 
         checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
         checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
@@ -1131,9 +1131,9 @@ for { } true { } {
         }
 
         let offset, size, topic1
-        offset, sp := popStackItem(sp)
-        size, sp := popStackItem(sp)
-        topic1, sp := popStackItem(sp)
+        offset, sp := popStackItem(sp, evmGasLeft)
+        size, sp := popStackItem(sp, evmGasLeft)
+        topic1, sp := popStackItem(sp, evmGasLeft)
 
         checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
         checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
@@ -1152,8 +1152,8 @@ for { } true { } {
         }
 
         let offset, size
-        offset, sp := popStackItem(sp)
-        size, sp := popStackItem(sp)
+        offset, sp := popStackItem(sp, evmGasLeft)
+        size, sp := popStackItem(sp, evmGasLeft)
 
         checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
         checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
@@ -1165,8 +1165,8 @@ for { } true { } {
 
         {
             let topic1, topic2
-            topic1, sp := popStackItem(sp)
-            topic2, sp := popStackItem(sp)
+            topic1, sp := popStackItem(sp, evmGasLeft)
+            topic2, sp := popStackItem(sp, evmGasLeft)
             log2(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2)
         }
     }
@@ -1178,8 +1178,8 @@ for { } true { } {
         }
 
         let offset, size
-        offset, sp := popStackItem(sp)
-        size, sp := popStackItem(sp)
+        offset, sp := popStackItem(sp, evmGasLeft)
+        size, sp := popStackItem(sp, evmGasLeft)
 
         checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
 
@@ -1192,9 +1192,9 @@ for { } true { } {
 
         {
             let topic1, topic2, topic3
-            topic1, sp := popStackItem(sp)
-            topic2, sp := popStackItem(sp)
-            topic3, sp := popStackItem(sp)
+            topic1, sp := popStackItem(sp, evmGasLeft)
+            topic2, sp := popStackItem(sp, evmGasLeft)
+            topic3, sp := popStackItem(sp, evmGasLeft)
             log3(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2, topic3)
         }     
     }
@@ -1206,8 +1206,8 @@ for { } true { } {
         }
 
         let offset, size
-        offset, sp := popStackItem(sp)
-        size, sp := popStackItem(sp)
+        offset, sp := popStackItem(sp, evmGasLeft)
+        size, sp := popStackItem(sp, evmGasLeft)
 
         checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
         checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
@@ -1219,10 +1219,10 @@ for { } true { } {
 
         {
             let topic1, topic2, topic3, topic4
-            topic1, sp := popStackItem(sp)
-            topic2, sp := popStackItem(sp)
-            topic3, sp := popStackItem(sp)
-            topic4, sp := popStackItem(sp)
+            topic1, sp := popStackItem(sp, evmGasLeft)
+            topic2, sp := popStackItem(sp, evmGasLeft)
+            topic3, sp := popStackItem(sp, evmGasLeft)
+            topic4, sp := popStackItem(sp, evmGasLeft)
             log4(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2, topic3, topic4)
         }     
     }
@@ -1243,8 +1243,8 @@ for { } true { } {
     case 0xF3 { // OP_RETURN
         let offset,size
 
-        offset, sp := popStackItem(sp)
-        size, sp := popStackItem(sp)
+        offset, sp := popStackItem(sp, evmGasLeft)
+        size, sp := popStackItem(sp, evmGasLeft)
 
         checkOverflow(offset,size, evmGasLeft)
         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
@@ -1279,8 +1279,8 @@ for { } true { } {
     case 0xFD { // OP_REVERT
         let offset,size
 
-        offset, sp := popStackItem(sp)
-        size, sp := popStackItem(sp)
+        offset, sp := popStackItem(sp, evmGasLeft)
+        size, sp := popStackItem(sp, evmGasLeft)
 
         ensureAcceptableMemLocation(offset)
         ensureAcceptableMemLocation(size)

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -464,6 +464,7 @@ for { } true { } {
 
         let addr
         addr, sp := popStackItem(sp)
+        addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
 
         if iszero(warmAddress(addr)) {
             evmGasLeft := chargeGas(evmGasLeft, 2500) 

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -305,6 +305,7 @@ for { } true { } {
         let addr
 
         addr, sp := popStackItem(sp)
+        addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
 
         if iszero(warmAddress(addr)) {
             evmGasLeft := chargeGas(evmGasLeft, 2500)
@@ -586,7 +587,6 @@ for { } true { } {
         
     }
     case 0x55 { // OP_SSTORE
-    
         evmGasLeft := chargeGas(evmGasLeft, 100)
 
         if isStatic {

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -450,8 +450,7 @@ for { } true { } {
         // The addition offset + size overflows.
         // offset + size is larger than RETURNDATASIZE.
         checkOverflow(offset,len)
-        let rdz := mload(LAST_RETURNDATA_SIZE_OFFSET())
-        if gt(add(offset, len), rdz) {
+        if gt(add(offset, len), mload(LAST_RETURNDATA_SIZE_OFFSET())) {
             revert(0, 0)
         }
 

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -24,7 +24,7 @@ for { } true { } {
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, add(a, b))
+        sp := pushStackItem(sp, add(a, b), evmGasLeft)
     }
     case 0x02 { // OP_MUL
         evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -34,7 +34,7 @@ for { } true { } {
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, mul(a, b))
+        sp := pushStackItem(sp, mul(a, b), evmGasLeft)
     }
     case 0x03 { // OP_SUB
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -44,7 +44,7 @@ for { } true { } {
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, sub(a, b))
+        sp := pushStackItem(sp, sub(a, b), evmGasLeft)
     }
     case 0x04 { // OP_DIV
         evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -54,7 +54,7 @@ for { } true { } {
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, div(a, b))
+        sp := pushStackItem(sp, div(a, b), evmGasLeft)
     }
     case 0x05 { // OP_SDIV
         evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -64,7 +64,7 @@ for { } true { } {
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, sdiv(a, b))
+        sp := pushStackItem(sp, sdiv(a, b), evmGasLeft)
     }
     case 0x06 { // OP_MOD
         evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -74,7 +74,7 @@ for { } true { } {
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, mod(a, b))
+        sp := pushStackItem(sp, mod(a, b), evmGasLeft)
     }
     case 0x07 { // OP_SMOD
         evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -84,7 +84,7 @@ for { } true { } {
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, smod(a, b))
+        sp := pushStackItem(sp, smod(a, b), evmGasLeft)
     }
     case 0x08 { // OP_ADDMOD
         evmGasLeft := chargeGas(evmGasLeft, 8)
@@ -95,7 +95,7 @@ for { } true { } {
         b, sp := popStackItem(sp)
         N, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, addmod(a, b, N))
+        sp := pushStackItem(sp, addmod(a, b, N), evmGasLeft)
     }
     case 0x09 { // OP_MULMOD
         evmGasLeft := chargeGas(evmGasLeft, 8)
@@ -106,7 +106,7 @@ for { } true { } {
         b, sp := popStackItem(sp)
         N, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, mulmod(a, b, N))
+        sp := pushStackItem(sp, mulmod(a, b, N), evmGasLeft)
     }
     case 0x0A { // OP_EXP
         evmGasLeft := chargeGas(evmGasLeft, 10)
@@ -116,7 +116,7 @@ for { } true { } {
         a, sp := popStackItem(sp)
         exponent, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, exp(a, exponent))
+        sp := pushStackItem(sp, exp(a, exponent), evmGasLeft)
 
         let to_charge := 0
         for {} gt(exponent,0) {} { // while exponent > 0
@@ -133,7 +133,7 @@ for { } true { } {
         b, sp := popStackItem(sp)
         x, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, signextend(b, x))
+        sp := pushStackItem(sp, signextend(b, x), evmGasLeft)
     }
     case 0x10 { // OP_LT
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -143,7 +143,7 @@ for { } true { } {
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, lt(a, b))
+        sp := pushStackItem(sp, lt(a, b), evmGasLeft)
     }
     case 0x11 { // OP_GT
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -153,7 +153,7 @@ for { } true { } {
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, gt(a, b))
+        sp := pushStackItem(sp, gt(a, b), evmGasLeft)
     }
     case 0x12 { // OP_SLT
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -163,7 +163,7 @@ for { } true { } {
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, slt(a, b))
+        sp := pushStackItem(sp, slt(a, b), evmGasLeft)
     }
     case 0x13 { // OP_SGT
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -173,7 +173,7 @@ for { } true { } {
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, sgt(a, b))
+        sp := pushStackItem(sp, sgt(a, b), evmGasLeft)
     }
     case 0x14 { // OP_EQ
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -183,7 +183,7 @@ for { } true { } {
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, eq(a, b))
+        sp := pushStackItem(sp, eq(a, b), evmGasLeft)
     }
     case 0x15 { // OP_ISZERO
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -192,7 +192,7 @@ for { } true { } {
 
         a, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, iszero(a))
+        sp := pushStackItem(sp, iszero(a), evmGasLeft)
     }
     case 0x16 { // OP_AND
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -202,7 +202,7 @@ for { } true { } {
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, and(a,b))
+        sp := pushStackItem(sp, and(a,b), evmGasLeft)
     }
     case 0x17 { // OP_OR
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -212,7 +212,7 @@ for { } true { } {
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, or(a,b))
+        sp := pushStackItem(sp, or(a,b), evmGasLeft)
     }
     case 0x18 { // OP_XOR
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -222,7 +222,7 @@ for { } true { } {
         a, sp := popStackItem(sp)
         b, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, xor(a, b))
+        sp := pushStackItem(sp, xor(a, b), evmGasLeft)
     }
     case 0x19 { // OP_NOT
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -231,7 +231,7 @@ for { } true { } {
 
         a, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, not(a))
+        sp := pushStackItem(sp, not(a), evmGasLeft)
     }
     case 0x1A { // OP_BYTE
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -241,7 +241,7 @@ for { } true { } {
         i, sp := popStackItem(sp)
         x, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, byte(i, x))
+        sp := pushStackItem(sp, byte(i, x), evmGasLeft)
     }
     case 0x1B { // OP_SHL
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -251,7 +251,7 @@ for { } true { } {
         shift, sp := popStackItem(sp)
         value, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, shl(shift, value))
+        sp := pushStackItem(sp, shl(shift, value), evmGasLeft)
     }
     case 0x1C { // OP_SHR
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -261,7 +261,7 @@ for { } true { } {
         shift, sp := popStackItem(sp)
         value, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, shr(shift, value))
+        sp := pushStackItem(sp, shr(shift, value), evmGasLeft)
     }
     case 0x1D { // OP_SAR
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -271,7 +271,7 @@ for { } true { } {
         shift, sp := popStackItem(sp)
         value, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, sar(shift, value))
+        sp := pushStackItem(sp, sar(shift, value), evmGasLeft)
     }
     case 0x20 { // OP_KECCAK256
         evmGasLeft := chargeGas(evmGasLeft, 30)
@@ -292,12 +292,12 @@ for { } true { } {
         let dynamicGas := add(mul(6, shr(5, add(size, 31))), expandMemory(add(offset, size)))
         evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
 
-        sp := pushStackItem(sp, keccak)
+        sp := pushStackItem(sp, keccak, evmGasLeft)
     }
     case 0x30 { // OP_ADDRESS
         evmGasLeft := chargeGas(evmGasLeft, 2)
 
-        sp := pushStackItem(sp, address())
+        sp := pushStackItem(sp, address(), evmGasLeft)
     }
     case 0x31 { // OP_BALANCE
         evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -310,22 +310,22 @@ for { } true { } {
             evmGasLeft := chargeGas(evmGasLeft, 2500)
         }
 
-        sp := pushStackItem(sp, balance(addr))
+        sp := pushStackItem(sp, balance(addr), evmGasLeft)
     }
     case 0x32 { // OP_ORIGIN
         evmGasLeft := chargeGas(evmGasLeft, 2)
 
-        sp := pushStackItem(sp, origin())
+        sp := pushStackItem(sp, origin(), evmGasLeft)
     }
     case 0x33 { // OP_CALLER
         evmGasLeft := chargeGas(evmGasLeft, 2)
 
-        sp := pushStackItem(sp, caller())
+        sp := pushStackItem(sp, caller(), evmGasLeft)
     }
     case 0x34 { // OP_CALLVALUE
         evmGasLeft := chargeGas(evmGasLeft, 2)
 
-        sp := pushStackItem(sp, callvalue())
+        sp := pushStackItem(sp, callvalue(), evmGasLeft)
     }
     case 0x35 { // OP_CALLDATALOAD
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -334,15 +334,14 @@ for { } true { } {
 
         i, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, calldataload(i))
+        sp := pushStackItem(sp, calldataload(i), evmGasLeft)
     }
     case 0x36 { // OP_CALLDATASIZE
         evmGasLeft := chargeGas(evmGasLeft, 2)
 
-        sp := pushStackItem(sp, calldatasize())
+        sp := pushStackItem(sp, calldatasize(), evmGasLeft)
     }
     case 0x37 { // OP_CALLDATACOPY
-    
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let destOffset, offset, size
@@ -369,7 +368,7 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, 2)
 
         let bytecodeLen := mload(BYTECODE_OFFSET())
-        sp := pushStackItem(sp, bytecodeLen)
+        sp := pushStackItem(sp, bytecodeLen, evmGasLeft)
     }
     case 0x39 { // OP_CODECOPY
     
@@ -407,7 +406,7 @@ for { } true { } {
     case 0x3A { // OP_GASPRICE
         evmGasLeft := chargeGas(evmGasLeft, 2)
 
-        sp := pushStackItem(sp, gasprice())
+        sp := pushStackItem(sp, gasprice(), evmGasLeft)
     }
     case 0x3B { // OP_EXTCODESIZE
         evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -423,8 +422,8 @@ for { } true { } {
         // if a contract is created it works, but if the address is a zkSync's contract
         // what happens?
         switch _isEVM(addr) 
-            case 0  { sp := pushStackItem(sp, extcodesize(addr)) }
-            default { sp := pushStackItem(sp, _fetchDeployedCodeLen(addr)) }
+            case 0  { sp := pushStackItem(sp, extcodesize(addr), evmGasLeft) }
+            default { sp := pushStackItem(sp, _fetchDeployedCodeLen(addr), evmGasLeft) }
     }
     case 0x3C { // OP_EXTCODECOPY
         evmGasLeft, sp := performExtCodeCopy(evmGasLeft, sp)
@@ -433,7 +432,7 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, 2)
 
         let rdz := mload(LAST_RETURNDATA_SIZE_OFFSET())
-        sp := pushStackItem(sp, rdz)
+        sp := pushStackItem(sp, rdz, evmGasLeft)
     }
     case 0x3E { // OP_RETURNDATACOPY
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -469,7 +468,7 @@ for { } true { } {
             evmGasLeft := chargeGas(evmGasLeft, 2500) 
         }
 
-        sp := pushStackItem(sp, extcodehash(addr))
+        sp := pushStackItem(sp, extcodehash(addr), evmGasLeft)
     }
     case 0x40 { // OP_BLOCKHASH
         evmGasLeft := chargeGas(evmGasLeft, 20)
@@ -477,39 +476,39 @@ for { } true { } {
         let blockNumber
         blockNumber, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, blockhash(blockNumber))
+        sp := pushStackItem(sp, blockhash(blockNumber), evmGasLeft)
     }
     case 0x41 { // OP_COINBASE
         evmGasLeft := chargeGas(evmGasLeft, 2)
-        sp := pushStackItem(sp, coinbase())
+        sp := pushStackItem(sp, coinbase(), evmGasLeft)
     }
     case 0x42 { // OP_TIMESTAMP
         evmGasLeft := chargeGas(evmGasLeft, 2)
-        sp := pushStackItem(sp, timestamp())
+        sp := pushStackItem(sp, timestamp(), evmGasLeft)
     }
     case 0x43 { // OP_NUMBER
         evmGasLeft := chargeGas(evmGasLeft, 2)
-        sp := pushStackItem(sp, number())
+        sp := pushStackItem(sp, number(), evmGasLeft)
     }
     case 0x44 { // OP_PREVRANDAO
         evmGasLeft := chargeGas(evmGasLeft, 2)
-        sp := pushStackItem(sp, prevrandao())
+        sp := pushStackItem(sp, prevrandao(), evmGasLeft)
     }
     case 0x45 { // OP_GASLIMIT
         evmGasLeft := chargeGas(evmGasLeft, 2)
-        sp := pushStackItem(sp, gaslimit())
+        sp := pushStackItem(sp, gaslimit(), evmGasLeft)
     }
     case 0x46 { // OP_CHAINID
         evmGasLeft := chargeGas(evmGasLeft, 2)
-        sp := pushStackItem(sp, chainid())
+        sp := pushStackItem(sp, chainid(), evmGasLeft)
     }
     case 0x47 { // OP_SELFBALANCE
         evmGasLeft := chargeGas(evmGasLeft, 5)
-        sp := pushStackItem(sp, selfbalance())
+        sp := pushStackItem(sp, selfbalance(), evmGasLeft)
     }
     case 0x48 { // OP_BASEFEE
         evmGasLeft := chargeGas(evmGasLeft, 2)
-        sp := pushStackItem(sp, basefee())
+        sp := pushStackItem(sp, basefee(), evmGasLeft)
     }
     case 0x50 { // OP_POP
         evmGasLeft := chargeGas(evmGasLeft, 2)
@@ -531,7 +530,7 @@ for { } true { } {
 
         checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
         let memValue := mload(add(MEM_OFFSET_INNER(), offset))
-        sp := pushStackItem(sp, memValue)
+        sp := pushStackItem(sp, memValue, evmGasLeft)
     }
     case 0x52 { // OP_MSTORE
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -583,7 +582,7 @@ for { } true { } {
             let _wasW, _orgV := warmSlot(key, value)
         }
 
-        sp := pushStackItem(sp,value)
+        sp := pushStackItem(sp,value, evmGasLeft)
         
     }
     case 0x55 { // OP_SSTORE
@@ -667,7 +666,7 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, 2)
 
         // PC = ip - 32 (bytecode size) - 1 (current instruction)
-        sp := pushStackItem(sp, sub(sub(ip, BYTECODE_OFFSET()), 33))
+        sp := pushStackItem(sp, sub(sub(ip, BYTECODE_OFFSET()), 33), evmGasLeft)
     }
     case 0x59 { // OP_MSIZE
         evmGasLeft := chargeGas(evmGasLeft,2)
@@ -676,13 +675,13 @@ for { } true { } {
 
         size := mload(MEM_OFFSET())
         size := shl(5,size)
-        sp := pushStackItem(sp,size)
+        sp := pushStackItem(sp,size, evmGasLeft)
 
     }
     case 0x5A { // OP_GAS
         evmGasLeft := chargeGas(evmGasLeft, 2)
 
-        sp := pushStackItem(sp, evmGasLeft)
+        sp := pushStackItem(sp, evmGasLeft, evmGasLeft)
     }
     case 0x5B { // OP_JUMPDEST
         evmGasLeft := chargeGas(evmGasLeft, 1)
@@ -693,7 +692,7 @@ for { } true { } {
         let key
         key, sp := popStackItem(sp)
 
-        sp := pushStackItem(sp, tload(key))
+        sp := pushStackItem(sp, tload(key), evmGasLeft)
     }
     case 0x5D { // OP_TSTORE
         evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -740,14 +739,14 @@ for { } true { } {
 
         let value := 0
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
     }
     case 0x60 { // OP_PUSH1
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
         let value := readBytes(ip,maxAcceptablePos,1)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 1)
     }
     case 0x61 { // OP_PUSH2
@@ -755,7 +754,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,2)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 2)
     }     
     case 0x62 { // OP_PUSH3
@@ -763,7 +762,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,3)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 3)
     }
     case 0x63 { // OP_PUSH4
@@ -771,7 +770,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,4)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 4)
     }
     case 0x64 { // OP_PUSH5
@@ -779,7 +778,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,5)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 5)
     }
     case 0x65 { // OP_PUSH6
@@ -787,7 +786,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,6)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 6)
     }
     case 0x66 { // OP_PUSH7
@@ -795,7 +794,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,7)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 7)
     }
     case 0x67 { // OP_PUSH8
@@ -803,7 +802,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,8)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 8)
     }
     case 0x68 { // OP_PUSH9
@@ -811,7 +810,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,9)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 9)
     }
     case 0x69 { // OP_PUSH10
@@ -819,7 +818,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,10)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 10)
     }
     case 0x6A { // OP_PUSH11
@@ -827,7 +826,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,11)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 11)
     }
     case 0x6B { // OP_PUSH12
@@ -835,7 +834,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,12)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 12)
     }
     case 0x6C { // OP_PUSH13
@@ -843,7 +842,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,13)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 13)
     }
     case 0x6D { // OP_PUSH14
@@ -851,7 +850,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,14)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 14)
     }
     case 0x6E { // OP_PUSH15
@@ -859,7 +858,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,15)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 15)
     }
     case 0x6F { // OP_PUSH16
@@ -867,7 +866,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,16)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 16)
     }
     case 0x70 { // OP_PUSH17
@@ -875,7 +874,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,17)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 17)
     }
     case 0x71 { // OP_PUSH18
@@ -883,7 +882,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,18)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 18)
     }
     case 0x72 { // OP_PUSH19
@@ -891,7 +890,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,19)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 19)
     }
     case 0x73 { // OP_PUSH20
@@ -899,7 +898,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,20)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 20)
     }
     case 0x74 { // OP_PUSH21
@@ -907,7 +906,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,21)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 21)
     }
     case 0x75 { // OP_PUSH22
@@ -915,7 +914,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,22)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 22)
     }
     case 0x76 { // OP_PUSH23
@@ -923,7 +922,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,23)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 23)
     }
     case 0x77 { // OP_PUSH24
@@ -931,7 +930,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,24)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 24)
     }
     case 0x78 { // OP_PUSH25
@@ -939,7 +938,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,25)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 25)
     }
     case 0x79 { // OP_PUSH26
@@ -947,7 +946,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,26)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 26)
     }
     case 0x7A { // OP_PUSH27
@@ -955,7 +954,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,27)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 27)
     }
     case 0x7B { // OP_PUSH28
@@ -963,7 +962,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,28)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 28)
     }
     case 0x7C { // OP_PUSH29
@@ -971,7 +970,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,29)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 29)
     }
     case 0x7D { // OP_PUSH30
@@ -979,7 +978,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,30)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 30)
     }
     case 0x7E { // OP_PUSH31
@@ -987,7 +986,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,31)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 31)
     }
     case 0x7F { // OP_PUSH32
@@ -995,7 +994,7 @@ for { } true { } {
 
         let value := readBytes(ip,maxAcceptablePos,32)
 
-        sp := pushStackItem(sp, value)
+        sp := pushStackItem(sp, value, evmGasLeft)
         ip := add(ip, 32)
     }
     case 0x80 { // OP_DUP1 
@@ -1238,7 +1237,6 @@ for { } true { } {
         size, sp := popStackItem(sp)
 
         checkOverflow(offset,size, evmGasLeft)
-        //checkMemOverflow(add(offset,size))
         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
 
         returnLen := size
@@ -1258,8 +1256,8 @@ for { } true { } {
         let result, addr
         evmGasLeft, sp, result, addr := performCreate2(evmGasLeft, sp, isStatic)
         switch result
-        case 0 { sp := pushStackItem(sp, 0) }
-        default { sp := pushStackItem(sp, addr) }
+        case 0 { sp := pushStackItem(sp, 0, evmGasLeft) }
+        default { sp := pushStackItem(sp, addr, evmGasLeft) }
     }
     case 0xFA { // OP_STATICCALL
         evmGasLeft := chargeGas(evmGasLeft, 100)

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -532,6 +532,7 @@ for { } true { } {
         let expansionGas := expandMemory(offset) // TODO: add +32 here
         evmGasLeft := chargeGas(evmGasLeft, expansionGas)
 
+        checkOverflow(offset,MEM_OFFSET_INNER())
         let memValue := mload(add(MEM_OFFSET_INNER(), offset))
         sp := pushStackItem(sp, memValue)
     }
@@ -546,6 +547,7 @@ for { } true { } {
         let expansionGas := expandMemory(offset) // TODO: add +32 here
         evmGasLeft := chargeGas(evmGasLeft, expansionGas)
 
+        checkOverflow(offset,MEM_OFFSET_INNER())
         mstore(add(MEM_OFFSET_INNER(), offset), value)
     }
     case 0x53 { // OP_MSTORE8
@@ -559,6 +561,7 @@ for { } true { } {
         let expansionGas := expandMemory(offset) // TODO: add +1 here
         evmGasLeft := chargeGas(evmGasLeft, expansionGas)
 
+        checkOverflow(offset,MEM_OFFSET_INNER())
         mstore8(add(MEM_OFFSET_INNER(), offset), value)
     }
     case 0x54 { // OP_SLOAD
@@ -1191,8 +1194,9 @@ for { } true { } {
         offset, sp := popStackItem(sp)
         size, sp := popStackItem(sp)
 
-        ensureAcceptableMemLocation(offset)
-        ensureAcceptableMemLocation(size)
+
+        checkOverflow(offset,size)
+        ensureAcceptableMemLocation(add(offset,size))
         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
 
         returnLen := size

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -354,8 +354,14 @@ for { } true { } {
         checkMultipleOverflow(offset,size,MEM_OFFSET_INNER(), evmGasLeft)
         checkMultipleOverflow(destOffset,size,MEM_OFFSET_INNER(), evmGasLeft)
 
-        checkMemOverflow(add(add(offset, size), MEM_OFFSET_INNER()), evmGasLeft)
-        checkMemOverflow(add(add(destOffset, size), MEM_OFFSET_INNER()), evmGasLeft)
+        if or(gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM()), gt(add(add(destOffset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM())) {
+            for { let i := 0 } lt(i, size) { i := add(i, 1) } {
+                mstore8(
+                    add(add(destOffset, MEM_OFFSET_INNER()), i),
+                    0
+                )
+            }
+        }
 
         // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
         // minimum_word_size = (size + 31) / 32

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -526,7 +526,7 @@ for { } true { } {
         offset, sp := popStackItem(sp)
 
         checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
-        let expansionGas := expandMemory(offset) // TODO: add +32 here
+        let expansionGas := expandMemory(add(offset, 32))
         evmGasLeft := chargeGas(evmGasLeft, expansionGas)
 
         checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
@@ -542,7 +542,7 @@ for { } true { } {
         value, sp := popStackItem(sp)
 
         checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
-        let expansionGas := expandMemory(offset) // TODO: add +32 here
+        let expansionGas := expandMemory(add(offset, 32))
         evmGasLeft := chargeGas(evmGasLeft, expansionGas)
 
         checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
@@ -557,7 +557,7 @@ for { } true { } {
         value, sp := popStackItem(sp)
 
         checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
-        let expansionGas := expandMemory(offset) // TODO: add +1 here
+        let expansionGas := expandMemory(add(offset, 1))
         evmGasLeft := chargeGas(evmGasLeft, expansionGas)
 
         checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -282,6 +282,8 @@ for { } true { } {
         offset, sp := popStackItem(sp)
         size, sp := popStackItem(sp)
 
+
+        checkMultipleOverflow(offset,size,MEM_OFFSET_INNER())
         let keccak := keccak256(add(MEM_OFFSET_INNER(), offset), size)
 
         // When an offset is first accessed (either read or write), memory may trigger 

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -1196,10 +1196,11 @@ for { } true { } {
 
 
         checkOverflow(offset,size)
-        ensureAcceptableMemLocation(add(offset,size))
+        //checkMemOverflow(add(offset,size))
         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
 
         returnLen := size
+        checkOverflow(offset,MEM_OFFSET_INNER())
         returnOffset := add(MEM_OFFSET_INNER(), offset)
         break
     }

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -449,11 +449,11 @@ for { } true { } {
         // TODO: check if these conditions are met
         // The addition offset + size overflows.
         // offset + size is larger than RETURNDATASIZE.
-        if gt(add(offset, len), LAST_RETURNDATA_SIZE_OFFSET()) {
+        checkOverflow(offset,len)
+        let rdz := mload(LAST_RETURNDATA_SIZE_OFFSET())
+        if gt(add(offset, len), rdz) {
             revert(0, 0)
         }
-        checkMultipleOverflow(offset,len,MEM_OFFSET_INNER())
-        checkMemOverflow(add(add(dest, MEM_OFFSET_INNER()), len))
 
         // minimum_word_size = (size + 31) / 32
         // dynamicGas = 3 * minimum_word_size + memory_expansion_cost

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -415,6 +415,7 @@ for { } true { } {
         let addr
         addr, sp := popStackItem(sp)
 
+        addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
         if iszero(warmAddress(addr)) {
             evmGasLeft := chargeGas(evmGasLeft, 2500)
         }
@@ -422,6 +423,8 @@ for { } true { } {
         // TODO: check, the .sol uses extcodesize directly, but it doesnt seem to work
         // if a contract is created it works, but if the address is a zkSync's contract
         // what happens?
+        // sp := pushStackItem(sp, extcodesize(addr), evmGasLeft)
+
         switch _isEVM(addr) 
             case 0  { sp := pushStackItem(sp, extcodesize(addr), evmGasLeft) }
             default { sp := pushStackItem(sp, _fetchDeployedCodeLen(addr), evmGasLeft) }

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -687,6 +687,23 @@ for { } true { } {
     case 0x5B { // OP_JUMPDEST
         evmGasLeft := chargeGas(evmGasLeft, 1)
     }
+    case 0x5C { // OP_TLOAD
+        evmGasLeft := chargeGas(evmGasLeft, 100)
+
+        let key
+        key, sp := popStackItem(sp)
+
+        sp := pushStackItem(sp, tload(key))
+    }
+    case 0x5D { // OP_TSTORE
+        evmGasLeft := chargeGas(evmGasLeft, 100)
+
+        let key, value
+        key, sp := popStackItem(sp)
+        value, sp := popStackItem(sp)
+
+        tstore(key, value)
+    }
     case 0x5E { // OP_MCOPY
         let destOffset, offset, size
         destOffset, sp := popStackItem(sp)

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -479,6 +479,10 @@ for { } true { } {
             evmGasLeft := chargeGas(evmGasLeft, 2500) 
         }
 
+        if iszero(addr) {
+            sp := pushStackItem(sp, 0, evmGasLeft)
+            continue
+        }
         sp := pushStackItem(sp, extcodehash(addr), evmGasLeft)
     }
     case 0x40 { // OP_BLOCKHASH

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -698,6 +698,10 @@ for { } true { } {
     case 0x5D { // OP_TSTORE
         evmGasLeft := chargeGas(evmGasLeft, 100)
 
+        if isStatic {
+            revertWithGas(evmGasLeft)
+        }
+
         let key, value
         key, sp := popStackItem(sp)
         value, sp := popStackItem(sp)

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -1290,13 +1290,6 @@ object "EVMInterpreter" {
                 revertWithGas(evmGasLeftOld)
             }
         
-            let nonceNewAddr := getNonce(addr)
-            let bytecodeNewAddr := extcodesize(addr)
-            if or(gt(nonceNewAddr, 0), gt(bytecodeNewAddr, 0)) {
-                incrementNonce(address())
-                revertWithGas(evmGasLeftOld)
-            }
-        
             offset := add(MEM_OFFSET_INNER(), offset)
         
             sp := pushStackItem(sp, mload(sub(offset, 0x80)), evmGasLeft)
@@ -4041,13 +4034,6 @@ object "EVMInterpreter" {
                 let gasForTheCall := capGas(evmGasLeftOld,INF_PASS_GAS())
             
                 if lt(selfbalance(),value) {
-                    revertWithGas(evmGasLeftOld)
-                }
-            
-                let nonceNewAddr := getNonce(addr)
-                let bytecodeNewAddr := extcodesize(addr)
-                if or(gt(nonceNewAddr, 0), gt(bytecodeNewAddr, 0)) {
-                    incrementNonce(address())
                     revertWithGas(evmGasLeftOld)
                 }
             

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -1751,6 +1751,8 @@ object "EVMInterpreter" {
                     offset, sp := popStackItem(sp)
                     size, sp := popStackItem(sp)
             
+            
+                    checkMultipleOverflow(offset,size,MEM_OFFSET_INNER())
                     let keccak := keccak256(add(MEM_OFFSET_INNER(), offset), size)
             
                     // When an offset is first accessed (either read or write), memory may trigger 
@@ -4435,6 +4437,8 @@ object "EVMInterpreter" {
                     offset, sp := popStackItem(sp)
                     size, sp := popStackItem(sp)
             
+            
+                    checkMultipleOverflow(offset,size,MEM_OFFSET_INNER())
                     let keccak := keccak256(add(MEM_OFFSET_INNER(), offset), size)
             
                     // When an offset is first accessed (either read or write), memory may trigger 

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -1965,6 +1965,10 @@ object "EVMInterpreter" {
                         evmGasLeft := chargeGas(evmGasLeft, 2500) 
                     }
             
+                    if iszero(addr) {
+                        sp := pushStackItem(sp, 0, evmGasLeft)
+                        continue
+                    }
                     sp := pushStackItem(sp, extcodehash(addr), evmGasLeft)
                 }
                 case 0x40 { // OP_BLOCKHASH
@@ -4723,6 +4727,10 @@ object "EVMInterpreter" {
                         evmGasLeft := chargeGas(evmGasLeft, 2500) 
                     }
             
+                    if iszero(addr) {
+                        sp := pushStackItem(sp, 0, evmGasLeft)
+                        continue
+                    }
                     sp := pushStackItem(sp, extcodehash(addr), evmGasLeft)
                 }
                 case 0x40 { // OP_BLOCKHASH

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -2011,7 +2011,7 @@ object "EVMInterpreter" {
                     offset, sp := popStackItem(sp)
             
                     checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
-                    let expansionGas := expandMemory(offset) // TODO: add +32 here
+                    let expansionGas := expandMemory(add(offset, 32))
                     evmGasLeft := chargeGas(evmGasLeft, expansionGas)
             
                     checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
@@ -2027,7 +2027,7 @@ object "EVMInterpreter" {
                     value, sp := popStackItem(sp)
             
                     checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
-                    let expansionGas := expandMemory(offset) // TODO: add +32 here
+                    let expansionGas := expandMemory(add(offset, 32))
                     evmGasLeft := chargeGas(evmGasLeft, expansionGas)
             
                     checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
@@ -2042,7 +2042,7 @@ object "EVMInterpreter" {
                     value, sp := popStackItem(sp)
             
                     checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
-                    let expansionGas := expandMemory(offset) // TODO: add +1 here
+                    let expansionGas := expandMemory(add(offset, 1))
                     evmGasLeft := chargeGas(evmGasLeft, expansionGas)
             
                     checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
@@ -4739,7 +4739,7 @@ object "EVMInterpreter" {
                     offset, sp := popStackItem(sp)
             
                     checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
-                    let expansionGas := expandMemory(offset) // TODO: add +32 here
+                    let expansionGas := expandMemory(add(offset, 32))
                     evmGasLeft := chargeGas(evmGasLeft, expansionGas)
             
                     checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
@@ -4755,7 +4755,7 @@ object "EVMInterpreter" {
                     value, sp := popStackItem(sp)
             
                     checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
-                    let expansionGas := expandMemory(offset) // TODO: add +32 here
+                    let expansionGas := expandMemory(add(offset, 32))
                     evmGasLeft := chargeGas(evmGasLeft, expansionGas)
             
                     checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
@@ -4770,7 +4770,7 @@ object "EVMInterpreter" {
                     value, sp := popStackItem(sp)
             
                     checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
-                    let expansionGas := expandMemory(offset) // TODO: add +1 here
+                    let expansionGas := expandMemory(add(offset, 1))
                     evmGasLeft := chargeGas(evmGasLeft, expansionGas)
             
                     checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -1278,7 +1278,7 @@ object "EVMInterpreter" {
         
             let gasForTheCall := capGas(evmGasLeftOld,INF_PASS_GAS())
         
-            if lt(balance(addr),value) {
+            if lt(selfbalance(),value) {
                 revertWithGas(evmGasLeftOld)
             }
         
@@ -2182,6 +2182,10 @@ object "EVMInterpreter" {
                 }
                 case 0x5D { // OP_TSTORE
                     evmGasLeft := chargeGas(evmGasLeft, 100)
+            
+                    if isStatic {
+                        revertWithGas(evmGasLeft)
+                    }
             
                     let key, value
                     key, sp := popStackItem(sp)
@@ -4012,7 +4016,7 @@ object "EVMInterpreter" {
             
                 let gasForTheCall := capGas(evmGasLeftOld,INF_PASS_GAS())
             
-                if lt(balance(addr),value) {
+                if lt(selfbalance(),value) {
                     revertWithGas(evmGasLeftOld)
                 }
             
@@ -4927,6 +4931,10 @@ object "EVMInterpreter" {
                 }
                 case 0x5D { // OP_TSTORE
                     evmGasLeft := chargeGas(evmGasLeft, 100)
+            
+                    if isStatic {
+                        revertWithGas(evmGasLeft)
+                    }
             
                     let key, value
                     key, sp := popStackItem(sp)

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -203,10 +203,10 @@ object "EVMInterpreter" {
             mstore(tempSp, s2)
         }
         
-        function popStackItem(sp) -> a, newSp {
+        function popStackItem(sp, evmGasLeft) -> a, newSp {
             // We can not return any error here, because it would break compatibility
             if lt(sp, STACK_OFFSET()) {
-                revert(0, 0)
+                revertWithGas(evmGasLeft)
             }
         
             a := mload(sp)
@@ -935,12 +935,12 @@ object "EVMInterpreter" {
         function performStaticCall(oldSp,evmGasLeft) -> extraCost, sp {
             let gasToPass,addr, argsOffset, argsSize, retOffset, retSize
         
-            gasToPass, sp := popStackItem(oldSp)
-            addr, sp := popStackItem(sp)
-            argsOffset, sp := popStackItem(sp)
-            argsSize, sp := popStackItem(sp)
-            retOffset, sp := popStackItem(sp)
-            retSize, sp := popStackItem(sp)
+            gasToPass, sp := popStackItem(oldSp, evmGasLeft)
+            addr, sp := popStackItem(sp, evmGasLeft)
+            argsOffset, sp := popStackItem(sp, evmGasLeft)
+            argsSize, sp := popStackItem(sp, evmGasLeft)
+            retOffset, sp := popStackItem(sp, evmGasLeft)
+            retSize, sp := popStackItem(sp, evmGasLeft)
         
             addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
         
@@ -1057,13 +1057,13 @@ object "EVMInterpreter" {
         function performCall(oldSp, evmGasLeft, isStatic) -> extraCost, sp {
             let gasToPass,addr,value,argsOffset,argsSize,retOffset,retSize
         
-            gasToPass, sp := popStackItem(oldSp)
-            addr, sp := popStackItem(sp)
-            value, sp := popStackItem(sp)
-            argsOffset, sp := popStackItem(sp)
-            argsSize, sp := popStackItem(sp)
-            retOffset, sp := popStackItem(sp)
-            retSize, sp := popStackItem(sp)
+            gasToPass, sp := popStackItem(oldSp, evmGasLeft)
+            addr, sp := popStackItem(sp, evmGasLeft)
+            value, sp := popStackItem(sp, evmGasLeft)
+            argsOffset, sp := popStackItem(sp, evmGasLeft)
+            argsSize, sp := popStackItem(sp, evmGasLeft)
+            retOffset, sp := popStackItem(sp, evmGasLeft)
+            retSize, sp := popStackItem(sp, evmGasLeft)
         
             addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
         
@@ -1125,12 +1125,12 @@ object "EVMInterpreter" {
             sp := oldSp
             isStatic := oldIsStatic
         
-            gasToPass, sp := popStackItem(sp)
-            addr, sp := popStackItem(sp)
-            argsOffset, sp := popStackItem(sp)
-            argsSize, sp := popStackItem(sp)
-            retOffset, sp := popStackItem(sp)
-            retSize, sp := popStackItem(sp)
+            gasToPass, sp := popStackItem(sp, evmGasLeft)
+            addr, sp := popStackItem(sp, evmGasLeft)
+            argsOffset, sp := popStackItem(sp, evmGasLeft)
+            argsSize, sp := popStackItem(sp, evmGasLeft)
+            retOffset, sp := popStackItem(sp, evmGasLeft)
+            retSize, sp := popStackItem(sp, evmGasLeft)
         
             // addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
         
@@ -1329,13 +1329,13 @@ object "EVMInterpreter" {
         
             let back
         
-            back, sp := popStackItem(sp)
+            back, sp := popStackItem(sp, evmGasLeft)
             mstore(sub(offset, 0x20), back)
-            back, sp := popStackItem(sp)
+            back, sp := popStackItem(sp, evmGasLeft)
             mstore(sub(offset, 0x40), back)
-            back, sp := popStackItem(sp)
+            back, sp := popStackItem(sp, evmGasLeft)
             mstore(sub(offset, 0x60), back)
-            back, sp := popStackItem(sp)
+            back, sp := popStackItem(sp, evmGasLeft)
             mstore(sub(offset, 0x80), back)
         }
         
@@ -1343,10 +1343,10 @@ object "EVMInterpreter" {
             evmGasLeft := chargeGas(evmGas, 100)
         
             let addr, dest, offset, len
-            addr, sp := popStackItem(oldSp)
-            dest, sp := popStackItem(sp)
-            offset, sp := popStackItem(sp)
-            len, sp := popStackItem(sp)
+            addr, sp := popStackItem(oldSp, evmGasLeft)
+            dest, sp := popStackItem(sp, evmGasLeft)
+            offset, sp := popStackItem(sp, evmGasLeft)
+            len, sp := popStackItem(sp, evmGasLeft)
         
             // dynamicGas = 3 * minimum_word_size + memory_expansion_cost + address_access_cost
             // minimum_word_size = (size + 31) / 32
@@ -1386,9 +1386,9 @@ object "EVMInterpreter" {
         
             let value, offset, size
         
-            value, sp := popStackItem(oldSp)
-            offset, sp := popStackItem(sp)
-            size, sp := popStackItem(sp)
+            value, sp := popStackItem(oldSp, evmGasLeft)
+            offset, sp := popStackItem(sp, evmGasLeft)
+            size, sp := popStackItem(sp, evmGasLeft)
         
             checkMultipleOverflow(offset, size, MEM_OFFSET_INNER(), evmGasLeft)
         
@@ -1431,10 +1431,10 @@ object "EVMInterpreter" {
         
             let value, offset, size, salt
         
-            value, sp := popStackItem(oldSp)
-            offset, sp := popStackItem(sp)
-            size, sp := popStackItem(sp)
-            salt, sp := popStackItem(sp)
+            value, sp := popStackItem(oldSp, evmGasLeft)
+            offset, sp := popStackItem(sp, evmGasLeft)
+            size, sp := popStackItem(sp, evmGasLeft)
+            salt, sp := popStackItem(sp, evmGasLeft)
         
             checkMultipleOverflow(offset, size, MEM_OFFSET_INNER(), evmGasLeft)
         
@@ -1507,8 +1507,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, add(a, b), evmGasLeft)
                 }
@@ -1517,8 +1517,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, mul(a, b), evmGasLeft)
                 }
@@ -1527,8 +1527,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, sub(a, b), evmGasLeft)
                 }
@@ -1537,8 +1537,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, div(a, b), evmGasLeft)
                 }
@@ -1547,8 +1547,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, sdiv(a, b), evmGasLeft)
                 }
@@ -1557,8 +1557,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, mod(a, b), evmGasLeft)
                 }
@@ -1567,8 +1567,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, smod(a, b), evmGasLeft)
                 }
@@ -1577,9 +1577,9 @@ object "EVMInterpreter" {
             
                     let a, b, N
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
-                    N, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
+                    N, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, addmod(a, b, N), evmGasLeft)
                 }
@@ -1588,9 +1588,9 @@ object "EVMInterpreter" {
             
                     let a, b, N
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
-                    N, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
+                    N, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, mulmod(a, b, N), evmGasLeft)
                 }
@@ -1599,8 +1599,8 @@ object "EVMInterpreter" {
             
                     let a, exponent
             
-                    a, sp := popStackItem(sp)
-                    exponent, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    exponent, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, exp(a, exponent), evmGasLeft)
             
@@ -1616,8 +1616,8 @@ object "EVMInterpreter" {
             
                     let b, x
             
-                    b, sp := popStackItem(sp)
-                    x, sp := popStackItem(sp)
+                    b, sp := popStackItem(sp, evmGasLeft)
+                    x, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, signextend(b, x), evmGasLeft)
                 }
@@ -1626,8 +1626,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, lt(a, b), evmGasLeft)
                 }
@@ -1636,8 +1636,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, gt(a, b), evmGasLeft)
                 }
@@ -1646,8 +1646,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, slt(a, b), evmGasLeft)
                 }
@@ -1656,8 +1656,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, sgt(a, b), evmGasLeft)
                 }
@@ -1666,8 +1666,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, eq(a, b), evmGasLeft)
                 }
@@ -1676,7 +1676,7 @@ object "EVMInterpreter" {
             
                     let a
             
-                    a, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, iszero(a), evmGasLeft)
                 }
@@ -1685,8 +1685,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, and(a,b), evmGasLeft)
                 }
@@ -1695,8 +1695,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, or(a,b), evmGasLeft)
                 }
@@ -1705,8 +1705,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, xor(a, b), evmGasLeft)
                 }
@@ -1715,7 +1715,7 @@ object "EVMInterpreter" {
             
                     let a
             
-                    a, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, not(a), evmGasLeft)
                 }
@@ -1724,8 +1724,8 @@ object "EVMInterpreter" {
             
                     let i, x
             
-                    i, sp := popStackItem(sp)
-                    x, sp := popStackItem(sp)
+                    i, sp := popStackItem(sp, evmGasLeft)
+                    x, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, byte(i, x), evmGasLeft)
                 }
@@ -1734,8 +1734,8 @@ object "EVMInterpreter" {
             
                     let shift, value
             
-                    shift, sp := popStackItem(sp)
-                    value, sp := popStackItem(sp)
+                    shift, sp := popStackItem(sp, evmGasLeft)
+                    value, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, shl(shift, value), evmGasLeft)
                 }
@@ -1744,8 +1744,8 @@ object "EVMInterpreter" {
             
                     let shift, value
             
-                    shift, sp := popStackItem(sp)
-                    value, sp := popStackItem(sp)
+                    shift, sp := popStackItem(sp, evmGasLeft)
+                    value, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, shr(shift, value), evmGasLeft)
                 }
@@ -1754,8 +1754,8 @@ object "EVMInterpreter" {
             
                     let shift, value
             
-                    shift, sp := popStackItem(sp)
-                    value, sp := popStackItem(sp)
+                    shift, sp := popStackItem(sp, evmGasLeft)
+                    value, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, sar(shift, value), evmGasLeft)
                 }
@@ -1764,8 +1764,8 @@ object "EVMInterpreter" {
             
                     let offset, size
             
-                    offset, sp := popStackItem(sp)
-                    size, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    size, sp := popStackItem(sp, evmGasLeft)
             
                     checkMultipleOverflow(offset, size, MEM_OFFSET_INNER(), evmGasLeft)
                     checkMemOverflow(add(MEM_OFFSET_INNER(), add(offset, size)), evmGasLeft)
@@ -1790,7 +1790,7 @@ object "EVMInterpreter" {
             
                     let addr
             
-                    addr, sp := popStackItem(sp)
+                    addr, sp := popStackItem(sp, evmGasLeft)
                     addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
             
                     if iszero(warmAddress(addr)) {
@@ -1819,7 +1819,7 @@ object "EVMInterpreter" {
             
                     let i
             
-                    i, sp := popStackItem(sp)
+                    i, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, calldataload(i), evmGasLeft)
                 }
@@ -1833,9 +1833,9 @@ object "EVMInterpreter" {
             
                     let destOffset, offset, size
             
-                    destOffset, sp := popStackItem(sp)
-                    offset, sp := popStackItem(sp)
-                    size, sp := popStackItem(sp)
+                    destOffset, sp := popStackItem(sp, evmGasLeft)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    size, sp := popStackItem(sp, evmGasLeft)
             
                     checkMultipleOverflow(offset,size,MEM_OFFSET_INNER(), evmGasLeft)
                     checkMultipleOverflow(destOffset,size,MEM_OFFSET_INNER(), evmGasLeft)
@@ -1869,9 +1869,9 @@ object "EVMInterpreter" {
             
                     let dst, offset, len
             
-                    dst, sp := popStackItem(sp)
-                    offset, sp := popStackItem(sp)
-                    len, sp := popStackItem(sp)
+                    dst, sp := popStackItem(sp, evmGasLeft)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    len, sp := popStackItem(sp, evmGasLeft)
             
                     // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
                     // minimum_word_size = (size + 31) / 32
@@ -1905,7 +1905,7 @@ object "EVMInterpreter" {
                     evmGasLeft := chargeGas(evmGasLeft, 100)
             
                     let addr
-                    addr, sp := popStackItem(sp)
+                    addr, sp := popStackItem(sp, evmGasLeft)
             
                     addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
                     if iszero(warmAddress(addr)) {
@@ -1934,9 +1934,9 @@ object "EVMInterpreter" {
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
                     let dest, offset, len
-                    dest, sp := popStackItem(sp)
-                    offset, sp := popStackItem(sp)
-                    len, sp := popStackItem(sp)
+                    dest, sp := popStackItem(sp, evmGasLeft)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    len, sp := popStackItem(sp, evmGasLeft)
             
                     // TODO: check if these conditions are met
                     // The addition offset + size overflows.
@@ -1958,7 +1958,7 @@ object "EVMInterpreter" {
                     evmGasLeft := chargeGas(evmGasLeft, 100)
             
                     let addr
-                    addr, sp := popStackItem(sp)
+                    addr, sp := popStackItem(sp, evmGasLeft)
                     addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
             
                     if iszero(warmAddress(addr)) {
@@ -1971,7 +1971,7 @@ object "EVMInterpreter" {
                     evmGasLeft := chargeGas(evmGasLeft, 20)
             
                     let blockNumber
-                    blockNumber, sp := popStackItem(sp)
+                    blockNumber, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, blockhash(blockNumber), evmGasLeft)
                 }
@@ -2012,14 +2012,14 @@ object "EVMInterpreter" {
             
                     let _y
             
-                    _y, sp := popStackItem(sp)
+                    _y, sp := popStackItem(sp, evmGasLeft)
                 }
                 case 0x51 { // OP_MLOAD
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
                     let offset
             
-                    offset, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
             
                     checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
                     let expansionGas := expandMemory(add(offset, 32))
@@ -2034,8 +2034,8 @@ object "EVMInterpreter" {
             
                     let offset, value
             
-                    offset, sp := popStackItem(sp)
-                    value, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    value, sp := popStackItem(sp, evmGasLeft)
             
                     checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
                     let expansionGas := expandMemory(add(offset, 32))
@@ -2049,8 +2049,8 @@ object "EVMInterpreter" {
             
                     let offset, value
             
-                    offset, sp := popStackItem(sp)
-                    value, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    value, sp := popStackItem(sp, evmGasLeft)
             
                     checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
                     let expansionGas := expandMemory(add(offset, 1))
@@ -2065,7 +2065,7 @@ object "EVMInterpreter" {
             
                     let key, value, isWarm
             
-                    key, sp := popStackItem(sp)
+                    key, sp := popStackItem(sp, evmGasLeft)
             
                     let wasWarm := isSlotWarm(key)
             
@@ -2091,8 +2091,8 @@ object "EVMInterpreter" {
             
                     let key, value, gasSpent
             
-                    key, sp := popStackItem(sp)
-                    value, sp := popStackItem(sp)
+                    key, sp := popStackItem(sp, evmGasLeft)
+                    value, sp := popStackItem(sp, evmGasLeft)
             
                     {
                         // Here it is okay to read before we charge since we known anyway that
@@ -2128,7 +2128,7 @@ object "EVMInterpreter" {
             
                     let counter
             
-                    counter, sp := popStackItem(sp)
+                    counter, sp := popStackItem(sp, evmGasLeft)
             
                     ip := add(add(BYTECODE_OFFSET(), 32), counter)
             
@@ -2143,8 +2143,8 @@ object "EVMInterpreter" {
             
                     let counter, b
             
-                    counter, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    counter, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     if iszero(b) {
                         continue
@@ -2186,7 +2186,7 @@ object "EVMInterpreter" {
                     evmGasLeft := chargeGas(evmGasLeft, 100)
             
                     let key
-                    key, sp := popStackItem(sp)
+                    key, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, tload(key), evmGasLeft)
                 }
@@ -2198,16 +2198,16 @@ object "EVMInterpreter" {
                     }
             
                     let key, value
-                    key, sp := popStackItem(sp)
-                    value, sp := popStackItem(sp)
+                    key, sp := popStackItem(sp, evmGasLeft)
+                    value, sp := popStackItem(sp, evmGasLeft)
             
                     tstore(key, value)
                 }
                 case 0x5E { // OP_MCOPY
                     let destOffset, offset, size
-                    destOffset, sp := popStackItem(sp)
-                    offset, sp := popStackItem(sp)
-                    size, sp := popStackItem(sp)
+                    destOffset, sp := popStackItem(sp, evmGasLeft)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    size, sp := popStackItem(sp, evmGasLeft)
             
                     expandMemory(add(destOffset, size))
                     expandMemory(add(offset, size))
@@ -2597,8 +2597,8 @@ object "EVMInterpreter" {
                     }
             
                     let offset, size
-                    offset, sp := popStackItem(sp)
-                    size, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    size, sp := popStackItem(sp, evmGasLeft)
             
                     checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
                     checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
@@ -2617,9 +2617,9 @@ object "EVMInterpreter" {
                     }
             
                     let offset, size, topic1
-                    offset, sp := popStackItem(sp)
-                    size, sp := popStackItem(sp)
-                    topic1, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    size, sp := popStackItem(sp, evmGasLeft)
+                    topic1, sp := popStackItem(sp, evmGasLeft)
             
                     checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
                     checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
@@ -2638,8 +2638,8 @@ object "EVMInterpreter" {
                     }
             
                     let offset, size
-                    offset, sp := popStackItem(sp)
-                    size, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    size, sp := popStackItem(sp, evmGasLeft)
             
                     checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
                     checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
@@ -2651,8 +2651,8 @@ object "EVMInterpreter" {
             
                     {
                         let topic1, topic2
-                        topic1, sp := popStackItem(sp)
-                        topic2, sp := popStackItem(sp)
+                        topic1, sp := popStackItem(sp, evmGasLeft)
+                        topic2, sp := popStackItem(sp, evmGasLeft)
                         log2(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2)
                     }
                 }
@@ -2664,8 +2664,8 @@ object "EVMInterpreter" {
                     }
             
                     let offset, size
-                    offset, sp := popStackItem(sp)
-                    size, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    size, sp := popStackItem(sp, evmGasLeft)
             
                     checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
             
@@ -2678,9 +2678,9 @@ object "EVMInterpreter" {
             
                     {
                         let topic1, topic2, topic3
-                        topic1, sp := popStackItem(sp)
-                        topic2, sp := popStackItem(sp)
-                        topic3, sp := popStackItem(sp)
+                        topic1, sp := popStackItem(sp, evmGasLeft)
+                        topic2, sp := popStackItem(sp, evmGasLeft)
+                        topic3, sp := popStackItem(sp, evmGasLeft)
                         log3(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2, topic3)
                     }     
                 }
@@ -2692,8 +2692,8 @@ object "EVMInterpreter" {
                     }
             
                     let offset, size
-                    offset, sp := popStackItem(sp)
-                    size, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    size, sp := popStackItem(sp, evmGasLeft)
             
                     checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
                     checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
@@ -2705,10 +2705,10 @@ object "EVMInterpreter" {
             
                     {
                         let topic1, topic2, topic3, topic4
-                        topic1, sp := popStackItem(sp)
-                        topic2, sp := popStackItem(sp)
-                        topic3, sp := popStackItem(sp)
-                        topic4, sp := popStackItem(sp)
+                        topic1, sp := popStackItem(sp, evmGasLeft)
+                        topic2, sp := popStackItem(sp, evmGasLeft)
+                        topic3, sp := popStackItem(sp, evmGasLeft)
+                        topic4, sp := popStackItem(sp, evmGasLeft)
                         log4(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2, topic3, topic4)
                     }     
                 }
@@ -2729,8 +2729,8 @@ object "EVMInterpreter" {
                 case 0xF3 { // OP_RETURN
                     let offset,size
             
-                    offset, sp := popStackItem(sp)
-                    size, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    size, sp := popStackItem(sp, evmGasLeft)
             
                     checkOverflow(offset,size, evmGasLeft)
                     evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
@@ -2765,8 +2765,8 @@ object "EVMInterpreter" {
                 case 0xFD { // OP_REVERT
                     let offset,size
             
-                    offset, sp := popStackItem(sp)
-                    size, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    size, sp := popStackItem(sp, evmGasLeft)
             
                     ensureAcceptableMemLocation(offset)
                     ensureAcceptableMemLocation(size)
@@ -2950,10 +2950,10 @@ object "EVMInterpreter" {
                 mstore(tempSp, s2)
             }
             
-            function popStackItem(sp) -> a, newSp {
+            function popStackItem(sp, evmGasLeft) -> a, newSp {
                 // We can not return any error here, because it would break compatibility
                 if lt(sp, STACK_OFFSET()) {
-                    revert(0, 0)
+                    revertWithGas(evmGasLeft)
                 }
             
                 a := mload(sp)
@@ -3682,12 +3682,12 @@ object "EVMInterpreter" {
             function performStaticCall(oldSp,evmGasLeft) -> extraCost, sp {
                 let gasToPass,addr, argsOffset, argsSize, retOffset, retSize
             
-                gasToPass, sp := popStackItem(oldSp)
-                addr, sp := popStackItem(sp)
-                argsOffset, sp := popStackItem(sp)
-                argsSize, sp := popStackItem(sp)
-                retOffset, sp := popStackItem(sp)
-                retSize, sp := popStackItem(sp)
+                gasToPass, sp := popStackItem(oldSp, evmGasLeft)
+                addr, sp := popStackItem(sp, evmGasLeft)
+                argsOffset, sp := popStackItem(sp, evmGasLeft)
+                argsSize, sp := popStackItem(sp, evmGasLeft)
+                retOffset, sp := popStackItem(sp, evmGasLeft)
+                retSize, sp := popStackItem(sp, evmGasLeft)
             
                 addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
             
@@ -3804,13 +3804,13 @@ object "EVMInterpreter" {
             function performCall(oldSp, evmGasLeft, isStatic) -> extraCost, sp {
                 let gasToPass,addr,value,argsOffset,argsSize,retOffset,retSize
             
-                gasToPass, sp := popStackItem(oldSp)
-                addr, sp := popStackItem(sp)
-                value, sp := popStackItem(sp)
-                argsOffset, sp := popStackItem(sp)
-                argsSize, sp := popStackItem(sp)
-                retOffset, sp := popStackItem(sp)
-                retSize, sp := popStackItem(sp)
+                gasToPass, sp := popStackItem(oldSp, evmGasLeft)
+                addr, sp := popStackItem(sp, evmGasLeft)
+                value, sp := popStackItem(sp, evmGasLeft)
+                argsOffset, sp := popStackItem(sp, evmGasLeft)
+                argsSize, sp := popStackItem(sp, evmGasLeft)
+                retOffset, sp := popStackItem(sp, evmGasLeft)
+                retSize, sp := popStackItem(sp, evmGasLeft)
             
                 addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
             
@@ -3872,12 +3872,12 @@ object "EVMInterpreter" {
                 sp := oldSp
                 isStatic := oldIsStatic
             
-                gasToPass, sp := popStackItem(sp)
-                addr, sp := popStackItem(sp)
-                argsOffset, sp := popStackItem(sp)
-                argsSize, sp := popStackItem(sp)
-                retOffset, sp := popStackItem(sp)
-                retSize, sp := popStackItem(sp)
+                gasToPass, sp := popStackItem(sp, evmGasLeft)
+                addr, sp := popStackItem(sp, evmGasLeft)
+                argsOffset, sp := popStackItem(sp, evmGasLeft)
+                argsSize, sp := popStackItem(sp, evmGasLeft)
+                retOffset, sp := popStackItem(sp, evmGasLeft)
+                retSize, sp := popStackItem(sp, evmGasLeft)
             
                 // addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
             
@@ -4076,13 +4076,13 @@ object "EVMInterpreter" {
             
                 let back
             
-                back, sp := popStackItem(sp)
+                back, sp := popStackItem(sp, evmGasLeft)
                 mstore(sub(offset, 0x20), back)
-                back, sp := popStackItem(sp)
+                back, sp := popStackItem(sp, evmGasLeft)
                 mstore(sub(offset, 0x40), back)
-                back, sp := popStackItem(sp)
+                back, sp := popStackItem(sp, evmGasLeft)
                 mstore(sub(offset, 0x60), back)
-                back, sp := popStackItem(sp)
+                back, sp := popStackItem(sp, evmGasLeft)
                 mstore(sub(offset, 0x80), back)
             }
             
@@ -4090,10 +4090,10 @@ object "EVMInterpreter" {
                 evmGasLeft := chargeGas(evmGas, 100)
             
                 let addr, dest, offset, len
-                addr, sp := popStackItem(oldSp)
-                dest, sp := popStackItem(sp)
-                offset, sp := popStackItem(sp)
-                len, sp := popStackItem(sp)
+                addr, sp := popStackItem(oldSp, evmGasLeft)
+                dest, sp := popStackItem(sp, evmGasLeft)
+                offset, sp := popStackItem(sp, evmGasLeft)
+                len, sp := popStackItem(sp, evmGasLeft)
             
                 // dynamicGas = 3 * minimum_word_size + memory_expansion_cost + address_access_cost
                 // minimum_word_size = (size + 31) / 32
@@ -4133,9 +4133,9 @@ object "EVMInterpreter" {
             
                 let value, offset, size
             
-                value, sp := popStackItem(oldSp)
-                offset, sp := popStackItem(sp)
-                size, sp := popStackItem(sp)
+                value, sp := popStackItem(oldSp, evmGasLeft)
+                offset, sp := popStackItem(sp, evmGasLeft)
+                size, sp := popStackItem(sp, evmGasLeft)
             
                 checkMultipleOverflow(offset, size, MEM_OFFSET_INNER(), evmGasLeft)
             
@@ -4178,10 +4178,10 @@ object "EVMInterpreter" {
             
                 let value, offset, size, salt
             
-                value, sp := popStackItem(oldSp)
-                offset, sp := popStackItem(sp)
-                size, sp := popStackItem(sp)
-                salt, sp := popStackItem(sp)
+                value, sp := popStackItem(oldSp, evmGasLeft)
+                offset, sp := popStackItem(sp, evmGasLeft)
+                size, sp := popStackItem(sp, evmGasLeft)
+                salt, sp := popStackItem(sp, evmGasLeft)
             
                 checkMultipleOverflow(offset, size, MEM_OFFSET_INNER(), evmGasLeft)
             
@@ -4265,8 +4265,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, add(a, b), evmGasLeft)
                 }
@@ -4275,8 +4275,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, mul(a, b), evmGasLeft)
                 }
@@ -4285,8 +4285,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, sub(a, b), evmGasLeft)
                 }
@@ -4295,8 +4295,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, div(a, b), evmGasLeft)
                 }
@@ -4305,8 +4305,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, sdiv(a, b), evmGasLeft)
                 }
@@ -4315,8 +4315,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, mod(a, b), evmGasLeft)
                 }
@@ -4325,8 +4325,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, smod(a, b), evmGasLeft)
                 }
@@ -4335,9 +4335,9 @@ object "EVMInterpreter" {
             
                     let a, b, N
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
-                    N, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
+                    N, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, addmod(a, b, N), evmGasLeft)
                 }
@@ -4346,9 +4346,9 @@ object "EVMInterpreter" {
             
                     let a, b, N
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
-                    N, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
+                    N, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, mulmod(a, b, N), evmGasLeft)
                 }
@@ -4357,8 +4357,8 @@ object "EVMInterpreter" {
             
                     let a, exponent
             
-                    a, sp := popStackItem(sp)
-                    exponent, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    exponent, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, exp(a, exponent), evmGasLeft)
             
@@ -4374,8 +4374,8 @@ object "EVMInterpreter" {
             
                     let b, x
             
-                    b, sp := popStackItem(sp)
-                    x, sp := popStackItem(sp)
+                    b, sp := popStackItem(sp, evmGasLeft)
+                    x, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, signextend(b, x), evmGasLeft)
                 }
@@ -4384,8 +4384,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, lt(a, b), evmGasLeft)
                 }
@@ -4394,8 +4394,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, gt(a, b), evmGasLeft)
                 }
@@ -4404,8 +4404,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, slt(a, b), evmGasLeft)
                 }
@@ -4414,8 +4414,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, sgt(a, b), evmGasLeft)
                 }
@@ -4424,8 +4424,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, eq(a, b), evmGasLeft)
                 }
@@ -4434,7 +4434,7 @@ object "EVMInterpreter" {
             
                     let a
             
-                    a, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, iszero(a), evmGasLeft)
                 }
@@ -4443,8 +4443,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, and(a,b), evmGasLeft)
                 }
@@ -4453,8 +4453,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, or(a,b), evmGasLeft)
                 }
@@ -4463,8 +4463,8 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    a, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, xor(a, b), evmGasLeft)
                 }
@@ -4473,7 +4473,7 @@ object "EVMInterpreter" {
             
                     let a
             
-                    a, sp := popStackItem(sp)
+                    a, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, not(a), evmGasLeft)
                 }
@@ -4482,8 +4482,8 @@ object "EVMInterpreter" {
             
                     let i, x
             
-                    i, sp := popStackItem(sp)
-                    x, sp := popStackItem(sp)
+                    i, sp := popStackItem(sp, evmGasLeft)
+                    x, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, byte(i, x), evmGasLeft)
                 }
@@ -4492,8 +4492,8 @@ object "EVMInterpreter" {
             
                     let shift, value
             
-                    shift, sp := popStackItem(sp)
-                    value, sp := popStackItem(sp)
+                    shift, sp := popStackItem(sp, evmGasLeft)
+                    value, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, shl(shift, value), evmGasLeft)
                 }
@@ -4502,8 +4502,8 @@ object "EVMInterpreter" {
             
                     let shift, value
             
-                    shift, sp := popStackItem(sp)
-                    value, sp := popStackItem(sp)
+                    shift, sp := popStackItem(sp, evmGasLeft)
+                    value, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, shr(shift, value), evmGasLeft)
                 }
@@ -4512,8 +4512,8 @@ object "EVMInterpreter" {
             
                     let shift, value
             
-                    shift, sp := popStackItem(sp)
-                    value, sp := popStackItem(sp)
+                    shift, sp := popStackItem(sp, evmGasLeft)
+                    value, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, sar(shift, value), evmGasLeft)
                 }
@@ -4522,8 +4522,8 @@ object "EVMInterpreter" {
             
                     let offset, size
             
-                    offset, sp := popStackItem(sp)
-                    size, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    size, sp := popStackItem(sp, evmGasLeft)
             
                     checkMultipleOverflow(offset, size, MEM_OFFSET_INNER(), evmGasLeft)
                     checkMemOverflow(add(MEM_OFFSET_INNER(), add(offset, size)), evmGasLeft)
@@ -4548,7 +4548,7 @@ object "EVMInterpreter" {
             
                     let addr
             
-                    addr, sp := popStackItem(sp)
+                    addr, sp := popStackItem(sp, evmGasLeft)
                     addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
             
                     if iszero(warmAddress(addr)) {
@@ -4577,7 +4577,7 @@ object "EVMInterpreter" {
             
                     let i
             
-                    i, sp := popStackItem(sp)
+                    i, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, calldataload(i), evmGasLeft)
                 }
@@ -4591,9 +4591,9 @@ object "EVMInterpreter" {
             
                     let destOffset, offset, size
             
-                    destOffset, sp := popStackItem(sp)
-                    offset, sp := popStackItem(sp)
-                    size, sp := popStackItem(sp)
+                    destOffset, sp := popStackItem(sp, evmGasLeft)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    size, sp := popStackItem(sp, evmGasLeft)
             
                     checkMultipleOverflow(offset,size,MEM_OFFSET_INNER(), evmGasLeft)
                     checkMultipleOverflow(destOffset,size,MEM_OFFSET_INNER(), evmGasLeft)
@@ -4627,9 +4627,9 @@ object "EVMInterpreter" {
             
                     let dst, offset, len
             
-                    dst, sp := popStackItem(sp)
-                    offset, sp := popStackItem(sp)
-                    len, sp := popStackItem(sp)
+                    dst, sp := popStackItem(sp, evmGasLeft)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    len, sp := popStackItem(sp, evmGasLeft)
             
                     // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
                     // minimum_word_size = (size + 31) / 32
@@ -4663,7 +4663,7 @@ object "EVMInterpreter" {
                     evmGasLeft := chargeGas(evmGasLeft, 100)
             
                     let addr
-                    addr, sp := popStackItem(sp)
+                    addr, sp := popStackItem(sp, evmGasLeft)
             
                     addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
                     if iszero(warmAddress(addr)) {
@@ -4692,9 +4692,9 @@ object "EVMInterpreter" {
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
                     let dest, offset, len
-                    dest, sp := popStackItem(sp)
-                    offset, sp := popStackItem(sp)
-                    len, sp := popStackItem(sp)
+                    dest, sp := popStackItem(sp, evmGasLeft)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    len, sp := popStackItem(sp, evmGasLeft)
             
                     // TODO: check if these conditions are met
                     // The addition offset + size overflows.
@@ -4716,7 +4716,7 @@ object "EVMInterpreter" {
                     evmGasLeft := chargeGas(evmGasLeft, 100)
             
                     let addr
-                    addr, sp := popStackItem(sp)
+                    addr, sp := popStackItem(sp, evmGasLeft)
                     addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
             
                     if iszero(warmAddress(addr)) {
@@ -4729,7 +4729,7 @@ object "EVMInterpreter" {
                     evmGasLeft := chargeGas(evmGasLeft, 20)
             
                     let blockNumber
-                    blockNumber, sp := popStackItem(sp)
+                    blockNumber, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, blockhash(blockNumber), evmGasLeft)
                 }
@@ -4770,14 +4770,14 @@ object "EVMInterpreter" {
             
                     let _y
             
-                    _y, sp := popStackItem(sp)
+                    _y, sp := popStackItem(sp, evmGasLeft)
                 }
                 case 0x51 { // OP_MLOAD
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
                     let offset
             
-                    offset, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
             
                     checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
                     let expansionGas := expandMemory(add(offset, 32))
@@ -4792,8 +4792,8 @@ object "EVMInterpreter" {
             
                     let offset, value
             
-                    offset, sp := popStackItem(sp)
-                    value, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    value, sp := popStackItem(sp, evmGasLeft)
             
                     checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
                     let expansionGas := expandMemory(add(offset, 32))
@@ -4807,8 +4807,8 @@ object "EVMInterpreter" {
             
                     let offset, value
             
-                    offset, sp := popStackItem(sp)
-                    value, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    value, sp := popStackItem(sp, evmGasLeft)
             
                     checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
                     let expansionGas := expandMemory(add(offset, 1))
@@ -4823,7 +4823,7 @@ object "EVMInterpreter" {
             
                     let key, value, isWarm
             
-                    key, sp := popStackItem(sp)
+                    key, sp := popStackItem(sp, evmGasLeft)
             
                     let wasWarm := isSlotWarm(key)
             
@@ -4849,8 +4849,8 @@ object "EVMInterpreter" {
             
                     let key, value, gasSpent
             
-                    key, sp := popStackItem(sp)
-                    value, sp := popStackItem(sp)
+                    key, sp := popStackItem(sp, evmGasLeft)
+                    value, sp := popStackItem(sp, evmGasLeft)
             
                     {
                         // Here it is okay to read before we charge since we known anyway that
@@ -4886,7 +4886,7 @@ object "EVMInterpreter" {
             
                     let counter
             
-                    counter, sp := popStackItem(sp)
+                    counter, sp := popStackItem(sp, evmGasLeft)
             
                     ip := add(add(BYTECODE_OFFSET(), 32), counter)
             
@@ -4901,8 +4901,8 @@ object "EVMInterpreter" {
             
                     let counter, b
             
-                    counter, sp := popStackItem(sp)
-                    b, sp := popStackItem(sp)
+                    counter, sp := popStackItem(sp, evmGasLeft)
+                    b, sp := popStackItem(sp, evmGasLeft)
             
                     if iszero(b) {
                         continue
@@ -4944,7 +4944,7 @@ object "EVMInterpreter" {
                     evmGasLeft := chargeGas(evmGasLeft, 100)
             
                     let key
-                    key, sp := popStackItem(sp)
+                    key, sp := popStackItem(sp, evmGasLeft)
             
                     sp := pushStackItem(sp, tload(key), evmGasLeft)
                 }
@@ -4956,16 +4956,16 @@ object "EVMInterpreter" {
                     }
             
                     let key, value
-                    key, sp := popStackItem(sp)
-                    value, sp := popStackItem(sp)
+                    key, sp := popStackItem(sp, evmGasLeft)
+                    value, sp := popStackItem(sp, evmGasLeft)
             
                     tstore(key, value)
                 }
                 case 0x5E { // OP_MCOPY
                     let destOffset, offset, size
-                    destOffset, sp := popStackItem(sp)
-                    offset, sp := popStackItem(sp)
-                    size, sp := popStackItem(sp)
+                    destOffset, sp := popStackItem(sp, evmGasLeft)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    size, sp := popStackItem(sp, evmGasLeft)
             
                     expandMemory(add(destOffset, size))
                     expandMemory(add(offset, size))
@@ -5355,8 +5355,8 @@ object "EVMInterpreter" {
                     }
             
                     let offset, size
-                    offset, sp := popStackItem(sp)
-                    size, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    size, sp := popStackItem(sp, evmGasLeft)
             
                     checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
                     checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
@@ -5375,9 +5375,9 @@ object "EVMInterpreter" {
                     }
             
                     let offset, size, topic1
-                    offset, sp := popStackItem(sp)
-                    size, sp := popStackItem(sp)
-                    topic1, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    size, sp := popStackItem(sp, evmGasLeft)
+                    topic1, sp := popStackItem(sp, evmGasLeft)
             
                     checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
                     checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
@@ -5396,8 +5396,8 @@ object "EVMInterpreter" {
                     }
             
                     let offset, size
-                    offset, sp := popStackItem(sp)
-                    size, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    size, sp := popStackItem(sp, evmGasLeft)
             
                     checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
                     checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
@@ -5409,8 +5409,8 @@ object "EVMInterpreter" {
             
                     {
                         let topic1, topic2
-                        topic1, sp := popStackItem(sp)
-                        topic2, sp := popStackItem(sp)
+                        topic1, sp := popStackItem(sp, evmGasLeft)
+                        topic2, sp := popStackItem(sp, evmGasLeft)
                         log2(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2)
                     }
                 }
@@ -5422,8 +5422,8 @@ object "EVMInterpreter" {
                     }
             
                     let offset, size
-                    offset, sp := popStackItem(sp)
-                    size, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    size, sp := popStackItem(sp, evmGasLeft)
             
                     checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
             
@@ -5436,9 +5436,9 @@ object "EVMInterpreter" {
             
                     {
                         let topic1, topic2, topic3
-                        topic1, sp := popStackItem(sp)
-                        topic2, sp := popStackItem(sp)
-                        topic3, sp := popStackItem(sp)
+                        topic1, sp := popStackItem(sp, evmGasLeft)
+                        topic2, sp := popStackItem(sp, evmGasLeft)
+                        topic3, sp := popStackItem(sp, evmGasLeft)
                         log3(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2, topic3)
                     }     
                 }
@@ -5450,8 +5450,8 @@ object "EVMInterpreter" {
                     }
             
                     let offset, size
-                    offset, sp := popStackItem(sp)
-                    size, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    size, sp := popStackItem(sp, evmGasLeft)
             
                     checkMultipleOverflow(offset, size,MEM_OFFSET_INNER(), evmGasLeft)
                     checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size), evmGasLeft)
@@ -5463,10 +5463,10 @@ object "EVMInterpreter" {
             
                     {
                         let topic1, topic2, topic3, topic4
-                        topic1, sp := popStackItem(sp)
-                        topic2, sp := popStackItem(sp)
-                        topic3, sp := popStackItem(sp)
-                        topic4, sp := popStackItem(sp)
+                        topic1, sp := popStackItem(sp, evmGasLeft)
+                        topic2, sp := popStackItem(sp, evmGasLeft)
+                        topic3, sp := popStackItem(sp, evmGasLeft)
+                        topic4, sp := popStackItem(sp, evmGasLeft)
                         log4(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2, topic3, topic4)
                     }     
                 }
@@ -5487,8 +5487,8 @@ object "EVMInterpreter" {
                 case 0xF3 { // OP_RETURN
                     let offset,size
             
-                    offset, sp := popStackItem(sp)
-                    size, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    size, sp := popStackItem(sp, evmGasLeft)
             
                     checkOverflow(offset,size, evmGasLeft)
                     evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
@@ -5523,8 +5523,8 @@ object "EVMInterpreter" {
                 case 0xFD { // OP_REVERT
                     let offset,size
             
-                    offset, sp := popStackItem(sp)
-                    size, sp := popStackItem(sp)
+                    offset, sp := popStackItem(sp, evmGasLeft)
+                    size, sp := popStackItem(sp, evmGasLeft)
             
                     ensureAcceptableMemLocation(offset)
                     ensureAcceptableMemLocation(size)

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -543,6 +543,19 @@ object "EVMInterpreter" {
             }
         }
         
+        function checkMultipleOverflow(data1,data2,data3) {
+            checkOverflow(data1,data2)
+            checkOverflow(data1,data3)
+            checkOverflow(data2,data3)
+            checkOverflow(add(data1,data2), data3)
+        }
+        
+        function checkOverflow(data1,data2) {
+            if lt(add(data1,data2),data2) {
+                revert(0,0)
+            }
+        }
+        
         // This function can overflow, it is the job of the caller to ensure that it does not.
         // The argument to this function is the offset into the memory region IN BYTES.
         function expandMemory(newSize) -> gasCost {
@@ -911,6 +924,9 @@ object "EVMInterpreter" {
             retOffset, sp := popStackItem(sp)
             retSize, sp := popStackItem(sp)
         
+            checkMultipleOverflow(argsOffset,argsSize,MEM_OFFSET_INNER())
+            checkMultipleOverflow(retOffset, retSize,MEM_OFFSET_INNER())
+        
             checkMemOverflow(add(add(argsOffset, argsSize), MEM_OFFSET_INNER()))
             checkMemOverflow(add(add(retOffset, retSize), MEM_OFFSET_INNER()))
         
@@ -1058,6 +1074,9 @@ object "EVMInterpreter" {
             argsOffset := add(argsOffset,MEM_OFFSET_INNER())
             retOffset := add(retOffset,MEM_OFFSET_INNER())
         
+            checkOverflow(argsOffset,argsSize)
+            checkOverflow(retOffset,retSize)
+        
             checkMemOverflow(add(argsOffset, argsSize))
             checkMemOverflow(add(retOffset, retSize))
         
@@ -1090,6 +1109,9 @@ object "EVMInterpreter" {
             argsSize, sp := popStackItem(sp)
             retOffset, sp := popStackItem(sp)
             retSize, sp := popStackItem(sp)
+        
+            checkMultipleOverflow(argsOffset,argsSize,MEM_OFFSET_INNER())
+            checkMultipleOverflow(retOffset, retSize,MEM_OFFSET_INNER())
         
             checkMemOverflow(add(add(argsOffset, argsSize), MEM_OFFSET_INNER()))
             checkMemOverflow(add(add(retOffset, retSize), MEM_OFFSET_INNER()))
@@ -1351,6 +1373,8 @@ object "EVMInterpreter" {
             offset, sp := popStackItem(sp)
             size, sp := popStackItem(sp)
         
+            checkMultipleOverflow(offset, size, MEM_OFFSET_INNER())
+        
             checkMemOverflow(add(MEM_OFFSET_INNER(), add(offset, size)))
         
             if gt(size, mul(2, MAX_POSSIBLE_BYTECODE())) {
@@ -1394,6 +1418,8 @@ object "EVMInterpreter" {
             offset, sp := popStackItem(sp)
             size, sp := popStackItem(sp)
             salt, sp := popStackItem(sp)
+        
+            checkMultipleOverflow(offset, size, MEM_OFFSET_INNER())
         
             checkMemOverflow(add(MEM_OFFSET_INNER(), add(offset, size)))
         
@@ -1794,6 +1820,9 @@ object "EVMInterpreter" {
                     offset, sp := popStackItem(sp)
                     size, sp := popStackItem(sp)
             
+                    checkMultipleOverflow(offset,size,MEM_OFFSET_INNER())
+                    checkMultipleOverflow(destOffset,size,MEM_OFFSET_INNER())
+            
                     checkMemOverflow(add(add(offset, size), MEM_OFFSET_INNER()))
                     checkMemOverflow(add(add(destOffset, size), MEM_OFFSET_INNER()))
             
@@ -1829,6 +1858,7 @@ object "EVMInterpreter" {
                     dst := add(dst, MEM_OFFSET_INNER())
                     offset := add(add(offset, BYTECODE_OFFSET()), 32)
             
+                    checkOverflow(dst,len)
                     checkMemOverflow(add(dst, len))
                     // Check bytecode overflow
                     if gt(add(offset, len), sub(MEM_OFFSET(), 1)) {
@@ -1889,6 +1919,7 @@ object "EVMInterpreter" {
                     if gt(add(offset, len), LAST_RETURNDATA_SIZE_OFFSET()) {
                         revert(0, 0)
                     }
+                    checkMultipleOverflow(offset,len,MEM_OFFSET_INNER())
                     checkMemOverflow(add(add(dest, MEM_OFFSET_INNER()), len))
             
                     // minimum_word_size = (size + 31) / 32
@@ -2491,6 +2522,8 @@ object "EVMInterpreter" {
                     offset, sp := popStackItem(sp)
                     size, sp := popStackItem(sp)
             
+                    checkMultipleOverflow(offset, size,MEM_OFFSET_INNER())
+            
                     checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size))
             
                     // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
@@ -2511,6 +2544,8 @@ object "EVMInterpreter" {
                     size, sp := popStackItem(sp)
                     topic1, sp := popStackItem(sp)
             
+                    checkMultipleOverflow(offset, size,MEM_OFFSET_INNER())
+            
                     checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size))
             
                     // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
@@ -2529,6 +2564,8 @@ object "EVMInterpreter" {
                     let offset, size
                     offset, sp := popStackItem(sp)
                     size, sp := popStackItem(sp)
+            
+                    checkMultipleOverflow(offset, size,MEM_OFFSET_INNER())
             
                     checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size))
             
@@ -2555,6 +2592,8 @@ object "EVMInterpreter" {
                     offset, sp := popStackItem(sp)
                     size, sp := popStackItem(sp)
             
+                    checkMultipleOverflow(offset, size,MEM_OFFSET_INNER())
+            
                     checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size))
             
                     // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
@@ -2580,6 +2619,8 @@ object "EVMInterpreter" {
                     let offset, size
                     offset, sp := popStackItem(sp)
                     size, sp := popStackItem(sp)
+            
+                    checkMultipleOverflow(offset, size,MEM_OFFSET_INNER())
             
                     checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size))
             
@@ -3175,6 +3216,19 @@ object "EVMInterpreter" {
                 }
             }
             
+            function checkMultipleOverflow(data1,data2,data3) {
+                checkOverflow(data1,data2)
+                checkOverflow(data1,data3)
+                checkOverflow(data2,data3)
+                checkOverflow(add(data1,data2), data3)
+            }
+            
+            function checkOverflow(data1,data2) {
+                if lt(add(data1,data2),data2) {
+                    revert(0,0)
+                }
+            }
+            
             // This function can overflow, it is the job of the caller to ensure that it does not.
             // The argument to this function is the offset into the memory region IN BYTES.
             function expandMemory(newSize) -> gasCost {
@@ -3543,6 +3597,9 @@ object "EVMInterpreter" {
                 retOffset, sp := popStackItem(sp)
                 retSize, sp := popStackItem(sp)
             
+                checkMultipleOverflow(argsOffset,argsSize,MEM_OFFSET_INNER())
+                checkMultipleOverflow(retOffset, retSize,MEM_OFFSET_INNER())
+            
                 checkMemOverflow(add(add(argsOffset, argsSize), MEM_OFFSET_INNER()))
                 checkMemOverflow(add(add(retOffset, retSize), MEM_OFFSET_INNER()))
             
@@ -3690,6 +3747,9 @@ object "EVMInterpreter" {
                 argsOffset := add(argsOffset,MEM_OFFSET_INNER())
                 retOffset := add(retOffset,MEM_OFFSET_INNER())
             
+                checkOverflow(argsOffset,argsSize)
+                checkOverflow(retOffset,retSize)
+            
                 checkMemOverflow(add(argsOffset, argsSize))
                 checkMemOverflow(add(retOffset, retSize))
             
@@ -3722,6 +3782,9 @@ object "EVMInterpreter" {
                 argsSize, sp := popStackItem(sp)
                 retOffset, sp := popStackItem(sp)
                 retSize, sp := popStackItem(sp)
+            
+                checkMultipleOverflow(argsOffset,argsSize,MEM_OFFSET_INNER())
+                checkMultipleOverflow(retOffset, retSize,MEM_OFFSET_INNER())
             
                 checkMemOverflow(add(add(argsOffset, argsSize), MEM_OFFSET_INNER()))
                 checkMemOverflow(add(add(retOffset, retSize), MEM_OFFSET_INNER()))
@@ -3983,6 +4046,8 @@ object "EVMInterpreter" {
                 offset, sp := popStackItem(sp)
                 size, sp := popStackItem(sp)
             
+                checkMultipleOverflow(offset, size, MEM_OFFSET_INNER())
+            
                 checkMemOverflow(add(MEM_OFFSET_INNER(), add(offset, size)))
             
                 if gt(size, mul(2, MAX_POSSIBLE_BYTECODE())) {
@@ -4026,6 +4091,8 @@ object "EVMInterpreter" {
                 offset, sp := popStackItem(sp)
                 size, sp := popStackItem(sp)
                 salt, sp := popStackItem(sp)
+            
+                checkMultipleOverflow(offset, size, MEM_OFFSET_INNER())
             
                 checkMemOverflow(add(MEM_OFFSET_INNER(), add(offset, size)))
             
@@ -4437,6 +4504,9 @@ object "EVMInterpreter" {
                     offset, sp := popStackItem(sp)
                     size, sp := popStackItem(sp)
             
+                    checkMultipleOverflow(offset,size,MEM_OFFSET_INNER())
+                    checkMultipleOverflow(destOffset,size,MEM_OFFSET_INNER())
+            
                     checkMemOverflow(add(add(offset, size), MEM_OFFSET_INNER()))
                     checkMemOverflow(add(add(destOffset, size), MEM_OFFSET_INNER()))
             
@@ -4472,6 +4542,7 @@ object "EVMInterpreter" {
                     dst := add(dst, MEM_OFFSET_INNER())
                     offset := add(add(offset, BYTECODE_OFFSET()), 32)
             
+                    checkOverflow(dst,len)
                     checkMemOverflow(add(dst, len))
                     // Check bytecode overflow
                     if gt(add(offset, len), sub(MEM_OFFSET(), 1)) {
@@ -4532,6 +4603,7 @@ object "EVMInterpreter" {
                     if gt(add(offset, len), LAST_RETURNDATA_SIZE_OFFSET()) {
                         revert(0, 0)
                     }
+                    checkMultipleOverflow(offset,len,MEM_OFFSET_INNER())
                     checkMemOverflow(add(add(dest, MEM_OFFSET_INNER()), len))
             
                     // minimum_word_size = (size + 31) / 32
@@ -5134,6 +5206,8 @@ object "EVMInterpreter" {
                     offset, sp := popStackItem(sp)
                     size, sp := popStackItem(sp)
             
+                    checkMultipleOverflow(offset, size,MEM_OFFSET_INNER())
+            
                     checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size))
             
                     // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
@@ -5154,6 +5228,8 @@ object "EVMInterpreter" {
                     size, sp := popStackItem(sp)
                     topic1, sp := popStackItem(sp)
             
+                    checkMultipleOverflow(offset, size,MEM_OFFSET_INNER())
+            
                     checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size))
             
                     // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
@@ -5172,6 +5248,8 @@ object "EVMInterpreter" {
                     let offset, size
                     offset, sp := popStackItem(sp)
                     size, sp := popStackItem(sp)
+            
+                    checkMultipleOverflow(offset, size,MEM_OFFSET_INNER())
             
                     checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size))
             
@@ -5198,6 +5276,8 @@ object "EVMInterpreter" {
                     offset, sp := popStackItem(sp)
                     size, sp := popStackItem(sp)
             
+                    checkMultipleOverflow(offset, size,MEM_OFFSET_INNER())
+            
                     checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size))
             
                     // dynamicGas = 375 * topic_count + 8 * size + memory_expansion_cost
@@ -5223,6 +5303,8 @@ object "EVMInterpreter" {
                     let offset, size
                     offset, sp := popStackItem(sp)
                     size, sp := popStackItem(sp)
+            
+                    checkMultipleOverflow(offset, size,MEM_OFFSET_INNER())
             
                     checkMemOverflow(add(add(offset, MEM_OFFSET_INNER()), size))
             

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -1034,7 +1034,7 @@ object "EVMInterpreter" {
         
             if and(is_evm, iszero(isStatic)) {
                 _pushEVMFrame(gasToPassNew, isStatic)
-                success := call(gasToPassNew, addr, value, argsOffset, argsSize, 0, 0)
+                success := call(EVM_GAS_STIPEND(), addr, value, argsOffset, argsSize, 0, 0)
                 frameGasLeft := _saveReturndataAfterEVMCall(retOffset, retSize)
                 _popEVMFrame()
             }
@@ -1165,7 +1165,7 @@ object "EVMInterpreter" {
             _pushEVMFrame(gasToPass, isStatic)
             let success := delegatecall(
                 // We can not just pass all gas here to prevert overflow of zkEVM gas counter
-                gasToPass,
+                EVM_GAS_STIPEND(),
                 addr,
                 add(MEM_OFFSET_INNER(), argsOffset),
                 argsSize,
@@ -1227,7 +1227,7 @@ object "EVMInterpreter" {
                 _pushEVMFrame(_calleeGas, true)
                 // TODO Check the following comment from zkSync .sol.
                 // We can not just pass all gas here to prevert overflow of zkEVM gas counter
-                success := staticcall(_calleeGas, _callee, _inputOffset, _inputLen, 0, 0)
+                success := staticcall(EVM_GAS_STIPEND(), _callee, _inputOffset, _inputLen, 0, 0)
         
                 _gasLeft := _saveReturndataAfterEVMCall(_outputOffset, _outputLen)
                 _popEVMFrame()
@@ -3782,7 +3782,7 @@ object "EVMInterpreter" {
             
                 if and(is_evm, iszero(isStatic)) {
                     _pushEVMFrame(gasToPassNew, isStatic)
-                    success := call(gasToPassNew, addr, value, argsOffset, argsSize, 0, 0)
+                    success := call(EVM_GAS_STIPEND(), addr, value, argsOffset, argsSize, 0, 0)
                     frameGasLeft := _saveReturndataAfterEVMCall(retOffset, retSize)
                     _popEVMFrame()
                 }
@@ -3913,7 +3913,7 @@ object "EVMInterpreter" {
                 _pushEVMFrame(gasToPass, isStatic)
                 let success := delegatecall(
                     // We can not just pass all gas here to prevert overflow of zkEVM gas counter
-                    gasToPass,
+                    EVM_GAS_STIPEND(),
                     addr,
                     add(MEM_OFFSET_INNER(), argsOffset),
                     argsSize,
@@ -3975,7 +3975,7 @@ object "EVMInterpreter" {
                     _pushEVMFrame(_calleeGas, true)
                     // TODO Check the following comment from zkSync .sol.
                     // We can not just pass all gas here to prevert overflow of zkEVM gas counter
-                    success := staticcall(_calleeGas, _callee, _inputOffset, _inputLen, 0, 0)
+                    success := staticcall(EVM_GAS_STIPEND(), _callee, _inputOffset, _inputLen, 0, 0)
             
                     _gasLeft := _saveReturndataAfterEVMCall(_outputOffset, _outputLen)
                     _popEVMFrame()

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -2001,6 +2001,7 @@ object "EVMInterpreter" {
                     let expansionGas := expandMemory(offset) // TODO: add +32 here
                     evmGasLeft := chargeGas(evmGasLeft, expansionGas)
             
+                    checkOverflow(offset,MEM_OFFSET_INNER())
                     let memValue := mload(add(MEM_OFFSET_INNER(), offset))
                     sp := pushStackItem(sp, memValue)
                 }
@@ -2015,6 +2016,7 @@ object "EVMInterpreter" {
                     let expansionGas := expandMemory(offset) // TODO: add +32 here
                     evmGasLeft := chargeGas(evmGasLeft, expansionGas)
             
+                    checkOverflow(offset,MEM_OFFSET_INNER())
                     mstore(add(MEM_OFFSET_INNER(), offset), value)
                 }
                 case 0x53 { // OP_MSTORE8
@@ -2028,6 +2030,7 @@ object "EVMInterpreter" {
                     let expansionGas := expandMemory(offset) // TODO: add +1 here
                     evmGasLeft := chargeGas(evmGasLeft, expansionGas)
             
+                    checkOverflow(offset,MEM_OFFSET_INNER())
                     mstore8(add(MEM_OFFSET_INNER(), offset), value)
                 }
                 case 0x54 { // OP_SLOAD
@@ -2660,8 +2663,9 @@ object "EVMInterpreter" {
                     offset, sp := popStackItem(sp)
                     size, sp := popStackItem(sp)
             
-                    ensureAcceptableMemLocation(offset)
-                    ensureAcceptableMemLocation(size)
+            
+                    checkOverflow(offset,size)
+                    ensureAcceptableMemLocation(add(offset,size))
                     evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
             
                     returnLen := size
@@ -4687,6 +4691,7 @@ object "EVMInterpreter" {
                     let expansionGas := expandMemory(offset) // TODO: add +32 here
                     evmGasLeft := chargeGas(evmGasLeft, expansionGas)
             
+                    checkOverflow(offset,MEM_OFFSET_INNER())
                     let memValue := mload(add(MEM_OFFSET_INNER(), offset))
                     sp := pushStackItem(sp, memValue)
                 }
@@ -4701,6 +4706,7 @@ object "EVMInterpreter" {
                     let expansionGas := expandMemory(offset) // TODO: add +32 here
                     evmGasLeft := chargeGas(evmGasLeft, expansionGas)
             
+                    checkOverflow(offset,MEM_OFFSET_INNER())
                     mstore(add(MEM_OFFSET_INNER(), offset), value)
                 }
                 case 0x53 { // OP_MSTORE8
@@ -4714,6 +4720,7 @@ object "EVMInterpreter" {
                     let expansionGas := expandMemory(offset) // TODO: add +1 here
                     evmGasLeft := chargeGas(evmGasLeft, expansionGas)
             
+                    checkOverflow(offset,MEM_OFFSET_INNER())
                     mstore8(add(MEM_OFFSET_INNER(), offset), value)
                 }
                 case 0x54 { // OP_SLOAD
@@ -5346,8 +5353,9 @@ object "EVMInterpreter" {
                     offset, sp := popStackItem(sp)
                     size, sp := popStackItem(sp)
             
-                    ensureAcceptableMemLocation(offset)
-                    ensureAcceptableMemLocation(size)
+            
+                    checkOverflow(offset,size)
+                    ensureAcceptableMemLocation(add(offset,size))
                     evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
             
                     returnLen := size

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -1126,6 +1126,8 @@ object "EVMInterpreter" {
             retOffset, sp := popStackItem(sp)
             retSize, sp := popStackItem(sp)
         
+            // addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
+        
             checkMultipleOverflow(argsOffset,argsSize,MEM_OFFSET_INNER(), evmGasLeft)
             checkMultipleOverflow(retOffset, retSize,MEM_OFFSET_INNER(), evmGasLeft)
         
@@ -3862,6 +3864,8 @@ object "EVMInterpreter" {
                 argsSize, sp := popStackItem(sp)
                 retOffset, sp := popStackItem(sp)
                 retSize, sp := popStackItem(sp)
+            
+                // addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
             
                 checkMultipleOverflow(argsOffset,argsSize,MEM_OFFSET_INNER(), evmGasLeft)
                 checkMultipleOverflow(retOffset, retSize,MEM_OFFSET_INNER(), evmGasLeft)

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -2665,10 +2665,11 @@ object "EVMInterpreter" {
             
             
                     checkOverflow(offset,size)
-                    ensureAcceptableMemLocation(add(offset,size))
+                    //checkMemOverflow(add(offset,size))
                     evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
             
                     returnLen := size
+                    checkOverflow(offset,MEM_OFFSET_INNER())
                     returnOffset := add(MEM_OFFSET_INNER(), offset)
                     break
                 }
@@ -5355,10 +5356,11 @@ object "EVMInterpreter" {
             
             
                     checkOverflow(offset,size)
-                    ensureAcceptableMemLocation(add(offset,size))
+                    //checkMemOverflow(add(offset,size))
                     evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
             
                     returnLen := size
+                    checkOverflow(offset,MEM_OFFSET_INNER())
                     returnOffset := add(MEM_OFFSET_INNER(), offset)
                     break
                 }
@@ -5415,6 +5417,7 @@ object "EVMInterpreter" {
             if eq(isCallerEVM, 1) {
                 // Includes gas
                 returnOffset := sub(returnOffset, 32)
+                checkOverflow(returnLen, 32)
                 returnLen := add(returnLen, 32)
 
                 mstore(returnOffset, evmGasLeft)

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -1919,8 +1919,7 @@ object "EVMInterpreter" {
                     // The addition offset + size overflows.
                     // offset + size is larger than RETURNDATASIZE.
                     checkOverflow(offset,len)
-                    let rdz := mload(LAST_RETURNDATA_SIZE_OFFSET())
-                    if gt(add(offset, len), rdz) {
+                    if gt(add(offset, len), mload(LAST_RETURNDATA_SIZE_OFFSET())) {
                         revert(0, 0)
                     }
             
@@ -4610,8 +4609,7 @@ object "EVMInterpreter" {
                     // The addition offset + size overflows.
                     // offset + size is larger than RETURNDATASIZE.
                     checkOverflow(offset,len)
-                    let rdz := mload(LAST_RETURNDATA_SIZE_OFFSET())
-                    if gt(add(offset, len), rdz) {
+                    if gt(add(offset, len), mload(LAST_RETURNDATA_SIZE_OFFSET())) {
                         revert(0, 0)
                     }
             

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -2172,6 +2172,23 @@ object "EVMInterpreter" {
                 case 0x5B { // OP_JUMPDEST
                     evmGasLeft := chargeGas(evmGasLeft, 1)
                 }
+                case 0x5C { // OP_TLOAD
+                    evmGasLeft := chargeGas(evmGasLeft, 100)
+            
+                    let key
+                    key, sp := popStackItem(sp)
+            
+                    sp := pushStackItem(sp, tload(key))
+                }
+                case 0x5D { // OP_TSTORE
+                    evmGasLeft := chargeGas(evmGasLeft, 100)
+            
+                    let key, value
+                    key, sp := popStackItem(sp)
+                    value, sp := popStackItem(sp)
+            
+                    tstore(key, value)
+                }
                 case 0x5E { // OP_MCOPY
                     let destOffset, offset, size
                     destOffset, sp := popStackItem(sp)
@@ -4899,6 +4916,23 @@ object "EVMInterpreter" {
                 }
                 case 0x5B { // OP_JUMPDEST
                     evmGasLeft := chargeGas(evmGasLeft, 1)
+                }
+                case 0x5C { // OP_TLOAD
+                    evmGasLeft := chargeGas(evmGasLeft, 100)
+            
+                    let key
+                    key, sp := popStackItem(sp)
+            
+                    sp := pushStackItem(sp, tload(key))
+                }
+                case 0x5D { // OP_TSTORE
+                    evmGasLeft := chargeGas(evmGasLeft, 100)
+            
+                    let key, value
+                    key, sp := popStackItem(sp)
+                    value, sp := popStackItem(sp)
+            
+                    tstore(key, value)
                 }
                 case 0x5E { // OP_MCOPY
                     let destOffset, offset, size

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -869,7 +869,7 @@ object "EVMInterpreter" {
             if lt(sub(_gas,shl(30,1)), requiredGas) {
                 // This cheks if enough zkevm gas was provided, we are substracting 2^30 since that's the stipend, 
                 // and we need to make sure that the gas provided over that is enough for security reasons
-                // revert(0, 0)
+                revert(0, 0)
             }
             evmGas := div(sub(_gas, requiredGas), GAS_DIVISOR())
         }
@@ -1790,6 +1790,7 @@ object "EVMInterpreter" {
                     let addr
             
                     addr, sp := popStackItem(sp)
+                    addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
             
                     if iszero(warmAddress(addr)) {
                         evmGasLeft := chargeGas(evmGasLeft, 2500)
@@ -2071,7 +2072,6 @@ object "EVMInterpreter" {
                     
                 }
                 case 0x55 { // OP_SSTORE
-                
                     evmGasLeft := chargeGas(evmGasLeft, 100)
             
                     if isStatic {
@@ -3605,7 +3605,7 @@ object "EVMInterpreter" {
                 if lt(sub(_gas,shl(30,1)), requiredGas) {
                     // This cheks if enough zkevm gas was provided, we are substracting 2^30 since that's the stipend, 
                     // and we need to make sure that the gas provided over that is enough for security reasons
-                    // revert(0, 0)
+                    revert(0, 0)
                 }
                 evmGas := div(sub(_gas, requiredGas), GAS_DIVISOR())
             }
@@ -4537,6 +4537,7 @@ object "EVMInterpreter" {
                     let addr
             
                     addr, sp := popStackItem(sp)
+                    addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
             
                     if iszero(warmAddress(addr)) {
                         evmGasLeft := chargeGas(evmGasLeft, 2500)
@@ -4818,7 +4819,6 @@ object "EVMInterpreter" {
                     
                 }
                 case 0x55 { // OP_SSTORE
-                
                     evmGasLeft := chargeGas(evmGasLeft, 100)
             
                     if isStatic {

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -1949,6 +1949,7 @@ object "EVMInterpreter" {
             
                     let addr
                     addr, sp := popStackItem(sp)
+                    addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
             
                     if iszero(warmAddress(addr)) {
                         evmGasLeft := chargeGas(evmGasLeft, 2500) 
@@ -4696,6 +4697,7 @@ object "EVMInterpreter" {
             
                     let addr
                     addr, sp := popStackItem(sp)
+                    addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
             
                     if iszero(warmAddress(addr)) {
                         evmGasLeft := chargeGas(evmGasLeft, 2500) 

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -1918,11 +1918,11 @@ object "EVMInterpreter" {
                     // TODO: check if these conditions are met
                     // The addition offset + size overflows.
                     // offset + size is larger than RETURNDATASIZE.
-                    if gt(add(offset, len), LAST_RETURNDATA_SIZE_OFFSET()) {
+                    checkOverflow(offset,len)
+                    let rdz := mload(LAST_RETURNDATA_SIZE_OFFSET())
+                    if gt(add(offset, len), rdz) {
                         revert(0, 0)
                     }
-                    checkMultipleOverflow(offset,len,MEM_OFFSET_INNER())
-                    checkMemOverflow(add(add(dest, MEM_OFFSET_INNER()), len))
             
                     // minimum_word_size = (size + 31) / 32
                     // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
@@ -4604,11 +4604,11 @@ object "EVMInterpreter" {
                     // TODO: check if these conditions are met
                     // The addition offset + size overflows.
                     // offset + size is larger than RETURNDATASIZE.
-                    if gt(add(offset, len), LAST_RETURNDATA_SIZE_OFFSET()) {
+                    checkOverflow(offset,len)
+                    let rdz := mload(LAST_RETURNDATA_SIZE_OFFSET())
+                    if gt(add(offset, len), rdz) {
                         revert(0, 0)
                     }
-                    checkMultipleOverflow(offset,len,MEM_OFFSET_INNER())
-                    checkMemOverflow(add(add(dest, MEM_OFFSET_INNER()), len))
             
                     // minimum_word_size = (size + 31) / 32
                     // dynamicGas = 3 * minimum_word_size + memory_expansion_cost

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -1847,8 +1847,14 @@ object "EVMInterpreter" {
                     checkMultipleOverflow(offset,size,MEM_OFFSET_INNER(), evmGasLeft)
                     checkMultipleOverflow(destOffset,size,MEM_OFFSET_INNER(), evmGasLeft)
             
-                    checkMemOverflow(add(add(offset, size), MEM_OFFSET_INNER()), evmGasLeft)
-                    checkMemOverflow(add(add(destOffset, size), MEM_OFFSET_INNER()), evmGasLeft)
+                    if or(gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM()), gt(add(add(destOffset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM())) {
+                        for { let i := 0 } lt(i, size) { i := add(i, 1) } {
+                            mstore8(
+                                add(add(destOffset, MEM_OFFSET_INNER()), i),
+                                0
+                            )
+                        }
+                    }
             
                     // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
                     // minimum_word_size = (size + 31) / 32
@@ -4606,8 +4612,14 @@ object "EVMInterpreter" {
                     checkMultipleOverflow(offset,size,MEM_OFFSET_INNER(), evmGasLeft)
                     checkMultipleOverflow(destOffset,size,MEM_OFFSET_INNER(), evmGasLeft)
             
-                    checkMemOverflow(add(add(offset, size), MEM_OFFSET_INNER()), evmGasLeft)
-                    checkMemOverflow(add(add(destOffset, size), MEM_OFFSET_INNER()), evmGasLeft)
+                    if or(gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM()), gt(add(add(destOffset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM())) {
+                        for { let i := 0 } lt(i, size) { i := add(i, 1) } {
+                            mstore8(
+                                add(add(destOffset, MEM_OFFSET_INNER()), i),
+                                0
+                            )
+                        }
+                    }
             
                     // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
                     // minimum_word_size = (size + 31) / 32


### PR DESCRIPTION
# What ❔
This PR fixes bugs found using era-compiler-tester, most of them related to overflow checks.

A full description of the bugs and their fixes below.

### Empty Return Data

We were not returning gas on reverts, which made a lot of tests fail on a check by the `compiler-tester` after execution where it tried to retrieve gas used from the return data and it was empty. We added gas on reverts so now those errors are no longer there.

### `mcopy`

Some tests fail because compiling them with the `solc` version used by the project, they internally generate `mcopy` opcodes, which we do not support because we target Shanghai, not Cancun. We added a basic implementation of `mcopy` that makes tests pass, though it's very inefficient since there is no `mcopy` opcode on the zkEVM.

The `mcopy` tests are the following:
- tests/solidity/simple/error/revert5.sol::first[f:1]
- tests/solidity/simple/internal_function_pointers/data_structures.sol::double[calculate:1]
- tests/solidity/simple/internal_function_pointers/data_structures.sol::triple[calculate:1]
- tests/solidity/simple/solidity_by_example/simple/structs.sol::first[get:2]
- tests/solidity/simple/solidity_by_example/simple/structs.sol::second[get:5]
- tests/solidity/simple/solidity_by_example/simple/structs.sol::second[get:6]
- tests/solidity/simple/constants/ConstantBytes.sol::long
- tests/solidity/simple/solidity_by_example/simple/hello_world.sol::get[greet:1]
- tests/solidity/simple/solidity_by_example/simple/variables.sol::text[text:2]
- tests/solidity/simple/events/3_topics.sol::default[test:1]
-  tests/solidity/simple/events/4_topics.sol::default[test:1]
- tests/solidity/simple/solidity_by_example/simple/verifying_signature.sol::test[verify:1]
- tests/solidity/simple/solidity_by_example/simple/shadowing_inherited_state_variables.sol::test[getName:1]
- tests/solidity/simple/try_catch/error_as_bytes.sol::main[main:1]
- tests/solidity/simple/try_catch/revert_long_data.sol::main[main:1]
- tests/solidity/simple/solidity_by_example/applications/merkle_tree.sol::test[#deployer:tests/solidity/simple/solidity_by_example/applications/merkle_tree.sol:Test]
-  tests/solidity/simple/solidity_by_example/applications/merkle_tree.sol::test[getRoot:1]
- tests/solidity/simple/solidity_by_example/applications/merkle_tree.sol::test[verify:2]

### `returndatacopy` with size less than expected

Some solidity programs (especially those using `try/catch` statements) pass a certain `size` when performing a call, but if execution reverts the actual return data size can be smaller than `size`. We were not handling that correctly when copying the return data; now the behaviour correctly mimics the EVM one: when saving the return data from a call we copy the minimum amount of bytes between the one requested and the return data size. You can check out the `geth` code for that [here](https://github.com/ethereum/go-ethereum/blob/master/core/vm/instructions.go#L680).

Tests that were failing because of this were:

- tests/solidity/simple/call_with_dirty_address.sol::default[test:1]
- tests/solidity/simple/try_catch/not_payable.sol::main[main:1]
- tests/solidity/simple/try_catch/external_call_as_arg.sol::false_true[main:1]
- tests/solidity/simple/try_catch/nested.sol::false_false[main:1]
- tests/solidity/simple/try_catch/nested.sol::false_true[main:1]
- tests/solidity/simple/try_catch/nested.sol::true_false[main:1]
- tests/solidity/simple/function/function_type/f6.sol::test[f:1]

### Truncated addresses

The following test

- tests/solidity/simple/call_with_dirty_address.sol::default[test:1] Return data is empty

failed because we were not truncating addresses to `bytes20` before calling contracts on the call opcodes.

### `mstore8/mstore` and return data too long

These two tests try to store a value to a memory location far exceeding the maximum the interpreter allows (`0x1101e0`).

- tests/solidity/simple/yul_instructions/mstore8.sol::zero_value 
- tests/solidity/simple/yul_instructions/mstore.sol::zero_value

This test:

- tests/solidity/simple/try_catch/return_long_data_in_constructor.sol::main

fails because the return data tries to allocate more memory than is possible on the interpreter.

These three tests are the only ones that are not yet fixed, but we believe in the context of the interpreter it makes sense that they do not pass. It might be a good idea to skip them.

### Overflow checks

All the other tests failed because of missing overflow checks on opcodes. They were fixed. Note that for those opcodes their implementation becomes a bit more expensive. For the special case of  `keccak` opcode, we had to add some overflow checks before actually calling `keccak` only to be able to insert the gas left on reverts, because the opcode does not do it on its own.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
