### PR TITLE
[EVM-Equivalence-YUL] fix: extcodecopy reverting when size was zero

### DIFF
--- a/system-contracts/contracts/EvmInterpreterFunctions.template.yul
+++ b/system-contracts/contracts/EvmInterpreterFunctions.template.yul
@@ -1345,10 +1345,12 @@ function performExtCodeCopy(evmGas,oldSp) -> evmGasLeft, sp {
     }
     evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
 
+
     let len_32 := shr(5, len)
     for {let i := 0} lt(i, len_32) { i := add(i, 1) } {
         mstore(add(dest,shl(5,i)),0)
     }
+
     let size_32 := shl(5,len_32)
     let rest_32 := sub(len, size_32)
     for {let i := 0} lt(i, rest_32) { i := add(i, 1) } {
@@ -1356,10 +1358,9 @@ function performExtCodeCopy(evmGas,oldSp) -> evmGasLeft, sp {
     }
 
     // Gets the code from the addr
-    if iszero(iszero(_getRawCodeHash(addr))) {
+    if and(iszero(iszero(_getRawCodeHash(addr))),gt(len,0)) {
         pop(_fetchDeployedCodeWithDest(addr, offset, len,add(dest,MEM_OFFSET_INNER())))  
     }
-
 }
 
 function performCreate(evmGas,oldSp,isStatic) -> evmGasLeft, sp {

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -1419,10 +1419,12 @@ object "EVMInterpreter" {
             }
             evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
         
+        
             let len_32 := shr(5, len)
             for {let i := 0} lt(i, len_32) { i := add(i, 1) } {
                 mstore(add(dest,shl(5,i)),0)
             }
+        
             let size_32 := shl(5,len_32)
             let rest_32 := sub(len, size_32)
             for {let i := 0} lt(i, rest_32) { i := add(i, 1) } {
@@ -1430,10 +1432,9 @@ object "EVMInterpreter" {
             }
         
             // Gets the code from the addr
-            if iszero(iszero(_getRawCodeHash(addr))) {
+            if and(iszero(iszero(_getRawCodeHash(addr))),gt(len,0)) {
                 pop(_fetchDeployedCodeWithDest(addr, offset, len,add(dest,MEM_OFFSET_INNER())))  
             }
-        
         }
         
         function performCreate(evmGas,oldSp,isStatic) -> evmGasLeft, sp {
@@ -4414,10 +4415,12 @@ object "EVMInterpreter" {
                 }
                 evmGasLeft := chargeGas(evmGasLeft, dynamicGas)
             
+            
                 let len_32 := shr(5, len)
                 for {let i := 0} lt(i, len_32) { i := add(i, 1) } {
                     mstore(add(dest,shl(5,i)),0)
                 }
+            
                 let size_32 := shl(5,len_32)
                 let rest_32 := sub(len, size_32)
                 for {let i := 0} lt(i, rest_32) { i := add(i, 1) } {
@@ -4425,10 +4428,9 @@ object "EVMInterpreter" {
                 }
             
                 // Gets the code from the addr
-                if iszero(iszero(_getRawCodeHash(addr))) {
+                if and(iszero(iszero(_getRawCodeHash(addr))),gt(len,0)) {
                     pop(_fetchDeployedCodeWithDest(addr, offset, len,add(dest,MEM_OFFSET_INNER())))  
                 }
-            
             }
             
             function performCreate(evmGas,oldSp,isStatic) -> evmGasLeft, sp {


### PR DESCRIPTION
# What ❔

This PR fixes the following semantic test:

`solidity/test/libsolidity/semanticTests/various/address_code.sol`

The test was failing on the `EXTODECOPY` opcode implementation, which calls the `CodeOracle` system contract underneath. When the passed `size ` for it was zero, the `staticcall` to the `CodeOracle` would return 0 and the interpreter reverted. This fixes it to check if the `size` specified is zero, and if so, simply does nothing.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
