### PR TITLE
Update solidity contracts version

### DIFF
--- a/gas-bound-caller/contracts/GasBoundCaller.sol
+++ b/gas-bound-caller/contracts/GasBoundCaller.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {EfficientCall} from "@matterlabs/zksync-contracts/l2/system-contracts/libraries/EfficientCall.sol";
 import {ISystemContext} from "./ISystemContext.sol";

--- a/gas-bound-caller/contracts/test-contracts/GasBoundCallerTester.sol
+++ b/gas-bound-caller/contracts/test-contracts/GasBoundCallerTester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {GasBoundCaller} from "../GasBoundCaller.sol";
 import {SystemContractHelper} from "./SystemContractHelper.sol";

--- a/l2-contracts/contracts/SystemContractsCaller.sol
+++ b/l2-contracts/contracts/SystemContractsCaller.sol
@@ -2,7 +2,7 @@
 
 // solhint-disable one-contract-per-file
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {MSG_VALUE_SYSTEM_CONTRACT} from "./L2ContractHelper.sol";
 

--- a/system-contracts/contracts/AccountCodeStorage.sol
+++ b/system-contracts/contracts/AccountCodeStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {IAccountCodeStorage} from "./interfaces/IAccountCodeStorage.sol";
 import {Utils} from "./libraries/Utils.sol";

--- a/system-contracts/contracts/BootloaderUtilities.sol
+++ b/system-contracts/contracts/BootloaderUtilities.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {IBootloaderUtilities} from "./interfaces/IBootloaderUtilities.sol";
 import {Transaction, TransactionHelper, EIP_712_TX_TYPE, LEGACY_TX_TYPE, EIP_2930_TX_TYPE, EIP_1559_TX_TYPE} from "./libraries/TransactionHelper.sol";

--- a/system-contracts/contracts/ComplexUpgrader.sol
+++ b/system-contracts/contracts/ComplexUpgrader.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {IComplexUpgrader} from "./interfaces/IComplexUpgrader.sol";
 import {FORCE_DEPLOYER} from "./Constants.sol";

--- a/system-contracts/contracts/Compressor.sol
+++ b/system-contracts/contracts/Compressor.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {ICompressor, OPERATION_BITMASK, LENGTH_BITS_OFFSET, MAX_ENUMERATION_INDEX_SIZE} from "./interfaces/ICompressor.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/system-contracts/contracts/Constants.sol
+++ b/system-contracts/contracts/Constants.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {IAccountCodeStorage} from "./interfaces/IAccountCodeStorage.sol";
 import {INonceHolder} from "./interfaces/INonceHolder.sol";

--- a/system-contracts/contracts/ContractDeployer.sol
+++ b/system-contracts/contracts/ContractDeployer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {ImmutableData} from "./interfaces/IImmutableSimulator.sol";
 import {IContractDeployer} from "./interfaces/IContractDeployer.sol";

--- a/system-contracts/contracts/Create2Factory.sol
+++ b/system-contracts/contracts/Create2Factory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {REAL_DEPLOYER_SYSTEM_CONTRACT} from "./Constants.sol";
 import {EfficientCall} from "./libraries/EfficientCall.sol";

--- a/system-contracts/contracts/DefaultAccount.sol
+++ b/system-contracts/contracts/DefaultAccount.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {IAccount, ACCOUNT_VALIDATION_SUCCESS_MAGIC} from "./interfaces/IAccount.sol";
 import {TransactionHelper, Transaction} from "./libraries/TransactionHelper.sol";

--- a/system-contracts/contracts/EmptyContract.sol
+++ b/system-contracts/contracts/EmptyContract.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 /**
  * @author Matter Labs

--- a/system-contracts/contracts/ImmutableSimulator.sol
+++ b/system-contracts/contracts/ImmutableSimulator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {IImmutableSimulator, ImmutableData} from "./interfaces/IImmutableSimulator.sol";
 import {DEPLOYER_SYSTEM_CONTRACT} from "./Constants.sol";

--- a/system-contracts/contracts/KnownCodesStorage.sol
+++ b/system-contracts/contracts/KnownCodesStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {IKnownCodesStorage} from "./interfaces/IKnownCodesStorage.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/system-contracts/contracts/L1Messenger.sol
+++ b/system-contracts/contracts/L1Messenger.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {IL1Messenger, L2ToL1Log, L2_L1_LOGS_TREE_DEFAULT_LEAF_HASH, L2_TO_L1_LOG_SERIALIZE_SIZE, STATE_DIFF_COMPRESSION_VERSION_NUMBER} from "./interfaces/IL1Messenger.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/system-contracts/contracts/L2BaseToken.sol
+++ b/system-contracts/contracts/L2BaseToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {IBaseToken} from "./interfaces/IBaseToken.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/system-contracts/contracts/MsgValueSimulator.sol
+++ b/system-contracts/contracts/MsgValueSimulator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {Utils} from "./libraries/Utils.sol";
 import {EfficientCall} from "./libraries/EfficientCall.sol";

--- a/system-contracts/contracts/NonceHolder.sol
+++ b/system-contracts/contracts/NonceHolder.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {INonceHolder} from "./interfaces/INonceHolder.sol";
 import {IContractDeployer} from "./interfaces/IContractDeployer.sol";

--- a/system-contracts/contracts/PubdataChunkPublisher.sol
+++ b/system-contracts/contracts/PubdataChunkPublisher.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {IPubdataChunkPublisher} from "./interfaces/IPubdataChunkPublisher.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/system-contracts/contracts/SystemContext.sol
+++ b/system-contracts/contracts/SystemContext.sol
@@ -2,7 +2,7 @@
 
 // solhint-disable reason-string, gas-custom-errors
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {ISystemContext} from "./interfaces/ISystemContext.sol";
 import {ISystemContract} from "./interfaces/ISystemContract.sol";

--- a/system-contracts/contracts/SystemContractErrors.sol
+++ b/system-contracts/contracts/SystemContractErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 error Unauthorized(address);
 error InvalidCodeHash(CodeHashReason);

--- a/system-contracts/contracts/interfaces/IAccount.sol
+++ b/system-contracts/contracts/interfaces/IAccount.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {Transaction} from "../libraries/TransactionHelper.sol";
 

--- a/system-contracts/contracts/interfaces/IAccountCodeStorage.sol
+++ b/system-contracts/contracts/interfaces/IAccountCodeStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 interface IAccountCodeStorage {
     function storeAccountConstructingCodeHash(address _address, bytes32 _hash) external;

--- a/system-contracts/contracts/interfaces/IBaseToken.sol
+++ b/system-contracts/contracts/interfaces/IBaseToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 interface IBaseToken {
     function balanceOf(uint256) external view returns (uint256);

--- a/system-contracts/contracts/interfaces/IBootloaderUtilities.sol
+++ b/system-contracts/contracts/interfaces/IBootloaderUtilities.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {Transaction} from "../libraries/TransactionHelper.sol";
 

--- a/system-contracts/contracts/interfaces/IComplexUpgrader.sol
+++ b/system-contracts/contracts/interfaces/IComplexUpgrader.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 /**
  * @author Matter Labs

--- a/system-contracts/contracts/interfaces/ICompressor.sol
+++ b/system-contracts/contracts/interfaces/ICompressor.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 // The bitmask by applying which to the compressed state diff metadata we retrieve its operation.
 uint8 constant OPERATION_BITMASK = 7;

--- a/system-contracts/contracts/interfaces/IContractDeployer.sol
+++ b/system-contracts/contracts/interfaces/IContractDeployer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 interface IContractDeployer {
     /// @notice Defines the version of the account abstraction protocol

--- a/system-contracts/contracts/interfaces/IImmutableSimulator.sol
+++ b/system-contracts/contracts/interfaces/IImmutableSimulator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 struct ImmutableData {
     uint256 index;

--- a/system-contracts/contracts/interfaces/IKnownCodesStorage.sol
+++ b/system-contracts/contracts/interfaces/IKnownCodesStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 /**
  * @author Matter Labs

--- a/system-contracts/contracts/interfaces/IL1Messenger.sol
+++ b/system-contracts/contracts/interfaces/IL1Messenger.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 /// @dev The log passed from L2
 /// @param l2ShardId The shard identifier, 0 - rollup, 1 - porter. All other values are not used but are reserved for the future

--- a/system-contracts/contracts/interfaces/IL2StandardToken.sol
+++ b/system-contracts/contracts/interfaces/IL2StandardToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 interface IL2StandardToken {
     event BridgeMint(address indexed _account, uint256 _amount);

--- a/system-contracts/contracts/interfaces/IMailbox.sol
+++ b/system-contracts/contracts/interfaces/IMailbox.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 interface IMailbox {
     function finalizeEthWithdrawal(

--- a/system-contracts/contracts/interfaces/INonceHolder.sol
+++ b/system-contracts/contracts/interfaces/INonceHolder.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 /**
  * @author Matter Labs

--- a/system-contracts/contracts/interfaces/IPaymaster.sol
+++ b/system-contracts/contracts/interfaces/IPaymaster.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {Transaction} from "../libraries/TransactionHelper.sol";
 

--- a/system-contracts/contracts/interfaces/IPaymasterFlow.sol
+++ b/system-contracts/contracts/interfaces/IPaymasterFlow.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 /**
  * @author Matter Labs

--- a/system-contracts/contracts/interfaces/IPubdataChunkPublisher.sol
+++ b/system-contracts/contracts/interfaces/IPubdataChunkPublisher.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 /**
  * @author Matter Labs

--- a/system-contracts/contracts/interfaces/ISystemContext.sol
+++ b/system-contracts/contracts/interfaces/ISystemContext.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 /**
  * @author Matter Labs

--- a/system-contracts/contracts/interfaces/ISystemContextDeprecated.sol
+++ b/system-contracts/contracts/interfaces/ISystemContextDeprecated.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 /**
  * @author Matter Labs

--- a/system-contracts/contracts/interfaces/ISystemContract.sol
+++ b/system-contracts/contracts/interfaces/ISystemContract.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {SystemContractHelper} from "../libraries/SystemContractHelper.sol";
 import {BOOTLOADER_FORMAL_ADDRESS, FORCE_DEPLOYER} from "../Constants.sol";

--- a/system-contracts/contracts/libraries/EfficientCall.sol
+++ b/system-contracts/contracts/libraries/EfficientCall.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {SystemContractHelper, ADDRESS_MASK} from "./SystemContractHelper.sol";
 import {SystemContractsCaller, CalldataForwardingMode, RAW_FAR_CALL_BY_REF_CALL_ADDRESS, SYSTEM_CALL_BY_REF_CALL_ADDRESS, MSG_VALUE_SIMULATOR_IS_SYSTEM_BIT, MIMIC_CALL_BY_REF_CALL_ADDRESS} from "./SystemContractsCaller.sol";

--- a/system-contracts/contracts/libraries/RLPEncoder.sol
+++ b/system-contracts/contracts/libraries/RLPEncoder.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 /**
  * @author Matter Labs

--- a/system-contracts/contracts/libraries/SystemContractHelper.sol
+++ b/system-contracts/contracts/libraries/SystemContractHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {MAX_SYSTEM_CONTRACT_ADDRESS} from "../Constants.sol";
 

--- a/system-contracts/contracts/libraries/SystemContractsCaller.sol
+++ b/system-contracts/contracts/libraries/SystemContractsCaller.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {MSG_VALUE_SYSTEM_CONTRACT, MSG_VALUE_SIMULATOR_IS_SYSTEM_BIT} from "../Constants.sol";
 import {Utils} from "./Utils.sol";

--- a/system-contracts/contracts/libraries/TransactionHelper.sol
+++ b/system-contracts/contracts/libraries/TransactionHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {IERC20} from "../openzeppelin/token/ERC20/IERC20.sol";
 import {SafeERC20} from "../openzeppelin/token/ERC20/utils/SafeERC20.sol";

--- a/system-contracts/contracts/libraries/UnsafeBytesCalldata.sol
+++ b/system-contracts/contracts/libraries/UnsafeBytesCalldata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 /**
  * @author Matter Labs

--- a/system-contracts/contracts/libraries/Utils.sol
+++ b/system-contracts/contracts/libraries/Utils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {EfficientCall} from "./EfficientCall.sol";
 import {MalformedBytecode, BytecodeError, Overflow} from "../SystemContractErrors.sol";

--- a/system-contracts/contracts/test-contracts/Deployable.sol
+++ b/system-contracts/contracts/test-contracts/Deployable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 contract Deployable {
     event Deployed(uint256 value, bytes data);

--- a/system-contracts/contracts/test-contracts/MockContract.sol
+++ b/system-contracts/contracts/test-contracts/MockContract.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 contract MockContract {
     event Called(uint256 value, bytes data);

--- a/system-contracts/contracts/test-contracts/SystemCaller.sol
+++ b/system-contracts/contracts/test-contracts/SystemCaller.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 import {SYSTEM_CALL_CALL_ADDRESS, MSG_VALUE_SIMULATOR_IS_SYSTEM_BIT, SystemContractsCaller, CalldataForwardingMode} from "../libraries/SystemContractsCaller.sol";
 import {Utils} from "../libraries/Utils.sol";

--- a/system-contracts/hardhat.config.ts
+++ b/system-contracts/hardhat.config.ts
@@ -34,8 +34,9 @@ export default {
     ethNetwork: "http://localhost:8545",
   },
   solidity: {
-    version: "0.8.20",
+    version: "0.8.24",
     settings: {
+      evmVersion: "cancun",
       optimizer: {
         enabled: true,
         runs: 9999999,


### PR DESCRIPTION
# What ❔

Updates the solc version on system contracts to be `0.8.24`.

## Why ❔

The EVM interpreter uses the `tstore/tload` opcodes, which were not present yet in 0.8.20. We need to bump this version to be able to integrate it with `zksync-era`.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
