### PR TITLE
fix: zksync-ethers v5 dependency

### DIFF
--- a/gas-bound-caller/package.json
+++ b/gas-bound-caller/package.json
@@ -15,7 +15,7 @@
     "fast-glob": "^3.3.2",
     "hardhat": "^2.18.3",
     "preprocess": "^3.2.0",
-    "zksync-ethers": "https://github.com/zksync-sdk/zksync-ethers#ethers-v5-feat/bridgehub"
+    "zksync-ethers": "^5.9.0"
   },
   "devDependencies": {
     "@matterlabs/hardhat-zksync-chai-matchers": "^0.1.4",
@@ -39,7 +39,7 @@
     "ts-node": "^10.1.0",
     "typechain": "^4.0.0",
     "typescript": "^4.6.4",
-    "zksync-ethers": "https://github.com/zksync-sdk/zksync-ethers#ethers-v5-feat/bridgehub"
+    "zksync-ethers": "^5.9.0"
   },
   "mocha": {
     "timeout": 240000,

--- a/l1-contracts/package.json
+++ b/l1-contracts/package.json
@@ -50,7 +50,7 @@
     "ts-node": "^10.1.0",
     "typechain": "^4.0.0",
     "typescript": "^4.6.4",
-    "zksync-ethers": "https://github.com/zksync-sdk/zksync-ethers#ethers-v5-feat/bridgehub"
+    "zksync-ethers": "^5.9.0"
   },
   "scripts": {
     "build": "hardhat compile",

--- a/l1-contracts/src.ts/deploy-test-process.ts
+++ b/l1-contracts/src.ts/deploy-test-process.ts
@@ -7,7 +7,7 @@ import * as ethers from "ethers";
 import type { BigNumberish, Wallet } from "ethers";
 import { Interface } from "ethers/lib/utils";
 import * as zkethers from "zksync-ethers";
-import { ETH_ADDRESS_IN_CONTRACTS } from "zksync-ethers/build/src/utils";
+import { ETH_ADDRESS_IN_CONTRACTS } from "zksync-ethers/build/utils";
 import * as fs from "fs";
 
 import type { FacetCut } from "./diamondCut";

--- a/l1-contracts/test/unit_tests/l2-upgrade.test.spec.ts
+++ b/l1-contracts/test/unit_tests/l2-upgrade.test.spec.ts
@@ -3,7 +3,7 @@ import type { BigNumberish } from "ethers";
 import { Wallet } from "ethers";
 import * as ethers from "ethers";
 import * as hardhat from "hardhat";
-import { hashBytecode } from "zksync-ethers/build/src/utils";
+import { hashBytecode } from "zksync-ethers/build/utils";
 
 import type { AdminFacet, ExecutorFacet, GettersFacet, StateTransitionManager } from "../../typechain";
 import {

--- a/l1-contracts/test/unit_tests/utils.ts
+++ b/l1-contracts/test/unit_tests/utils.ts
@@ -1,8 +1,8 @@
 import * as hardhat from "hardhat";
 import type { BigNumberish, BytesLike } from "ethers";
 import { BigNumber, ethers } from "ethers";
-import type { Address } from "zksync-ethers/build/src/types";
-import { REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT } from "zksync-ethers/build/src/utils";
+import type { Address } from "zksync-ethers/build/types";
+import { REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT } from "zksync-ethers/build/utils";
 
 import type { IBridgehub } from "../../typechain/IBridgehub";
 import type { IL1ERC20Bridge } from "../../typechain/IL1ERC20Bridge";

--- a/system-contracts/package.json
+++ b/system-contracts/package.json
@@ -15,7 +15,7 @@
     "fast-glob": "^3.3.2",
     "hardhat": "=2.22.2",
     "preprocess": "^3.2.0",
-    "zksync-ethers": "https://github.com/zksync-sdk/zksync-ethers#ethers-v5-feat/bridgehub"
+    "zksync-ethers": "^5.9.0"
   },
   "devDependencies": {
     "@matterlabs/hardhat-zksync-chai-matchers": "^0.1.4",
@@ -38,7 +38,7 @@
     "ts-node": "^10.1.0",
     "typechain": "^4.0.0",
     "typescript": "^4.6.4",
-    "zksync-ethers": "https://github.com/zksync-sdk/zksync-ethers#ethers-v5-feat/bridgehub"
+    "zksync-ethers": "^5.9.0"
   },
   "mocha": {
     "timeout": 240000,

--- a/system-contracts/scripts/verify-on-explorer.ts
+++ b/system-contracts/scripts/verify-on-explorer.ts
@@ -6,7 +6,7 @@ import { SYSTEM_CONTRACTS } from "./constants";
 import { query } from "./utils";
 import { Command } from "commander";
 import * as fs from "fs";
-import { sleep } from "zksync-ethers/build/src/utils";
+import { sleep } from "zksync-ethers/build/utils";
 
 const VERIFICATION_URL = hre.network?.config?.verifyURL;
 

--- a/system-contracts/test/BootloaderUtilities.spec.ts
+++ b/system-contracts/test/BootloaderUtilities.spec.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import type { Wallet } from "zksync-ethers";
 import * as zksync from "zksync-ethers";
-import { serialize } from "zksync-ethers/build/src/utils";
+import { serialize } from "zksync-ethers/build/utils";
 import type { BootloaderUtilities } from "../typechain";
 import { BootloaderUtilitiesFactory } from "../typechain";
 import { TEST_BOOTLOADER_UTILITIES_ADDRESS } from "./shared/constants";

--- a/system-contracts/test/Create2Factory.spec.ts
+++ b/system-contracts/test/Create2Factory.spec.ts
@@ -3,7 +3,7 @@ import { ethers } from "hardhat";
 import type { Wallet } from "zksync-ethers";
 import type { Create2Factory } from "../typechain";
 import { deployContract, getWallets, loadArtifact } from "./shared/utils";
-import { create2Address, getDeployedContracts, hashBytecode } from "zksync-ethers/build/src/utils";
+import { create2Address, getDeployedContracts, hashBytecode } from "zksync-ethers/build/utils";
 
 describe("Create2Factory tests", function () {
   let wallet: Wallet;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7654,9 +7654,10 @@ zksync-ethers@^5.0.0:
   dependencies:
     ethers "~5.7.0"
 
-"zksync-ethers@https://github.com/zksync-sdk/zksync-ethers#ethers-v5-feat/bridgehub":
-  version "5.1.0"
-  resolved "https://github.com/zksync-sdk/zksync-ethers#28ccbe7d67b170c202b17475e06a82002e6e3acc"
+zksync-ethers@^5.9.0:
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/zksync-ethers/-/zksync-ethers-5.9.2.tgz#1c5f34cb25ac0b040fd1a6118f2ba1c2c3bda090"
+  integrity sha512-Y2Mx6ovvxO6UdC2dePLguVzvNToOY8iLWeq5ne+jgGSJxAi/f4He/NF6FNsf6x1aWX0o8dy4Df8RcOQXAkj5qw==
   dependencies:
     ethers "~5.7.0"
 


### PR DESCRIPTION
# What ❔

Changing `zksync-ethers` dependency source to `v5.9.0` version from development branch.
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
