### PR TITLE
[EVM Equivalence] Fix evm contract nonces starting at 0 instead of 1

### DIFF
--- a/system-contracts/contracts/ContractDeployer.sol
+++ b/system-contracts/contracts/ContractDeployer.sol
@@ -187,7 +187,7 @@ contract ContractDeployer is IContractDeployer, ISystemContract {
         // Subtract 1 for EOA since the nonce has already been incremented for this transaction
         uint256 senderNonce = msg.sender == tx.origin
             ? NONCE_HOLDER_SYSTEM_CONTRACT.getMinNonce(msg.sender) - 1
-            : NONCE_HOLDER_SYSTEM_CONTRACT.incrementDeploymentNonce(msg.sender);
+            : NONCE_HOLDER_SYSTEM_CONTRACT.incrementDeploymentNonce(msg.sender) + 1;
         address newAddress = Utils.getNewAddressCreateEVM(msg.sender, senderNonce);
         _evmDeployOnAddress(newAddress, _initCode);
         return newAddress;


### PR DESCRIPTION
# What ❔

This PR changes the `createEVM` function on the `ContractDeployer` to add 1 to returned contract nonces (the `incrementDeploymentNonce` function increments it but returns the previous value), as on zkSync deployment nonces start out at zero, while contract nonces on ethereum start at 1 after EIP 161.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
