### PR TITLE
chore(ci): Additional permissions for CI token

### DIFF
--- a/.github/workflows/l1-contracts-ci.yaml
+++ b/.github/workflows/l1-contracts-ci.yaml
@@ -3,6 +3,11 @@ name: L1 contracts CI
 on:
   pull_request:
 
+# We need this permissions for this CI to work with external contributions
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# What ❔

Granting additional permissions for CI generated token

## Why ❔

This will fiix problem when external contributors can't get coverage report due to insufficient permissions.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
