### PR TITLE
[EVM-Equivalence-YUL] Optimize opcodes further

### DIFF
--- a/system-contracts/contracts/EvmInterpreterFunctions.template.yul
+++ b/system-contracts/contracts/EvmInterpreterFunctions.template.yul
@@ -1252,7 +1252,7 @@ function _fetchConstructorReturnGas() -> gasLeft {
     gasLeft := mload(0)
 }
 
-function genericCreate(addr, offset, size, sp, value, evmGasLeftOld) -> result, evmGasLeft {
+function $llvm_NoInline_llvm$_genericCreate(addr, offset, size, sp, value, evmGasLeftOld) -> result, evmGasLeft {
     pop($llvm_AlwaysInline_llvm$_warmAddress(addr))
 
     _eraseReturndataPointer()
@@ -1401,7 +1401,7 @@ function performCreate(evmGas,oldSp,isStatic) -> evmGasLeft, sp {
     let addr := getNewAddress(address())
 
     let result
-    result, evmGasLeft := genericCreate(addr, offset, size, sp, value, evmGasLeft)
+    result, evmGasLeft := $llvm_NoInline_llvm$_genericCreate(addr, offset, size, sp, value, evmGasLeft)
 
     switch result
         case 0 { sp := pushStackItem(sp, 0, evmGasLeft) }
@@ -1458,5 +1458,5 @@ function performCreate2(evmGas, oldSp, isStatic) -> evmGasLeft, sp, result, addr
         0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
     )
 
-    result, evmGasLeft := genericCreate(addr, offset, size, sp, value, evmGasLeft) 
+    result, evmGasLeft := $llvm_NoInline_llvm$_genericCreate(addr, offset, size, sp, value, evmGasLeft)
 }

--- a/system-contracts/contracts/EvmInterpreterFunctions.template.yul
+++ b/system-contracts/contracts/EvmInterpreterFunctions.template.yul
@@ -1265,10 +1265,10 @@ function $llvm_NoInline_llvm$_genericCreate(addr, offset, size, sp, value, evmGa
 
     offset := add(MEM_OFFSET_INNER(), offset)
 
-    sp := pushStackItem(sp, mload(sub(offset, 0x80)), evmGasLeft)
-    sp := pushStackItem(sp, mload(sub(offset, 0x60)), evmGasLeft)
-    sp := pushStackItem(sp, mload(sub(offset, 0x40)), evmGasLeft)
-    sp := pushStackItem(sp, mload(sub(offset, 0x20)), evmGasLeft)
+    sp := pushStackItem(sp, mload(sub(offset, 0x80)), evmGasLeftOld)
+    sp := pushStackItem(sp, mload(sub(offset, 0x60)), evmGasLeftOld)
+    sp := pushStackItem(sp, mload(sub(offset, 0x40)), evmGasLeftOld)
+    sp := pushStackItem(sp, mload(sub(offset, 0x20)), evmGasLeftOld)
 
     // Selector
     mstore(sub(offset, 0x80), 0x5b16a23c)

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -10,8 +10,6 @@ let maxAcceptablePos := add(add(BYTECODE_OFFSET(), mload(BYTECODE_OFFSET())), 31
 for { } true { } {
     opcode := readIP(ip,maxAcceptablePos)
 
-    ip := add(ip, 1)
-
     switch opcode
     case 0x00 { // OP_STOP
         break
@@ -26,6 +24,7 @@ for { } true { } {
         b, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, add(a, b))
+        ip := add(ip, 1)
     }
     case 0x02 { // OP_MUL
         evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -37,6 +36,7 @@ for { } true { } {
         b, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, mul(a, b))
+        ip := add(ip, 1)
     }
     case 0x03 { // OP_SUB
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -48,6 +48,7 @@ for { } true { } {
         b, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, sub(a, b))
+        ip := add(ip, 1)
     }
     case 0x04 { // OP_DIV
         evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -59,6 +60,7 @@ for { } true { } {
         b, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, div(a, b))
+        ip := add(ip, 1)
     }
     case 0x05 { // OP_SDIV
         evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -70,6 +72,7 @@ for { } true { } {
         b, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, sdiv(a, b))
+        ip := add(ip, 1)
     }
     case 0x06 { // OP_MOD
         evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -81,6 +84,7 @@ for { } true { } {
         b, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, mod(a, b))
+        ip := add(ip, 1)
     }
     case 0x07 { // OP_SMOD
         evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -92,6 +96,7 @@ for { } true { } {
         b, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, smod(a, b))
+        ip := add(ip, 1)
     }
     case 0x08 { // OP_ADDMOD
         evmGasLeft := chargeGas(evmGasLeft, 8)
@@ -104,6 +109,7 @@ for { } true { } {
         N, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, addmod(a, b, N))
+        ip := add(ip, 1)
     }
     case 0x09 { // OP_MULMOD
         evmGasLeft := chargeGas(evmGasLeft, 8)
@@ -116,6 +122,7 @@ for { } true { } {
         N, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItem(sp, mulmod(a, b, N), evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x0A { // OP_EXP
         evmGasLeft := chargeGas(evmGasLeft, 10)
@@ -134,6 +141,7 @@ for { } true { } {
             exponent := shr(8, exponent)
         } 
         evmGasLeft := chargeGas(evmGasLeft, to_charge)
+        ip := add(ip, 1)
     }
     case 0x0B { // OP_SIGNEXTEND
         evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -145,6 +153,7 @@ for { } true { } {
         x, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, signextend(b, x))
+        ip := add(ip, 1)
     }
     case 0x10 { // OP_LT
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -156,6 +165,7 @@ for { } true { } {
         b, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, lt(a, b))
+        ip := add(ip, 1)
     }
     case 0x11 { // OP_GT
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -167,6 +177,7 @@ for { } true { } {
         b, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, gt(a, b))
+        ip := add(ip, 1)
     }
     case 0x12 { // OP_SLT
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -178,6 +189,7 @@ for { } true { } {
         b, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, slt(a, b))
+        ip := add(ip, 1)
     }
     case 0x13 { // OP_SGT
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -189,6 +201,7 @@ for { } true { } {
         b, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, sgt(a, b))
+        ip := add(ip, 1)
     }
     case 0x14 { // OP_EQ
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -200,6 +213,7 @@ for { } true { } {
         b, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, eq(a, b))
+        ip := add(ip, 1)
     }
     case 0x15 { // OP_ISZERO
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -210,6 +224,7 @@ for { } true { } {
         a, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, iszero(a))
+        ip := add(ip, 1)
     }
     case 0x16 { // OP_AND
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -221,6 +236,7 @@ for { } true { } {
         b, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, and(a,b))
+        ip := add(ip, 1)
     }
     case 0x17 { // OP_OR
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -232,6 +248,7 @@ for { } true { } {
         b, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, or(a,b))
+        ip := add(ip, 1)
     }
     case 0x18 { // OP_XOR
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -243,6 +260,7 @@ for { } true { } {
         b, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, xor(a, b))
+        ip := add(ip, 1)
     }
     case 0x19 { // OP_NOT
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -253,6 +271,7 @@ for { } true { } {
         a, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, not(a))
+        ip := add(ip, 1)
     }
     case 0x1A { // OP_BYTE
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -264,6 +283,7 @@ for { } true { } {
         x, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, byte(i, x))
+        ip := add(ip, 1)
     }
     case 0x1B { // OP_SHL
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -275,6 +295,7 @@ for { } true { } {
         value, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, shl(shift, value))
+        ip := add(ip, 1)
     }
     case 0x1C { // OP_SHR
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -286,6 +307,7 @@ for { } true { } {
         value, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, shr(shift, value))
+        ip := add(ip, 1)
     }
     case 0x1D { // OP_SAR
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -297,6 +319,7 @@ for { } true { } {
         value, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, sar(shift, value))
+        ip := add(ip, 1)
     }
     case 0x20 { // OP_KECCAK256
         evmGasLeft := chargeGas(evmGasLeft, 30)
@@ -319,11 +342,13 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
 
         sp := pushStackItem(sp, keccak, evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x30 { // OP_ADDRESS
         evmGasLeft := chargeGas(evmGasLeft, 2)
 
         sp := pushStackItem(sp, address(), evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x31 { // OP_BALANCE
         evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -338,21 +363,25 @@ for { } true { } {
         }
 
         sp := pushStackItem(sp, balance(addr), evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x32 { // OP_ORIGIN
         evmGasLeft := chargeGas(evmGasLeft, 2)
 
         sp := pushStackItem(sp, origin(), evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x33 { // OP_CALLER
         evmGasLeft := chargeGas(evmGasLeft, 2)
 
         sp := pushStackItem(sp, caller(), evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x34 { // OP_CALLVALUE
         evmGasLeft := chargeGas(evmGasLeft, 2)
 
         sp := pushStackItem(sp, callvalue(), evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x35 { // OP_CALLDATALOAD
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -363,11 +392,13 @@ for { } true { } {
         i, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, calldataload(i))
+        ip := add(ip, 1)
     }
     case 0x36 { // OP_CALLDATASIZE
         evmGasLeft := chargeGas(evmGasLeft, 2)
 
         sp := pushStackItem(sp, calldatasize(), evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x37 { // OP_CALLDATACOPY
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -397,6 +428,7 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
 
         calldatacopy(add(destOffset, MEM_OFFSET_INNER()), offset, size)
+        ip := add(ip, 1)
         
     }
     case 0x38 { // OP_CODESIZE
@@ -404,6 +436,7 @@ for { } true { } {
 
         let bytecodeLen := mload(BYTECODE_OFFSET())
         sp := pushStackItem(sp, bytecodeLen, evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x39 { // OP_CODECOPY
     
@@ -437,12 +470,13 @@ for { } true { } {
                 shr(248, mload(add(offset, i)))
             )
         }
-        
+        ip := add(ip, 1)
     }
     case 0x3A { // OP_GASPRICE
         evmGasLeft := chargeGas(evmGasLeft, 2)
 
         sp := pushStackItem(sp, gasprice(), evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x3B { // OP_EXTCODESIZE
         evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -463,15 +497,18 @@ for { } true { } {
         switch _isEVM(addr) 
             case 0  { sp := pushStackItem(sp, extcodesize(addr), evmGasLeft) }
             default { sp := pushStackItem(sp, _fetchDeployedCodeLen(addr), evmGasLeft) }
+        ip := add(ip, 1)
     }
     case 0x3C { // OP_EXTCODECOPY
         evmGasLeft, sp := performExtCodeCopy(evmGasLeft, sp)
+        ip := add(ip, 1)
     }
     case 0x3D { // OP_RETURNDATASIZE
         evmGasLeft := chargeGas(evmGasLeft, 2)
 
         let rdz := mload(LAST_RETURNDATA_SIZE_OFFSET())
         sp := pushStackItem(sp, rdz, evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x3E { // OP_RETURNDATACOPY
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -497,6 +534,7 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
 
         copyActivePtrData(add(MEM_OFFSET_INNER(), dest), offset, len)
+        ip := add(ip, 1)
     }
     case 0x3F { // OP_EXTCODEHASH
         evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -509,6 +547,7 @@ for { } true { } {
             evmGasLeft := chargeGas(evmGasLeft, 2500) 
         }
 
+        ip := add(ip, 1)
         if iszero(addr) {
             sp := pushStackItem(sp, 0, evmGasLeft)
             continue
@@ -523,38 +562,47 @@ for { } true { } {
         blockNumber, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, blockhash(blockNumber))
+        ip := add(ip, 1)
     }
     case 0x41 { // OP_COINBASE
         evmGasLeft := chargeGas(evmGasLeft, 2)
         sp := pushStackItem(sp, coinbase(), evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x42 { // OP_TIMESTAMP
         evmGasLeft := chargeGas(evmGasLeft, 2)
         sp := pushStackItem(sp, timestamp(), evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x43 { // OP_NUMBER
         evmGasLeft := chargeGas(evmGasLeft, 2)
         sp := pushStackItem(sp, number(), evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x44 { // OP_PREVRANDAO
         evmGasLeft := chargeGas(evmGasLeft, 2)
         sp := pushStackItem(sp, prevrandao(), evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x45 { // OP_GASLIMIT
         evmGasLeft := chargeGas(evmGasLeft, 2)
         sp := pushStackItem(sp, gaslimit(), evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x46 { // OP_CHAINID
         evmGasLeft := chargeGas(evmGasLeft, 2)
         sp := pushStackItem(sp, chainid(), evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x47 { // OP_SELFBALANCE
         evmGasLeft := chargeGas(evmGasLeft, 5)
         sp := pushStackItem(sp, selfbalance(), evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x48 { // OP_BASEFEE
         evmGasLeft := chargeGas(evmGasLeft, 2)
         sp := pushStackItem(sp, basefee(), evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x50 { // OP_POP
         evmGasLeft := chargeGas(evmGasLeft, 2)
@@ -562,6 +610,7 @@ for { } true { } {
         let _y
 
         _y, sp := popStackItem(sp, evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x51 { // OP_MLOAD
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -577,6 +626,7 @@ for { } true { } {
         checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
         let memValue := mload(add(MEM_OFFSET_INNER(), offset))
         sp := pushStackItem(sp, memValue, evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x52 { // OP_MSTORE
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -593,6 +643,7 @@ for { } true { } {
 
         checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
         mstore(add(MEM_OFFSET_INNER(), offset), value)
+        ip := add(ip, 1)
     }
     case 0x53 { // OP_MSTORE8
         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -609,6 +660,7 @@ for { } true { } {
 
         checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
         mstore8(add(MEM_OFFSET_INNER(), offset), value)
+        ip := add(ip, 1)
     }
     case 0x54 { // OP_SLOAD
     
@@ -631,7 +683,7 @@ for { } true { } {
         }
 
         sp := pushStackItem(sp,value, evmGasLeft)
-        
+        ip := add(ip, 1)
     }
     case 0x55 { // OP_SSTORE
         evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -646,6 +698,7 @@ for { } true { } {
         key, sp := popStackItemWithoutCheck(sp)
         value, sp := popStackItemWithoutCheck(sp)
 
+        ip := add(ip, 1)
         {
             // Here it is okay to read before we charge since we known anyway that
             // the context has enough funds to compensate at least for the read.
@@ -700,6 +753,7 @@ for { } true { } {
         b, sp := popStackItemWithoutCheck(sp)
 
         if iszero(b) {
+            ip := add(ip, 1)
             continue
         }
 
@@ -713,6 +767,7 @@ for { } true { } {
     }
     case 0x58 { // OP_PC
         evmGasLeft := chargeGas(evmGasLeft, 2)
+        ip := add(ip, 1)
 
         // PC = ip - 32 (bytecode size) - 1 (current instruction)
         sp := pushStackItem(sp, sub(sub(ip, BYTECODE_OFFSET()), 33), evmGasLeft)
@@ -725,15 +780,17 @@ for { } true { } {
         size := mload(MEM_OFFSET())
         size := shl(5,size)
         sp := pushStackItem(sp,size, evmGasLeft)
-
+        ip := add(ip, 1)
     }
     case 0x5A { // OP_GAS
         evmGasLeft := chargeGas(evmGasLeft, 2)
 
         sp := pushStackItem(sp, evmGasLeft, evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x5B { // OP_JUMPDEST
         evmGasLeft := chargeGas(evmGasLeft, 1)
+        ip := add(ip, 1)
     }
     case 0x5C { // OP_TLOAD
         evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -743,6 +800,7 @@ for { } true { } {
         key, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, tload(key))
+        ip := add(ip, 1)
     }
     case 0x5D { // OP_TSTORE
         evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -757,6 +815,7 @@ for { } true { } {
         value, sp := popStackItemWithoutCheck(sp)
 
         tstore(key, value)
+        ip := add(ip, 1)
     }
     case 0x5E { // OP_MCOPY
         let destOffset, offset, size
@@ -785,6 +844,7 @@ for { } true { } {
                 shr(248,mload(add(add(oldSize,MEM_OFFSET_INNER()), i)))
             )
         }
+        ip := add(ip, 1)
     }
     case 0x5F { // OP_PUSH0
         evmGasLeft := chargeGas(evmGasLeft, 2)
@@ -792,10 +852,12 @@ for { } true { } {
         let value := 0
 
         sp := pushStackItem(sp, value, evmGasLeft)
+        ip := add(ip, 1)
     }
     case 0x60 { // OP_PUSH1
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,1)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -804,6 +866,7 @@ for { } true { } {
     case 0x61 { // OP_PUSH2
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,2)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -812,6 +875,7 @@ for { } true { } {
     case 0x62 { // OP_PUSH3
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,3)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -820,6 +884,7 @@ for { } true { } {
     case 0x63 { // OP_PUSH4
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,4)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -828,6 +893,7 @@ for { } true { } {
     case 0x64 { // OP_PUSH5
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,5)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -836,6 +902,7 @@ for { } true { } {
     case 0x65 { // OP_PUSH6
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,6)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -844,6 +911,7 @@ for { } true { } {
     case 0x66 { // OP_PUSH7
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,7)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -852,6 +920,7 @@ for { } true { } {
     case 0x67 { // OP_PUSH8
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,8)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -860,6 +929,7 @@ for { } true { } {
     case 0x68 { // OP_PUSH9
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,9)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -868,6 +938,7 @@ for { } true { } {
     case 0x69 { // OP_PUSH10
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,10)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -876,6 +947,7 @@ for { } true { } {
     case 0x6A { // OP_PUSH11
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,11)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -884,6 +956,7 @@ for { } true { } {
     case 0x6B { // OP_PUSH12
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,12)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -892,6 +965,7 @@ for { } true { } {
     case 0x6C { // OP_PUSH13
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,13)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -900,6 +974,7 @@ for { } true { } {
     case 0x6D { // OP_PUSH14
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,14)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -908,6 +983,7 @@ for { } true { } {
     case 0x6E { // OP_PUSH15
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,15)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -916,6 +992,7 @@ for { } true { } {
     case 0x6F { // OP_PUSH16
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,16)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -924,6 +1001,7 @@ for { } true { } {
     case 0x70 { // OP_PUSH17
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,17)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -932,6 +1010,7 @@ for { } true { } {
     case 0x71 { // OP_PUSH18
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,18)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -940,6 +1019,7 @@ for { } true { } {
     case 0x72 { // OP_PUSH19
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,19)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -948,6 +1028,7 @@ for { } true { } {
     case 0x73 { // OP_PUSH20
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,20)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -956,6 +1037,7 @@ for { } true { } {
     case 0x74 { // OP_PUSH21
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,21)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -964,6 +1046,7 @@ for { } true { } {
     case 0x75 { // OP_PUSH22
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,22)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -972,6 +1055,7 @@ for { } true { } {
     case 0x76 { // OP_PUSH23
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,23)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -980,6 +1064,7 @@ for { } true { } {
     case 0x77 { // OP_PUSH24
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,24)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -988,6 +1073,7 @@ for { } true { } {
     case 0x78 { // OP_PUSH25
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,25)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -996,6 +1082,7 @@ for { } true { } {
     case 0x79 { // OP_PUSH26
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,26)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -1004,6 +1091,7 @@ for { } true { } {
     case 0x7A { // OP_PUSH27
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,27)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -1012,6 +1100,7 @@ for { } true { } {
     case 0x7B { // OP_PUSH28
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,28)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -1020,6 +1109,7 @@ for { } true { } {
     case 0x7C { // OP_PUSH29
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,29)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -1028,6 +1118,7 @@ for { } true { } {
     case 0x7D { // OP_PUSH30
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,30)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -1036,6 +1127,7 @@ for { } true { } {
     case 0x7E { // OP_PUSH31
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,31)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -1044,6 +1136,7 @@ for { } true { } {
     case 0x7F { // OP_PUSH32
         evmGasLeft := chargeGas(evmGasLeft, 3)
 
+        ip := add(ip, 1)
         let value := readBytes(ip,maxAcceptablePos,32)
 
         sp := pushStackItem(sp, value, evmGasLeft)
@@ -1051,99 +1144,131 @@ for { } true { } {
     }
     case 0x80 { // OP_DUP1 
         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 1)
+        ip := add(ip, 1)
     }
     case 0x81 { // OP_DUP2
         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 2)
+        ip := add(ip, 1)
     }
     case 0x82 { // OP_DUP3
         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 3)
+        ip := add(ip, 1)
     }
     case 0x83 { // OP_DUP4    
         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 4)
+        ip := add(ip, 1)
     }
     case 0x84 { // OP_DUP5
         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 5)
+        ip := add(ip, 1)
     }
     case 0x85 { // OP_DUP6
         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 6)
+        ip := add(ip, 1)
     }
     case 0x86 { // OP_DUP7    
         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 7)
+        ip := add(ip, 1)
     }
     case 0x87 { // OP_DUP8
         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 8)
+        ip := add(ip, 1)
     }
     case 0x88 { // OP_DUP9
         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 9)
+        ip := add(ip, 1)
     }
     case 0x89 { // OP_DUP10   
         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 10)
+        ip := add(ip, 1)
     }
     case 0x8A { // OP_DUP11
         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 11)
+        ip := add(ip, 1)
     }
     case 0x8B { // OP_DUP12
         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 12)
+        ip := add(ip, 1)
     }
     case 0x8C { // OP_DUP13
         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 13)
+        ip := add(ip, 1)
     }
     case 0x8D { // OP_DUP14
         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 14)
+        ip := add(ip, 1)
     }
     case 0x8E { // OP_DUP15
         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 15)
+        ip := add(ip, 1)
     }
     case 0x8F { // OP_DUP16
         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 16)
+        ip := add(ip, 1)
     }
     case 0x90 { // OP_SWAP1 
         evmGasLeft := swapStackItem(sp, evmGasLeft, 1)
+        ip := add(ip, 1)
     }
     case 0x91 { // OP_SWAP2
         evmGasLeft := swapStackItem(sp, evmGasLeft, 2)
+        ip := add(ip, 1)
     }
     case 0x92 { // OP_SWAP3
         evmGasLeft := swapStackItem(sp, evmGasLeft, 3)
+        ip := add(ip, 1)
     }
     case 0x93 { // OP_SWAP4    
         evmGasLeft := swapStackItem(sp, evmGasLeft, 4)
+        ip := add(ip, 1)
     }
     case 0x94 { // OP_SWAP5
         evmGasLeft := swapStackItem(sp, evmGasLeft, 5)
+        ip := add(ip, 1)
     }
     case 0x95 { // OP_SWAP6
         evmGasLeft := swapStackItem(sp, evmGasLeft, 6)
+        ip := add(ip, 1)
     }
     case 0x96 { // OP_SWAP7    
         evmGasLeft := swapStackItem(sp, evmGasLeft, 7)
+        ip := add(ip, 1)
     }
     case 0x97 { // OP_SWAP8
         evmGasLeft := swapStackItem(sp, evmGasLeft, 8)
+        ip := add(ip, 1)
     }
     case 0x98 { // OP_SWAP9
         evmGasLeft := swapStackItem(sp, evmGasLeft, 9)
+        ip := add(ip, 1)
     }
     case 0x99 { // OP_SWAP10   
         evmGasLeft := swapStackItem(sp, evmGasLeft, 10)
+        ip := add(ip, 1)
     }
     case 0x9A { // OP_SWAP11
         evmGasLeft := swapStackItem(sp, evmGasLeft, 11)
+        ip := add(ip, 1)
     }
     case 0x9B { // OP_SWAP12
         evmGasLeft := swapStackItem(sp, evmGasLeft, 12)
+        ip := add(ip, 1)
     }
     case 0x9C { // OP_SWAP13
         evmGasLeft := swapStackItem(sp, evmGasLeft, 13)
+        ip := add(ip, 1)
     }
     case 0x9D { // OP_SWAP14
         evmGasLeft := swapStackItem(sp, evmGasLeft, 14)
+        ip := add(ip, 1)
     }
     case 0x9E { // OP_SWAP15
         evmGasLeft := swapStackItem(sp, evmGasLeft, 15)
+        ip := add(ip, 1)
     }
     case 0x9F { // OP_SWAP16
         evmGasLeft := swapStackItem(sp, evmGasLeft, 16)
+        ip := add(ip, 1)
     }
     case 0xA0 { // OP_LOG0
         evmGasLeft := chargeGas(evmGasLeft, 375)
@@ -1165,6 +1290,7 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
 
         log0(add(offset, MEM_OFFSET_INNER()), size)
+        ip := add(ip, 1)
     }
     case 0xA1 { // OP_LOG1
         evmGasLeft := chargeGas(evmGasLeft, 375)
@@ -1188,6 +1314,7 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
 
         log1(add(offset, MEM_OFFSET_INNER()), size, topic1)
+        ip := add(ip, 1)
     }
     case 0xA2 { // OP_LOG2
         evmGasLeft := chargeGas(evmGasLeft, 375)
@@ -1215,6 +1342,7 @@ for { } true { } {
             topic2, sp := popStackItemWithoutCheck(sp)
             log2(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2)
         }
+        ip := add(ip, 1)
     }
     case 0xA3 { // OP_LOG3
         evmGasLeft := chargeGas(evmGasLeft, 375)
@@ -1245,6 +1373,7 @@ for { } true { } {
             topic3, sp := popStackItemWithoutCheck(sp)
             log3(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2, topic3)
         }     
+        ip := add(ip, 1)
     }
     case 0xA4 { // OP_LOG4
         evmGasLeft := chargeGas(evmGasLeft, 375)
@@ -1275,9 +1404,11 @@ for { } true { } {
             topic4, sp := popStackItemWithoutCheck(sp)
             log4(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2, topic3, topic4)
         }     
+        ip := add(ip, 1)
     }
     case 0xF0 { // OP_CREATE
         evmGasLeft, sp := performCreate(evmGasLeft, sp, isStatic)
+        ip := add(ip, 1)
     }
     case 0xF1 { // OP_CALL
         evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -1289,6 +1420,7 @@ for { } true { } {
 
         // Check if the following is ok
         evmGasLeft := chargeGas(evmGasLeft, gasUsed)
+        ip := add(ip, 1)
     }
     case 0xF3 { // OP_RETURN
         let offset,size
@@ -1312,6 +1444,7 @@ for { } true { } {
         sp, isStatic, gasUsed := delegateCall(sp, isStatic, evmGasLeft)
 
         evmGasLeft := chargeGas(evmGasLeft, gasUsed)
+        ip := add(ip, 1)
     }
     case 0xF5 { // OP_CREATE2
         let result, addr
@@ -1319,6 +1452,7 @@ for { } true { } {
         switch result
         case 0 { sp := pushStackItem(sp, 0, evmGasLeft) }
         default { sp := pushStackItem(sp, addr, evmGasLeft) }
+        ip := add(ip, 1)
     }
     case 0xFA { // OP_STATICCALL
         evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -1326,6 +1460,7 @@ for { } true { } {
         let gasUsed
         gasUsed, sp := performStaticCall(sp,evmGasLeft)
         evmGasLeft := chargeGas(evmGasLeft,gasUsed)
+        ip := add(ip, 1)
     }
     case 0xFD { // OP_REVERT
         let offset,size

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -1339,10 +1339,10 @@ object "EVMInterpreter" {
         
             offset := add(MEM_OFFSET_INNER(), offset)
         
-            sp := pushStackItem(sp, mload(sub(offset, 0x80)), evmGasLeft)
-            sp := pushStackItem(sp, mload(sub(offset, 0x60)), evmGasLeft)
-            sp := pushStackItem(sp, mload(sub(offset, 0x40)), evmGasLeft)
-            sp := pushStackItem(sp, mload(sub(offset, 0x20)), evmGasLeft)
+            sp := pushStackItem(sp, mload(sub(offset, 0x80)), evmGasLeftOld)
+            sp := pushStackItem(sp, mload(sub(offset, 0x60)), evmGasLeftOld)
+            sp := pushStackItem(sp, mload(sub(offset, 0x40)), evmGasLeftOld)
+            sp := pushStackItem(sp, mload(sub(offset, 0x20)), evmGasLeftOld)
         
             // Selector
             mstore(sub(offset, 0x80), 0x5b16a23c)
@@ -4334,10 +4334,10 @@ object "EVMInterpreter" {
             
                 offset := add(MEM_OFFSET_INNER(), offset)
             
-                sp := pushStackItem(sp, mload(sub(offset, 0x80)), evmGasLeft)
-                sp := pushStackItem(sp, mload(sub(offset, 0x60)), evmGasLeft)
-                sp := pushStackItem(sp, mload(sub(offset, 0x40)), evmGasLeft)
-                sp := pushStackItem(sp, mload(sub(offset, 0x20)), evmGasLeft)
+                sp := pushStackItem(sp, mload(sub(offset, 0x80)), evmGasLeftOld)
+                sp := pushStackItem(sp, mload(sub(offset, 0x60)), evmGasLeftOld)
+                sp := pushStackItem(sp, mload(sub(offset, 0x40)), evmGasLeftOld)
+                sp := pushStackItem(sp, mload(sub(offset, 0x20)), evmGasLeftOld)
             
                 // Selector
                 mstore(sub(offset, 0x80), 0x5b16a23c)

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -1557,8 +1557,6 @@ object "EVMInterpreter" {
             for { } true { } {
                 opcode := readIP(ip,maxAcceptablePos)
             
-                ip := add(ip, 1)
-            
                 switch opcode
                 case 0x00 { // OP_STOP
                     break
@@ -1573,6 +1571,7 @@ object "EVMInterpreter" {
                     b, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, add(a, b))
+                    ip := add(ip, 1)
                 }
                 case 0x02 { // OP_MUL
                     evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -1584,6 +1583,7 @@ object "EVMInterpreter" {
                     b, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, mul(a, b))
+                    ip := add(ip, 1)
                 }
                 case 0x03 { // OP_SUB
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -1595,6 +1595,7 @@ object "EVMInterpreter" {
                     b, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, sub(a, b))
+                    ip := add(ip, 1)
                 }
                 case 0x04 { // OP_DIV
                     evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -1606,6 +1607,7 @@ object "EVMInterpreter" {
                     b, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, div(a, b))
+                    ip := add(ip, 1)
                 }
                 case 0x05 { // OP_SDIV
                     evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -1617,6 +1619,7 @@ object "EVMInterpreter" {
                     b, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, sdiv(a, b))
+                    ip := add(ip, 1)
                 }
                 case 0x06 { // OP_MOD
                     evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -1628,6 +1631,7 @@ object "EVMInterpreter" {
                     b, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, mod(a, b))
+                    ip := add(ip, 1)
                 }
                 case 0x07 { // OP_SMOD
                     evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -1639,6 +1643,7 @@ object "EVMInterpreter" {
                     b, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, smod(a, b))
+                    ip := add(ip, 1)
                 }
                 case 0x08 { // OP_ADDMOD
                     evmGasLeft := chargeGas(evmGasLeft, 8)
@@ -1651,6 +1656,7 @@ object "EVMInterpreter" {
                     N, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, addmod(a, b, N))
+                    ip := add(ip, 1)
                 }
                 case 0x09 { // OP_MULMOD
                     evmGasLeft := chargeGas(evmGasLeft, 8)
@@ -1663,6 +1669,7 @@ object "EVMInterpreter" {
                     N, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItem(sp, mulmod(a, b, N), evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x0A { // OP_EXP
                     evmGasLeft := chargeGas(evmGasLeft, 10)
@@ -1681,6 +1688,7 @@ object "EVMInterpreter" {
                         exponent := shr(8, exponent)
                     } 
                     evmGasLeft := chargeGas(evmGasLeft, to_charge)
+                    ip := add(ip, 1)
                 }
                 case 0x0B { // OP_SIGNEXTEND
                     evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -1692,6 +1700,7 @@ object "EVMInterpreter" {
                     x, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, signextend(b, x))
+                    ip := add(ip, 1)
                 }
                 case 0x10 { // OP_LT
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -1703,6 +1712,7 @@ object "EVMInterpreter" {
                     b, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, lt(a, b))
+                    ip := add(ip, 1)
                 }
                 case 0x11 { // OP_GT
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -1714,6 +1724,7 @@ object "EVMInterpreter" {
                     b, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, gt(a, b))
+                    ip := add(ip, 1)
                 }
                 case 0x12 { // OP_SLT
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -1725,6 +1736,7 @@ object "EVMInterpreter" {
                     b, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, slt(a, b))
+                    ip := add(ip, 1)
                 }
                 case 0x13 { // OP_SGT
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -1736,6 +1748,7 @@ object "EVMInterpreter" {
                     b, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, sgt(a, b))
+                    ip := add(ip, 1)
                 }
                 case 0x14 { // OP_EQ
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -1747,6 +1760,7 @@ object "EVMInterpreter" {
                     b, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, eq(a, b))
+                    ip := add(ip, 1)
                 }
                 case 0x15 { // OP_ISZERO
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -1757,6 +1771,7 @@ object "EVMInterpreter" {
                     a, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, iszero(a))
+                    ip := add(ip, 1)
                 }
                 case 0x16 { // OP_AND
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -1768,6 +1783,7 @@ object "EVMInterpreter" {
                     b, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, and(a,b))
+                    ip := add(ip, 1)
                 }
                 case 0x17 { // OP_OR
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -1779,6 +1795,7 @@ object "EVMInterpreter" {
                     b, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, or(a,b))
+                    ip := add(ip, 1)
                 }
                 case 0x18 { // OP_XOR
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -1790,6 +1807,7 @@ object "EVMInterpreter" {
                     b, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, xor(a, b))
+                    ip := add(ip, 1)
                 }
                 case 0x19 { // OP_NOT
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -1800,6 +1818,7 @@ object "EVMInterpreter" {
                     a, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, not(a))
+                    ip := add(ip, 1)
                 }
                 case 0x1A { // OP_BYTE
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -1811,6 +1830,7 @@ object "EVMInterpreter" {
                     x, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, byte(i, x))
+                    ip := add(ip, 1)
                 }
                 case 0x1B { // OP_SHL
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -1822,6 +1842,7 @@ object "EVMInterpreter" {
                     value, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, shl(shift, value))
+                    ip := add(ip, 1)
                 }
                 case 0x1C { // OP_SHR
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -1833,6 +1854,7 @@ object "EVMInterpreter" {
                     value, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, shr(shift, value))
+                    ip := add(ip, 1)
                 }
                 case 0x1D { // OP_SAR
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -1844,6 +1866,7 @@ object "EVMInterpreter" {
                     value, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, sar(shift, value))
+                    ip := add(ip, 1)
                 }
                 case 0x20 { // OP_KECCAK256
                     evmGasLeft := chargeGas(evmGasLeft, 30)
@@ -1866,11 +1889,13 @@ object "EVMInterpreter" {
                     evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
             
                     sp := pushStackItem(sp, keccak, evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x30 { // OP_ADDRESS
                     evmGasLeft := chargeGas(evmGasLeft, 2)
             
                     sp := pushStackItem(sp, address(), evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x31 { // OP_BALANCE
                     evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -1885,21 +1910,25 @@ object "EVMInterpreter" {
                     }
             
                     sp := pushStackItem(sp, balance(addr), evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x32 { // OP_ORIGIN
                     evmGasLeft := chargeGas(evmGasLeft, 2)
             
                     sp := pushStackItem(sp, origin(), evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x33 { // OP_CALLER
                     evmGasLeft := chargeGas(evmGasLeft, 2)
             
                     sp := pushStackItem(sp, caller(), evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x34 { // OP_CALLVALUE
                     evmGasLeft := chargeGas(evmGasLeft, 2)
             
                     sp := pushStackItem(sp, callvalue(), evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x35 { // OP_CALLDATALOAD
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -1910,11 +1939,13 @@ object "EVMInterpreter" {
                     i, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, calldataload(i))
+                    ip := add(ip, 1)
                 }
                 case 0x36 { // OP_CALLDATASIZE
                     evmGasLeft := chargeGas(evmGasLeft, 2)
             
                     sp := pushStackItem(sp, calldatasize(), evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x37 { // OP_CALLDATACOPY
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -1944,6 +1975,7 @@ object "EVMInterpreter" {
                     evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
             
                     calldatacopy(add(destOffset, MEM_OFFSET_INNER()), offset, size)
+                    ip := add(ip, 1)
                     
                 }
                 case 0x38 { // OP_CODESIZE
@@ -1951,6 +1983,7 @@ object "EVMInterpreter" {
             
                     let bytecodeLen := mload(BYTECODE_OFFSET())
                     sp := pushStackItem(sp, bytecodeLen, evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x39 { // OP_CODECOPY
                 
@@ -1984,12 +2017,13 @@ object "EVMInterpreter" {
                             shr(248, mload(add(offset, i)))
                         )
                     }
-                    
+                    ip := add(ip, 1)
                 }
                 case 0x3A { // OP_GASPRICE
                     evmGasLeft := chargeGas(evmGasLeft, 2)
             
                     sp := pushStackItem(sp, gasprice(), evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x3B { // OP_EXTCODESIZE
                     evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -2010,15 +2044,18 @@ object "EVMInterpreter" {
                     switch _isEVM(addr) 
                         case 0  { sp := pushStackItem(sp, extcodesize(addr), evmGasLeft) }
                         default { sp := pushStackItem(sp, _fetchDeployedCodeLen(addr), evmGasLeft) }
+                    ip := add(ip, 1)
                 }
                 case 0x3C { // OP_EXTCODECOPY
                     evmGasLeft, sp := performExtCodeCopy(evmGasLeft, sp)
+                    ip := add(ip, 1)
                 }
                 case 0x3D { // OP_RETURNDATASIZE
                     evmGasLeft := chargeGas(evmGasLeft, 2)
             
                     let rdz := mload(LAST_RETURNDATA_SIZE_OFFSET())
                     sp := pushStackItem(sp, rdz, evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x3E { // OP_RETURNDATACOPY
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -2044,6 +2081,7 @@ object "EVMInterpreter" {
                     evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
             
                     copyActivePtrData(add(MEM_OFFSET_INNER(), dest), offset, len)
+                    ip := add(ip, 1)
                 }
                 case 0x3F { // OP_EXTCODEHASH
                     evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -2056,6 +2094,7 @@ object "EVMInterpreter" {
                         evmGasLeft := chargeGas(evmGasLeft, 2500) 
                     }
             
+                    ip := add(ip, 1)
                     if iszero(addr) {
                         sp := pushStackItem(sp, 0, evmGasLeft)
                         continue
@@ -2070,38 +2109,47 @@ object "EVMInterpreter" {
                     blockNumber, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, blockhash(blockNumber))
+                    ip := add(ip, 1)
                 }
                 case 0x41 { // OP_COINBASE
                     evmGasLeft := chargeGas(evmGasLeft, 2)
                     sp := pushStackItem(sp, coinbase(), evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x42 { // OP_TIMESTAMP
                     evmGasLeft := chargeGas(evmGasLeft, 2)
                     sp := pushStackItem(sp, timestamp(), evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x43 { // OP_NUMBER
                     evmGasLeft := chargeGas(evmGasLeft, 2)
                     sp := pushStackItem(sp, number(), evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x44 { // OP_PREVRANDAO
                     evmGasLeft := chargeGas(evmGasLeft, 2)
                     sp := pushStackItem(sp, prevrandao(), evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x45 { // OP_GASLIMIT
                     evmGasLeft := chargeGas(evmGasLeft, 2)
                     sp := pushStackItem(sp, gaslimit(), evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x46 { // OP_CHAINID
                     evmGasLeft := chargeGas(evmGasLeft, 2)
                     sp := pushStackItem(sp, chainid(), evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x47 { // OP_SELFBALANCE
                     evmGasLeft := chargeGas(evmGasLeft, 5)
                     sp := pushStackItem(sp, selfbalance(), evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x48 { // OP_BASEFEE
                     evmGasLeft := chargeGas(evmGasLeft, 2)
                     sp := pushStackItem(sp, basefee(), evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x50 { // OP_POP
                     evmGasLeft := chargeGas(evmGasLeft, 2)
@@ -2109,6 +2157,7 @@ object "EVMInterpreter" {
                     let _y
             
                     _y, sp := popStackItem(sp, evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x51 { // OP_MLOAD
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -2124,6 +2173,7 @@ object "EVMInterpreter" {
                     checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
                     let memValue := mload(add(MEM_OFFSET_INNER(), offset))
                     sp := pushStackItem(sp, memValue, evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x52 { // OP_MSTORE
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -2140,6 +2190,7 @@ object "EVMInterpreter" {
             
                     checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
                     mstore(add(MEM_OFFSET_INNER(), offset), value)
+                    ip := add(ip, 1)
                 }
                 case 0x53 { // OP_MSTORE8
                     evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -2156,6 +2207,7 @@ object "EVMInterpreter" {
             
                     checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
                     mstore8(add(MEM_OFFSET_INNER(), offset), value)
+                    ip := add(ip, 1)
                 }
                 case 0x54 { // OP_SLOAD
                 
@@ -2178,7 +2230,7 @@ object "EVMInterpreter" {
                     }
             
                     sp := pushStackItem(sp,value, evmGasLeft)
-                    
+                    ip := add(ip, 1)
                 }
                 case 0x55 { // OP_SSTORE
                     evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -2193,6 +2245,7 @@ object "EVMInterpreter" {
                     key, sp := popStackItemWithoutCheck(sp)
                     value, sp := popStackItemWithoutCheck(sp)
             
+                    ip := add(ip, 1)
                     {
                         // Here it is okay to read before we charge since we known anyway that
                         // the context has enough funds to compensate at least for the read.
@@ -2247,6 +2300,7 @@ object "EVMInterpreter" {
                     b, sp := popStackItemWithoutCheck(sp)
             
                     if iszero(b) {
+                        ip := add(ip, 1)
                         continue
                     }
             
@@ -2260,6 +2314,7 @@ object "EVMInterpreter" {
                 }
                 case 0x58 { // OP_PC
                     evmGasLeft := chargeGas(evmGasLeft, 2)
+                    ip := add(ip, 1)
             
                     // PC = ip - 32 (bytecode size) - 1 (current instruction)
                     sp := pushStackItem(sp, sub(sub(ip, BYTECODE_OFFSET()), 33), evmGasLeft)
@@ -2272,15 +2327,17 @@ object "EVMInterpreter" {
                     size := mload(MEM_OFFSET())
                     size := shl(5,size)
                     sp := pushStackItem(sp,size, evmGasLeft)
-            
+                    ip := add(ip, 1)
                 }
                 case 0x5A { // OP_GAS
                     evmGasLeft := chargeGas(evmGasLeft, 2)
             
                     sp := pushStackItem(sp, evmGasLeft, evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x5B { // OP_JUMPDEST
                     evmGasLeft := chargeGas(evmGasLeft, 1)
+                    ip := add(ip, 1)
                 }
                 case 0x5C { // OP_TLOAD
                     evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -2290,6 +2347,7 @@ object "EVMInterpreter" {
                     key, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, tload(key))
+                    ip := add(ip, 1)
                 }
                 case 0x5D { // OP_TSTORE
                     evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -2304,6 +2362,7 @@ object "EVMInterpreter" {
                     value, sp := popStackItemWithoutCheck(sp)
             
                     tstore(key, value)
+                    ip := add(ip, 1)
                 }
                 case 0x5E { // OP_MCOPY
                     let destOffset, offset, size
@@ -2332,6 +2391,7 @@ object "EVMInterpreter" {
                             shr(248,mload(add(add(oldSize,MEM_OFFSET_INNER()), i)))
                         )
                     }
+                    ip := add(ip, 1)
                 }
                 case 0x5F { // OP_PUSH0
                     evmGasLeft := chargeGas(evmGasLeft, 2)
@@ -2339,10 +2399,12 @@ object "EVMInterpreter" {
                     let value := 0
             
                     sp := pushStackItem(sp, value, evmGasLeft)
+                    ip := add(ip, 1)
                 }
                 case 0x60 { // OP_PUSH1
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,1)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2351,6 +2413,7 @@ object "EVMInterpreter" {
                 case 0x61 { // OP_PUSH2
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,2)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2359,6 +2422,7 @@ object "EVMInterpreter" {
                 case 0x62 { // OP_PUSH3
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,3)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2367,6 +2431,7 @@ object "EVMInterpreter" {
                 case 0x63 { // OP_PUSH4
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,4)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2375,6 +2440,7 @@ object "EVMInterpreter" {
                 case 0x64 { // OP_PUSH5
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,5)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2383,6 +2449,7 @@ object "EVMInterpreter" {
                 case 0x65 { // OP_PUSH6
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,6)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2391,6 +2458,7 @@ object "EVMInterpreter" {
                 case 0x66 { // OP_PUSH7
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,7)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2399,6 +2467,7 @@ object "EVMInterpreter" {
                 case 0x67 { // OP_PUSH8
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,8)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2407,6 +2476,7 @@ object "EVMInterpreter" {
                 case 0x68 { // OP_PUSH9
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,9)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2415,6 +2485,7 @@ object "EVMInterpreter" {
                 case 0x69 { // OP_PUSH10
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,10)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2423,6 +2494,7 @@ object "EVMInterpreter" {
                 case 0x6A { // OP_PUSH11
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,11)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2431,6 +2503,7 @@ object "EVMInterpreter" {
                 case 0x6B { // OP_PUSH12
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,12)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2439,6 +2512,7 @@ object "EVMInterpreter" {
                 case 0x6C { // OP_PUSH13
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,13)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2447,6 +2521,7 @@ object "EVMInterpreter" {
                 case 0x6D { // OP_PUSH14
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,14)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2455,6 +2530,7 @@ object "EVMInterpreter" {
                 case 0x6E { // OP_PUSH15
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,15)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2463,6 +2539,7 @@ object "EVMInterpreter" {
                 case 0x6F { // OP_PUSH16
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,16)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2471,6 +2548,7 @@ object "EVMInterpreter" {
                 case 0x70 { // OP_PUSH17
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,17)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2479,6 +2557,7 @@ object "EVMInterpreter" {
                 case 0x71 { // OP_PUSH18
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,18)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2487,6 +2566,7 @@ object "EVMInterpreter" {
                 case 0x72 { // OP_PUSH19
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,19)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2495,6 +2575,7 @@ object "EVMInterpreter" {
                 case 0x73 { // OP_PUSH20
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,20)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2503,6 +2584,7 @@ object "EVMInterpreter" {
                 case 0x74 { // OP_PUSH21
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,21)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2511,6 +2593,7 @@ object "EVMInterpreter" {
                 case 0x75 { // OP_PUSH22
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,22)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2519,6 +2602,7 @@ object "EVMInterpreter" {
                 case 0x76 { // OP_PUSH23
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,23)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2527,6 +2611,7 @@ object "EVMInterpreter" {
                 case 0x77 { // OP_PUSH24
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,24)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2535,6 +2620,7 @@ object "EVMInterpreter" {
                 case 0x78 { // OP_PUSH25
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,25)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2543,6 +2629,7 @@ object "EVMInterpreter" {
                 case 0x79 { // OP_PUSH26
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,26)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2551,6 +2638,7 @@ object "EVMInterpreter" {
                 case 0x7A { // OP_PUSH27
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,27)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2559,6 +2647,7 @@ object "EVMInterpreter" {
                 case 0x7B { // OP_PUSH28
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,28)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2567,6 +2656,7 @@ object "EVMInterpreter" {
                 case 0x7C { // OP_PUSH29
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,29)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2575,6 +2665,7 @@ object "EVMInterpreter" {
                 case 0x7D { // OP_PUSH30
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,30)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2583,6 +2674,7 @@ object "EVMInterpreter" {
                 case 0x7E { // OP_PUSH31
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,31)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2591,6 +2683,7 @@ object "EVMInterpreter" {
                 case 0x7F { // OP_PUSH32
                     evmGasLeft := chargeGas(evmGasLeft, 3)
             
+                    ip := add(ip, 1)
                     let value := readBytes(ip,maxAcceptablePos,32)
             
                     sp := pushStackItem(sp, value, evmGasLeft)
@@ -2598,99 +2691,131 @@ object "EVMInterpreter" {
                 }
                 case 0x80 { // OP_DUP1 
                     sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 1)
+                    ip := add(ip, 1)
                 }
                 case 0x81 { // OP_DUP2
                     sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 2)
+                    ip := add(ip, 1)
                 }
                 case 0x82 { // OP_DUP3
                     sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 3)
+                    ip := add(ip, 1)
                 }
                 case 0x83 { // OP_DUP4    
                     sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 4)
+                    ip := add(ip, 1)
                 }
                 case 0x84 { // OP_DUP5
                     sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 5)
+                    ip := add(ip, 1)
                 }
                 case 0x85 { // OP_DUP6
                     sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 6)
+                    ip := add(ip, 1)
                 }
                 case 0x86 { // OP_DUP7    
                     sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 7)
+                    ip := add(ip, 1)
                 }
                 case 0x87 { // OP_DUP8
                     sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 8)
+                    ip := add(ip, 1)
                 }
                 case 0x88 { // OP_DUP9
                     sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 9)
+                    ip := add(ip, 1)
                 }
                 case 0x89 { // OP_DUP10   
                     sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 10)
+                    ip := add(ip, 1)
                 }
                 case 0x8A { // OP_DUP11
                     sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 11)
+                    ip := add(ip, 1)
                 }
                 case 0x8B { // OP_DUP12
                     sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 12)
+                    ip := add(ip, 1)
                 }
                 case 0x8C { // OP_DUP13
                     sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 13)
+                    ip := add(ip, 1)
                 }
                 case 0x8D { // OP_DUP14
                     sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 14)
+                    ip := add(ip, 1)
                 }
                 case 0x8E { // OP_DUP15
                     sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 15)
+                    ip := add(ip, 1)
                 }
                 case 0x8F { // OP_DUP16
                     sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 16)
+                    ip := add(ip, 1)
                 }
                 case 0x90 { // OP_SWAP1 
                     evmGasLeft := swapStackItem(sp, evmGasLeft, 1)
+                    ip := add(ip, 1)
                 }
                 case 0x91 { // OP_SWAP2
                     evmGasLeft := swapStackItem(sp, evmGasLeft, 2)
+                    ip := add(ip, 1)
                 }
                 case 0x92 { // OP_SWAP3
                     evmGasLeft := swapStackItem(sp, evmGasLeft, 3)
+                    ip := add(ip, 1)
                 }
                 case 0x93 { // OP_SWAP4    
                     evmGasLeft := swapStackItem(sp, evmGasLeft, 4)
+                    ip := add(ip, 1)
                 }
                 case 0x94 { // OP_SWAP5
                     evmGasLeft := swapStackItem(sp, evmGasLeft, 5)
+                    ip := add(ip, 1)
                 }
                 case 0x95 { // OP_SWAP6
                     evmGasLeft := swapStackItem(sp, evmGasLeft, 6)
+                    ip := add(ip, 1)
                 }
                 case 0x96 { // OP_SWAP7    
                     evmGasLeft := swapStackItem(sp, evmGasLeft, 7)
+                    ip := add(ip, 1)
                 }
                 case 0x97 { // OP_SWAP8
                     evmGasLeft := swapStackItem(sp, evmGasLeft, 8)
+                    ip := add(ip, 1)
                 }
                 case 0x98 { // OP_SWAP9
                     evmGasLeft := swapStackItem(sp, evmGasLeft, 9)
+                    ip := add(ip, 1)
                 }
                 case 0x99 { // OP_SWAP10   
                     evmGasLeft := swapStackItem(sp, evmGasLeft, 10)
+                    ip := add(ip, 1)
                 }
                 case 0x9A { // OP_SWAP11
                     evmGasLeft := swapStackItem(sp, evmGasLeft, 11)
+                    ip := add(ip, 1)
                 }
                 case 0x9B { // OP_SWAP12
                     evmGasLeft := swapStackItem(sp, evmGasLeft, 12)
+                    ip := add(ip, 1)
                 }
                 case 0x9C { // OP_SWAP13
                     evmGasLeft := swapStackItem(sp, evmGasLeft, 13)
+                    ip := add(ip, 1)
                 }
                 case 0x9D { // OP_SWAP14
                     evmGasLeft := swapStackItem(sp, evmGasLeft, 14)
+                    ip := add(ip, 1)
                 }
                 case 0x9E { // OP_SWAP15
                     evmGasLeft := swapStackItem(sp, evmGasLeft, 15)
+                    ip := add(ip, 1)
                 }
                 case 0x9F { // OP_SWAP16
                     evmGasLeft := swapStackItem(sp, evmGasLeft, 16)
+                    ip := add(ip, 1)
                 }
                 case 0xA0 { // OP_LOG0
                     evmGasLeft := chargeGas(evmGasLeft, 375)
@@ -2712,6 +2837,7 @@ object "EVMInterpreter" {
                     evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
             
                     log0(add(offset, MEM_OFFSET_INNER()), size)
+                    ip := add(ip, 1)
                 }
                 case 0xA1 { // OP_LOG1
                     evmGasLeft := chargeGas(evmGasLeft, 375)
@@ -2735,6 +2861,7 @@ object "EVMInterpreter" {
                     evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
             
                     log1(add(offset, MEM_OFFSET_INNER()), size, topic1)
+                    ip := add(ip, 1)
                 }
                 case 0xA2 { // OP_LOG2
                     evmGasLeft := chargeGas(evmGasLeft, 375)
@@ -2762,6 +2889,7 @@ object "EVMInterpreter" {
                         topic2, sp := popStackItemWithoutCheck(sp)
                         log2(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2)
                     }
+                    ip := add(ip, 1)
                 }
                 case 0xA3 { // OP_LOG3
                     evmGasLeft := chargeGas(evmGasLeft, 375)
@@ -2792,6 +2920,7 @@ object "EVMInterpreter" {
                         topic3, sp := popStackItemWithoutCheck(sp)
                         log3(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2, topic3)
                     }     
+                    ip := add(ip, 1)
                 }
                 case 0xA4 { // OP_LOG4
                     evmGasLeft := chargeGas(evmGasLeft, 375)
@@ -2822,9 +2951,11 @@ object "EVMInterpreter" {
                         topic4, sp := popStackItemWithoutCheck(sp)
                         log4(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2, topic3, topic4)
                     }     
+                    ip := add(ip, 1)
                 }
                 case 0xF0 { // OP_CREATE
                     evmGasLeft, sp := performCreate(evmGasLeft, sp, isStatic)
+                    ip := add(ip, 1)
                 }
                 case 0xF1 { // OP_CALL
                     evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -2836,6 +2967,7 @@ object "EVMInterpreter" {
             
                     // Check if the following is ok
                     evmGasLeft := chargeGas(evmGasLeft, gasUsed)
+                    ip := add(ip, 1)
                 }
                 case 0xF3 { // OP_RETURN
                     let offset,size
@@ -2859,6 +2991,7 @@ object "EVMInterpreter" {
                     sp, isStatic, gasUsed := delegateCall(sp, isStatic, evmGasLeft)
             
                     evmGasLeft := chargeGas(evmGasLeft, gasUsed)
+                    ip := add(ip, 1)
                 }
                 case 0xF5 { // OP_CREATE2
                     let result, addr
@@ -2866,6 +2999,7 @@ object "EVMInterpreter" {
                     switch result
                     case 0 { sp := pushStackItem(sp, 0, evmGasLeft) }
                     default { sp := pushStackItem(sp, addr, evmGasLeft) }
+                    ip := add(ip, 1)
                 }
                 case 0xFA { // OP_STATICCALL
                     evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -2873,6 +3007,7 @@ object "EVMInterpreter" {
                     let gasUsed
                     gasUsed, sp := performStaticCall(sp,evmGasLeft)
                     evmGasLeft := chargeGas(evmGasLeft,gasUsed)
+                    ip := add(ip, 1)
                 }
                 case 0xFD { // OP_REVERT
                     let offset,size
@@ -4417,8 +4552,6 @@ object "EVMInterpreter" {
                 for { } true { } {
                     opcode := readIP(ip,maxAcceptablePos)
                 
-                    ip := add(ip, 1)
-                
                     switch opcode
                     case 0x00 { // OP_STOP
                         break
@@ -4433,6 +4566,7 @@ object "EVMInterpreter" {
                         b, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, add(a, b))
+                        ip := add(ip, 1)
                     }
                     case 0x02 { // OP_MUL
                         evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -4444,6 +4578,7 @@ object "EVMInterpreter" {
                         b, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, mul(a, b))
+                        ip := add(ip, 1)
                     }
                     case 0x03 { // OP_SUB
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -4455,6 +4590,7 @@ object "EVMInterpreter" {
                         b, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, sub(a, b))
+                        ip := add(ip, 1)
                     }
                     case 0x04 { // OP_DIV
                         evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -4466,6 +4602,7 @@ object "EVMInterpreter" {
                         b, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, div(a, b))
+                        ip := add(ip, 1)
                     }
                     case 0x05 { // OP_SDIV
                         evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -4477,6 +4614,7 @@ object "EVMInterpreter" {
                         b, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, sdiv(a, b))
+                        ip := add(ip, 1)
                     }
                     case 0x06 { // OP_MOD
                         evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -4488,6 +4626,7 @@ object "EVMInterpreter" {
                         b, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, mod(a, b))
+                        ip := add(ip, 1)
                     }
                     case 0x07 { // OP_SMOD
                         evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -4499,6 +4638,7 @@ object "EVMInterpreter" {
                         b, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, smod(a, b))
+                        ip := add(ip, 1)
                     }
                     case 0x08 { // OP_ADDMOD
                         evmGasLeft := chargeGas(evmGasLeft, 8)
@@ -4511,6 +4651,7 @@ object "EVMInterpreter" {
                         N, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, addmod(a, b, N))
+                        ip := add(ip, 1)
                     }
                     case 0x09 { // OP_MULMOD
                         evmGasLeft := chargeGas(evmGasLeft, 8)
@@ -4523,6 +4664,7 @@ object "EVMInterpreter" {
                         N, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItem(sp, mulmod(a, b, N), evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x0A { // OP_EXP
                         evmGasLeft := chargeGas(evmGasLeft, 10)
@@ -4541,6 +4683,7 @@ object "EVMInterpreter" {
                             exponent := shr(8, exponent)
                         } 
                         evmGasLeft := chargeGas(evmGasLeft, to_charge)
+                        ip := add(ip, 1)
                     }
                     case 0x0B { // OP_SIGNEXTEND
                         evmGasLeft := chargeGas(evmGasLeft, 5)
@@ -4552,6 +4695,7 @@ object "EVMInterpreter" {
                         x, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, signextend(b, x))
+                        ip := add(ip, 1)
                     }
                     case 0x10 { // OP_LT
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -4563,6 +4707,7 @@ object "EVMInterpreter" {
                         b, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, lt(a, b))
+                        ip := add(ip, 1)
                     }
                     case 0x11 { // OP_GT
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -4574,6 +4719,7 @@ object "EVMInterpreter" {
                         b, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, gt(a, b))
+                        ip := add(ip, 1)
                     }
                     case 0x12 { // OP_SLT
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -4585,6 +4731,7 @@ object "EVMInterpreter" {
                         b, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, slt(a, b))
+                        ip := add(ip, 1)
                     }
                     case 0x13 { // OP_SGT
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -4596,6 +4743,7 @@ object "EVMInterpreter" {
                         b, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, sgt(a, b))
+                        ip := add(ip, 1)
                     }
                     case 0x14 { // OP_EQ
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -4607,6 +4755,7 @@ object "EVMInterpreter" {
                         b, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, eq(a, b))
+                        ip := add(ip, 1)
                     }
                     case 0x15 { // OP_ISZERO
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -4617,6 +4766,7 @@ object "EVMInterpreter" {
                         a, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, iszero(a))
+                        ip := add(ip, 1)
                     }
                     case 0x16 { // OP_AND
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -4628,6 +4778,7 @@ object "EVMInterpreter" {
                         b, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, and(a,b))
+                        ip := add(ip, 1)
                     }
                     case 0x17 { // OP_OR
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -4639,6 +4790,7 @@ object "EVMInterpreter" {
                         b, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, or(a,b))
+                        ip := add(ip, 1)
                     }
                     case 0x18 { // OP_XOR
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -4650,6 +4802,7 @@ object "EVMInterpreter" {
                         b, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, xor(a, b))
+                        ip := add(ip, 1)
                     }
                     case 0x19 { // OP_NOT
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -4660,6 +4813,7 @@ object "EVMInterpreter" {
                         a, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, not(a))
+                        ip := add(ip, 1)
                     }
                     case 0x1A { // OP_BYTE
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -4671,6 +4825,7 @@ object "EVMInterpreter" {
                         x, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, byte(i, x))
+                        ip := add(ip, 1)
                     }
                     case 0x1B { // OP_SHL
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -4682,6 +4837,7 @@ object "EVMInterpreter" {
                         value, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, shl(shift, value))
+                        ip := add(ip, 1)
                     }
                     case 0x1C { // OP_SHR
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -4693,6 +4849,7 @@ object "EVMInterpreter" {
                         value, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, shr(shift, value))
+                        ip := add(ip, 1)
                     }
                     case 0x1D { // OP_SAR
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -4704,6 +4861,7 @@ object "EVMInterpreter" {
                         value, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, sar(shift, value))
+                        ip := add(ip, 1)
                     }
                     case 0x20 { // OP_KECCAK256
                         evmGasLeft := chargeGas(evmGasLeft, 30)
@@ -4726,11 +4884,13 @@ object "EVMInterpreter" {
                         evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
                 
                         sp := pushStackItem(sp, keccak, evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x30 { // OP_ADDRESS
                         evmGasLeft := chargeGas(evmGasLeft, 2)
                 
                         sp := pushStackItem(sp, address(), evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x31 { // OP_BALANCE
                         evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -4745,21 +4905,25 @@ object "EVMInterpreter" {
                         }
                 
                         sp := pushStackItem(sp, balance(addr), evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x32 { // OP_ORIGIN
                         evmGasLeft := chargeGas(evmGasLeft, 2)
                 
                         sp := pushStackItem(sp, origin(), evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x33 { // OP_CALLER
                         evmGasLeft := chargeGas(evmGasLeft, 2)
                 
                         sp := pushStackItem(sp, caller(), evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x34 { // OP_CALLVALUE
                         evmGasLeft := chargeGas(evmGasLeft, 2)
                 
                         sp := pushStackItem(sp, callvalue(), evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x35 { // OP_CALLDATALOAD
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -4770,11 +4934,13 @@ object "EVMInterpreter" {
                         i, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, calldataload(i))
+                        ip := add(ip, 1)
                     }
                     case 0x36 { // OP_CALLDATASIZE
                         evmGasLeft := chargeGas(evmGasLeft, 2)
                 
                         sp := pushStackItem(sp, calldatasize(), evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x37 { // OP_CALLDATACOPY
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -4804,6 +4970,7 @@ object "EVMInterpreter" {
                         evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
                 
                         calldatacopy(add(destOffset, MEM_OFFSET_INNER()), offset, size)
+                        ip := add(ip, 1)
                         
                     }
                     case 0x38 { // OP_CODESIZE
@@ -4811,6 +4978,7 @@ object "EVMInterpreter" {
                 
                         let bytecodeLen := mload(BYTECODE_OFFSET())
                         sp := pushStackItem(sp, bytecodeLen, evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x39 { // OP_CODECOPY
                     
@@ -4844,12 +5012,13 @@ object "EVMInterpreter" {
                                 shr(248, mload(add(offset, i)))
                             )
                         }
-                        
+                        ip := add(ip, 1)
                     }
                     case 0x3A { // OP_GASPRICE
                         evmGasLeft := chargeGas(evmGasLeft, 2)
                 
                         sp := pushStackItem(sp, gasprice(), evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x3B { // OP_EXTCODESIZE
                         evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -4870,15 +5039,18 @@ object "EVMInterpreter" {
                         switch _isEVM(addr) 
                             case 0  { sp := pushStackItem(sp, extcodesize(addr), evmGasLeft) }
                             default { sp := pushStackItem(sp, _fetchDeployedCodeLen(addr), evmGasLeft) }
+                        ip := add(ip, 1)
                     }
                     case 0x3C { // OP_EXTCODECOPY
                         evmGasLeft, sp := performExtCodeCopy(evmGasLeft, sp)
+                        ip := add(ip, 1)
                     }
                     case 0x3D { // OP_RETURNDATASIZE
                         evmGasLeft := chargeGas(evmGasLeft, 2)
                 
                         let rdz := mload(LAST_RETURNDATA_SIZE_OFFSET())
                         sp := pushStackItem(sp, rdz, evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x3E { // OP_RETURNDATACOPY
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -4904,6 +5076,7 @@ object "EVMInterpreter" {
                         evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
                 
                         copyActivePtrData(add(MEM_OFFSET_INNER(), dest), offset, len)
+                        ip := add(ip, 1)
                     }
                     case 0x3F { // OP_EXTCODEHASH
                         evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -4916,6 +5089,7 @@ object "EVMInterpreter" {
                             evmGasLeft := chargeGas(evmGasLeft, 2500) 
                         }
                 
+                        ip := add(ip, 1)
                         if iszero(addr) {
                             sp := pushStackItem(sp, 0, evmGasLeft)
                             continue
@@ -4930,38 +5104,47 @@ object "EVMInterpreter" {
                         blockNumber, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, blockhash(blockNumber))
+                        ip := add(ip, 1)
                     }
                     case 0x41 { // OP_COINBASE
                         evmGasLeft := chargeGas(evmGasLeft, 2)
                         sp := pushStackItem(sp, coinbase(), evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x42 { // OP_TIMESTAMP
                         evmGasLeft := chargeGas(evmGasLeft, 2)
                         sp := pushStackItem(sp, timestamp(), evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x43 { // OP_NUMBER
                         evmGasLeft := chargeGas(evmGasLeft, 2)
                         sp := pushStackItem(sp, number(), evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x44 { // OP_PREVRANDAO
                         evmGasLeft := chargeGas(evmGasLeft, 2)
                         sp := pushStackItem(sp, prevrandao(), evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x45 { // OP_GASLIMIT
                         evmGasLeft := chargeGas(evmGasLeft, 2)
                         sp := pushStackItem(sp, gaslimit(), evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x46 { // OP_CHAINID
                         evmGasLeft := chargeGas(evmGasLeft, 2)
                         sp := pushStackItem(sp, chainid(), evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x47 { // OP_SELFBALANCE
                         evmGasLeft := chargeGas(evmGasLeft, 5)
                         sp := pushStackItem(sp, selfbalance(), evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x48 { // OP_BASEFEE
                         evmGasLeft := chargeGas(evmGasLeft, 2)
                         sp := pushStackItem(sp, basefee(), evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x50 { // OP_POP
                         evmGasLeft := chargeGas(evmGasLeft, 2)
@@ -4969,6 +5152,7 @@ object "EVMInterpreter" {
                         let _y
                 
                         _y, sp := popStackItem(sp, evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x51 { // OP_MLOAD
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -4984,6 +5168,7 @@ object "EVMInterpreter" {
                         checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
                         let memValue := mload(add(MEM_OFFSET_INNER(), offset))
                         sp := pushStackItem(sp, memValue, evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x52 { // OP_MSTORE
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -5000,6 +5185,7 @@ object "EVMInterpreter" {
                 
                         checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
                         mstore(add(MEM_OFFSET_INNER(), offset), value)
+                        ip := add(ip, 1)
                     }
                     case 0x53 { // OP_MSTORE8
                         evmGasLeft := chargeGas(evmGasLeft, 3)
@@ -5016,6 +5202,7 @@ object "EVMInterpreter" {
                 
                         checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
                         mstore8(add(MEM_OFFSET_INNER(), offset), value)
+                        ip := add(ip, 1)
                     }
                     case 0x54 { // OP_SLOAD
                     
@@ -5038,7 +5225,7 @@ object "EVMInterpreter" {
                         }
                 
                         sp := pushStackItem(sp,value, evmGasLeft)
-                        
+                        ip := add(ip, 1)
                     }
                     case 0x55 { // OP_SSTORE
                         evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -5053,6 +5240,7 @@ object "EVMInterpreter" {
                         key, sp := popStackItemWithoutCheck(sp)
                         value, sp := popStackItemWithoutCheck(sp)
                 
+                        ip := add(ip, 1)
                         {
                             // Here it is okay to read before we charge since we known anyway that
                             // the context has enough funds to compensate at least for the read.
@@ -5107,6 +5295,7 @@ object "EVMInterpreter" {
                         b, sp := popStackItemWithoutCheck(sp)
                 
                         if iszero(b) {
+                            ip := add(ip, 1)
                             continue
                         }
                 
@@ -5120,6 +5309,7 @@ object "EVMInterpreter" {
                     }
                     case 0x58 { // OP_PC
                         evmGasLeft := chargeGas(evmGasLeft, 2)
+                        ip := add(ip, 1)
                 
                         // PC = ip - 32 (bytecode size) - 1 (current instruction)
                         sp := pushStackItem(sp, sub(sub(ip, BYTECODE_OFFSET()), 33), evmGasLeft)
@@ -5132,15 +5322,17 @@ object "EVMInterpreter" {
                         size := mload(MEM_OFFSET())
                         size := shl(5,size)
                         sp := pushStackItem(sp,size, evmGasLeft)
-                
+                        ip := add(ip, 1)
                     }
                     case 0x5A { // OP_GAS
                         evmGasLeft := chargeGas(evmGasLeft, 2)
                 
                         sp := pushStackItem(sp, evmGasLeft, evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x5B { // OP_JUMPDEST
                         evmGasLeft := chargeGas(evmGasLeft, 1)
+                        ip := add(ip, 1)
                     }
                     case 0x5C { // OP_TLOAD
                         evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -5150,6 +5342,7 @@ object "EVMInterpreter" {
                         key, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, tload(key))
+                        ip := add(ip, 1)
                     }
                     case 0x5D { // OP_TSTORE
                         evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -5164,6 +5357,7 @@ object "EVMInterpreter" {
                         value, sp := popStackItemWithoutCheck(sp)
                 
                         tstore(key, value)
+                        ip := add(ip, 1)
                     }
                     case 0x5E { // OP_MCOPY
                         let destOffset, offset, size
@@ -5192,6 +5386,7 @@ object "EVMInterpreter" {
                                 shr(248,mload(add(add(oldSize,MEM_OFFSET_INNER()), i)))
                             )
                         }
+                        ip := add(ip, 1)
                     }
                     case 0x5F { // OP_PUSH0
                         evmGasLeft := chargeGas(evmGasLeft, 2)
@@ -5199,10 +5394,12 @@ object "EVMInterpreter" {
                         let value := 0
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
+                        ip := add(ip, 1)
                     }
                     case 0x60 { // OP_PUSH1
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,1)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5211,6 +5408,7 @@ object "EVMInterpreter" {
                     case 0x61 { // OP_PUSH2
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,2)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5219,6 +5417,7 @@ object "EVMInterpreter" {
                     case 0x62 { // OP_PUSH3
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,3)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5227,6 +5426,7 @@ object "EVMInterpreter" {
                     case 0x63 { // OP_PUSH4
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,4)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5235,6 +5435,7 @@ object "EVMInterpreter" {
                     case 0x64 { // OP_PUSH5
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,5)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5243,6 +5444,7 @@ object "EVMInterpreter" {
                     case 0x65 { // OP_PUSH6
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,6)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5251,6 +5453,7 @@ object "EVMInterpreter" {
                     case 0x66 { // OP_PUSH7
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,7)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5259,6 +5462,7 @@ object "EVMInterpreter" {
                     case 0x67 { // OP_PUSH8
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,8)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5267,6 +5471,7 @@ object "EVMInterpreter" {
                     case 0x68 { // OP_PUSH9
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,9)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5275,6 +5480,7 @@ object "EVMInterpreter" {
                     case 0x69 { // OP_PUSH10
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,10)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5283,6 +5489,7 @@ object "EVMInterpreter" {
                     case 0x6A { // OP_PUSH11
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,11)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5291,6 +5498,7 @@ object "EVMInterpreter" {
                     case 0x6B { // OP_PUSH12
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,12)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5299,6 +5507,7 @@ object "EVMInterpreter" {
                     case 0x6C { // OP_PUSH13
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,13)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5307,6 +5516,7 @@ object "EVMInterpreter" {
                     case 0x6D { // OP_PUSH14
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,14)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5315,6 +5525,7 @@ object "EVMInterpreter" {
                     case 0x6E { // OP_PUSH15
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,15)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5323,6 +5534,7 @@ object "EVMInterpreter" {
                     case 0x6F { // OP_PUSH16
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,16)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5331,6 +5543,7 @@ object "EVMInterpreter" {
                     case 0x70 { // OP_PUSH17
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,17)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5339,6 +5552,7 @@ object "EVMInterpreter" {
                     case 0x71 { // OP_PUSH18
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,18)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5347,6 +5561,7 @@ object "EVMInterpreter" {
                     case 0x72 { // OP_PUSH19
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,19)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5355,6 +5570,7 @@ object "EVMInterpreter" {
                     case 0x73 { // OP_PUSH20
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,20)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5363,6 +5579,7 @@ object "EVMInterpreter" {
                     case 0x74 { // OP_PUSH21
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,21)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5371,6 +5588,7 @@ object "EVMInterpreter" {
                     case 0x75 { // OP_PUSH22
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,22)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5379,6 +5597,7 @@ object "EVMInterpreter" {
                     case 0x76 { // OP_PUSH23
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,23)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5387,6 +5606,7 @@ object "EVMInterpreter" {
                     case 0x77 { // OP_PUSH24
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,24)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5395,6 +5615,7 @@ object "EVMInterpreter" {
                     case 0x78 { // OP_PUSH25
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,25)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5403,6 +5624,7 @@ object "EVMInterpreter" {
                     case 0x79 { // OP_PUSH26
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,26)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5411,6 +5633,7 @@ object "EVMInterpreter" {
                     case 0x7A { // OP_PUSH27
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,27)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5419,6 +5642,7 @@ object "EVMInterpreter" {
                     case 0x7B { // OP_PUSH28
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,28)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5427,6 +5651,7 @@ object "EVMInterpreter" {
                     case 0x7C { // OP_PUSH29
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,29)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5435,6 +5660,7 @@ object "EVMInterpreter" {
                     case 0x7D { // OP_PUSH30
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,30)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5443,6 +5669,7 @@ object "EVMInterpreter" {
                     case 0x7E { // OP_PUSH31
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,31)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5451,6 +5678,7 @@ object "EVMInterpreter" {
                     case 0x7F { // OP_PUSH32
                         evmGasLeft := chargeGas(evmGasLeft, 3)
                 
+                        ip := add(ip, 1)
                         let value := readBytes(ip,maxAcceptablePos,32)
                 
                         sp := pushStackItem(sp, value, evmGasLeft)
@@ -5458,99 +5686,131 @@ object "EVMInterpreter" {
                     }
                     case 0x80 { // OP_DUP1 
                         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 1)
+                        ip := add(ip, 1)
                     }
                     case 0x81 { // OP_DUP2
                         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 2)
+                        ip := add(ip, 1)
                     }
                     case 0x82 { // OP_DUP3
                         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 3)
+                        ip := add(ip, 1)
                     }
                     case 0x83 { // OP_DUP4    
                         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 4)
+                        ip := add(ip, 1)
                     }
                     case 0x84 { // OP_DUP5
                         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 5)
+                        ip := add(ip, 1)
                     }
                     case 0x85 { // OP_DUP6
                         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 6)
+                        ip := add(ip, 1)
                     }
                     case 0x86 { // OP_DUP7    
                         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 7)
+                        ip := add(ip, 1)
                     }
                     case 0x87 { // OP_DUP8
                         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 8)
+                        ip := add(ip, 1)
                     }
                     case 0x88 { // OP_DUP9
                         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 9)
+                        ip := add(ip, 1)
                     }
                     case 0x89 { // OP_DUP10   
                         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 10)
+                        ip := add(ip, 1)
                     }
                     case 0x8A { // OP_DUP11
                         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 11)
+                        ip := add(ip, 1)
                     }
                     case 0x8B { // OP_DUP12
                         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 12)
+                        ip := add(ip, 1)
                     }
                     case 0x8C { // OP_DUP13
                         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 13)
+                        ip := add(ip, 1)
                     }
                     case 0x8D { // OP_DUP14
                         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 14)
+                        ip := add(ip, 1)
                     }
                     case 0x8E { // OP_DUP15
                         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 15)
+                        ip := add(ip, 1)
                     }
                     case 0x8F { // OP_DUP16
                         sp, evmGasLeft := dupStackItem(sp, evmGasLeft, 16)
+                        ip := add(ip, 1)
                     }
                     case 0x90 { // OP_SWAP1 
                         evmGasLeft := swapStackItem(sp, evmGasLeft, 1)
+                        ip := add(ip, 1)
                     }
                     case 0x91 { // OP_SWAP2
                         evmGasLeft := swapStackItem(sp, evmGasLeft, 2)
+                        ip := add(ip, 1)
                     }
                     case 0x92 { // OP_SWAP3
                         evmGasLeft := swapStackItem(sp, evmGasLeft, 3)
+                        ip := add(ip, 1)
                     }
                     case 0x93 { // OP_SWAP4    
                         evmGasLeft := swapStackItem(sp, evmGasLeft, 4)
+                        ip := add(ip, 1)
                     }
                     case 0x94 { // OP_SWAP5
                         evmGasLeft := swapStackItem(sp, evmGasLeft, 5)
+                        ip := add(ip, 1)
                     }
                     case 0x95 { // OP_SWAP6
                         evmGasLeft := swapStackItem(sp, evmGasLeft, 6)
+                        ip := add(ip, 1)
                     }
                     case 0x96 { // OP_SWAP7    
                         evmGasLeft := swapStackItem(sp, evmGasLeft, 7)
+                        ip := add(ip, 1)
                     }
                     case 0x97 { // OP_SWAP8
                         evmGasLeft := swapStackItem(sp, evmGasLeft, 8)
+                        ip := add(ip, 1)
                     }
                     case 0x98 { // OP_SWAP9
                         evmGasLeft := swapStackItem(sp, evmGasLeft, 9)
+                        ip := add(ip, 1)
                     }
                     case 0x99 { // OP_SWAP10   
                         evmGasLeft := swapStackItem(sp, evmGasLeft, 10)
+                        ip := add(ip, 1)
                     }
                     case 0x9A { // OP_SWAP11
                         evmGasLeft := swapStackItem(sp, evmGasLeft, 11)
+                        ip := add(ip, 1)
                     }
                     case 0x9B { // OP_SWAP12
                         evmGasLeft := swapStackItem(sp, evmGasLeft, 12)
+                        ip := add(ip, 1)
                     }
                     case 0x9C { // OP_SWAP13
                         evmGasLeft := swapStackItem(sp, evmGasLeft, 13)
+                        ip := add(ip, 1)
                     }
                     case 0x9D { // OP_SWAP14
                         evmGasLeft := swapStackItem(sp, evmGasLeft, 14)
+                        ip := add(ip, 1)
                     }
                     case 0x9E { // OP_SWAP15
                         evmGasLeft := swapStackItem(sp, evmGasLeft, 15)
+                        ip := add(ip, 1)
                     }
                     case 0x9F { // OP_SWAP16
                         evmGasLeft := swapStackItem(sp, evmGasLeft, 16)
+                        ip := add(ip, 1)
                     }
                     case 0xA0 { // OP_LOG0
                         evmGasLeft := chargeGas(evmGasLeft, 375)
@@ -5572,6 +5832,7 @@ object "EVMInterpreter" {
                         evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
                 
                         log0(add(offset, MEM_OFFSET_INNER()), size)
+                        ip := add(ip, 1)
                     }
                     case 0xA1 { // OP_LOG1
                         evmGasLeft := chargeGas(evmGasLeft, 375)
@@ -5595,6 +5856,7 @@ object "EVMInterpreter" {
                         evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
                 
                         log1(add(offset, MEM_OFFSET_INNER()), size, topic1)
+                        ip := add(ip, 1)
                     }
                     case 0xA2 { // OP_LOG2
                         evmGasLeft := chargeGas(evmGasLeft, 375)
@@ -5622,6 +5884,7 @@ object "EVMInterpreter" {
                             topic2, sp := popStackItemWithoutCheck(sp)
                             log2(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2)
                         }
+                        ip := add(ip, 1)
                     }
                     case 0xA3 { // OP_LOG3
                         evmGasLeft := chargeGas(evmGasLeft, 375)
@@ -5652,6 +5915,7 @@ object "EVMInterpreter" {
                             topic3, sp := popStackItemWithoutCheck(sp)
                             log3(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2, topic3)
                         }     
+                        ip := add(ip, 1)
                     }
                     case 0xA4 { // OP_LOG4
                         evmGasLeft := chargeGas(evmGasLeft, 375)
@@ -5682,9 +5946,11 @@ object "EVMInterpreter" {
                             topic4, sp := popStackItemWithoutCheck(sp)
                             log4(add(offset, MEM_OFFSET_INNER()), size, topic1, topic2, topic3, topic4)
                         }     
+                        ip := add(ip, 1)
                     }
                     case 0xF0 { // OP_CREATE
                         evmGasLeft, sp := performCreate(evmGasLeft, sp, isStatic)
+                        ip := add(ip, 1)
                     }
                     case 0xF1 { // OP_CALL
                         evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -5696,6 +5962,7 @@ object "EVMInterpreter" {
                 
                         // Check if the following is ok
                         evmGasLeft := chargeGas(evmGasLeft, gasUsed)
+                        ip := add(ip, 1)
                     }
                     case 0xF3 { // OP_RETURN
                         let offset,size
@@ -5719,6 +5986,7 @@ object "EVMInterpreter" {
                         sp, isStatic, gasUsed := delegateCall(sp, isStatic, evmGasLeft)
                 
                         evmGasLeft := chargeGas(evmGasLeft, gasUsed)
+                        ip := add(ip, 1)
                     }
                     case 0xF5 { // OP_CREATE2
                         let result, addr
@@ -5726,6 +5994,7 @@ object "EVMInterpreter" {
                         switch result
                         case 0 { sp := pushStackItem(sp, 0, evmGasLeft) }
                         default { sp := pushStackItem(sp, addr, evmGasLeft) }
+                        ip := add(ip, 1)
                     }
                     case 0xFA { // OP_STATICCALL
                         evmGasLeft := chargeGas(evmGasLeft, 100)
@@ -5733,6 +6002,7 @@ object "EVMInterpreter" {
                         let gasUsed
                         gasUsed, sp := performStaticCall(sp,evmGasLeft)
                         evmGasLeft := chargeGas(evmGasLeft,gasUsed)
+                        ip := add(ip, 1)
                     }
                     case 0xFD { // OP_REVERT
                         let offset,size

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -1326,7 +1326,7 @@ object "EVMInterpreter" {
             gasLeft := mload(0)
         }
         
-        function genericCreate(addr, offset, size, sp, value, evmGasLeftOld) -> result, evmGasLeft {
+        function $llvm_NoInline_llvm$_genericCreate(addr, offset, size, sp, value, evmGasLeftOld) -> result, evmGasLeft {
             pop($llvm_AlwaysInline_llvm$_warmAddress(addr))
         
             _eraseReturndataPointer()
@@ -1475,7 +1475,7 @@ object "EVMInterpreter" {
             let addr := getNewAddress(address())
         
             let result
-            result, evmGasLeft := genericCreate(addr, offset, size, sp, value, evmGasLeft)
+            result, evmGasLeft := $llvm_NoInline_llvm$_genericCreate(addr, offset, size, sp, value, evmGasLeft)
         
             switch result
                 case 0 { sp := pushStackItem(sp, 0, evmGasLeft) }
@@ -1532,7 +1532,7 @@ object "EVMInterpreter" {
                 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
             )
         
-            result, evmGasLeft := genericCreate(addr, offset, size, sp, value, evmGasLeft) 
+            result, evmGasLeft := $llvm_NoInline_llvm$_genericCreate(addr, offset, size, sp, value, evmGasLeft)
         }
         
 
@@ -4186,7 +4186,7 @@ object "EVMInterpreter" {
                 gasLeft := mload(0)
             }
             
-            function genericCreate(addr, offset, size, sp, value, evmGasLeftOld) -> result, evmGasLeft {
+            function $llvm_NoInline_llvm$_genericCreate(addr, offset, size, sp, value, evmGasLeftOld) -> result, evmGasLeft {
                 pop($llvm_AlwaysInline_llvm$_warmAddress(addr))
             
                 _eraseReturndataPointer()
@@ -4335,7 +4335,7 @@ object "EVMInterpreter" {
                 let addr := getNewAddress(address())
             
                 let result
-                result, evmGasLeft := genericCreate(addr, offset, size, sp, value, evmGasLeft)
+                result, evmGasLeft := $llvm_NoInline_llvm$_genericCreate(addr, offset, size, sp, value, evmGasLeft)
             
                 switch result
                     case 0 { sp := pushStackItem(sp, 0, evmGasLeft) }
@@ -4392,7 +4392,7 @@ object "EVMInterpreter" {
                     0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
                 )
             
-                result, evmGasLeft := genericCreate(addr, offset, size, sp, value, evmGasLeft) 
+                result, evmGasLeft := $llvm_NoInline_llvm$_genericCreate(addr, offset, size, sp, value, evmGasLeft)
             }
             
 


### PR DESCRIPTION
# What ❔
This PR optimizes opcodes by:
1. Adding noinline attribute to genericCreate function. This removes 2 copy instructions from the main loop, and moves them to the opcode handling. These two copies are not needed for each opcode, so instead of doing them regardless, do them where they are needed.
2. Sinking instruction pointer increment to opcode handling. Instruction pointer is incremented in the beginning of each iteration and copy instructions is introduced in majority of opcode handling to preserve the ip value. Instead of doing that, sink ip increment to opcode handling to prevent regalloc to introduce copy instructions.

This PR also fixes issue where uninitialized variable is passed to pushStackItem in genericCreate function.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
