### PR TITLE
[EVM-Equivalence-YUL] Check offset overflow earlier in memory opcodes

### DIFF
--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -619,11 +619,11 @@ for { } true { } {
 
         offset, sp := popStackItem(sp, evmGasLeft)
 
+        checkOverflow(offset, MEM_OFFSET_INNER(), evmGasLeft)
         checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
         let expansionGas := expandMemory(add(offset, 32))
         evmGasLeft := chargeGas(evmGasLeft, expansionGas)
 
-        checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
         let memValue := mload(add(MEM_OFFSET_INNER(), offset))
         sp := pushStackItem(sp, memValue, evmGasLeft)
         ip := add(ip, 1)
@@ -637,11 +637,11 @@ for { } true { } {
         offset, sp := popStackItemWithoutCheck(sp)
         value, sp := popStackItemWithoutCheck(sp)
 
+        checkOverflow(offset, MEM_OFFSET_INNER(), evmGasLeft)
         checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
         let expansionGas := expandMemory(add(offset, 32))
         evmGasLeft := chargeGas(evmGasLeft, expansionGas)
 
-        checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
         mstore(add(MEM_OFFSET_INNER(), offset), value)
         ip := add(ip, 1)
     }
@@ -654,11 +654,11 @@ for { } true { } {
         offset, sp := popStackItemWithoutCheck(sp)
         value, sp := popStackItemWithoutCheck(sp)
 
+        checkOverflow(offset, MEM_OFFSET_INNER(), evmGasLeft)
         checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
         let expansionGas := expandMemory(add(offset, 1))
         evmGasLeft := chargeGas(evmGasLeft, expansionGas)
 
-        checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
         mstore8(add(MEM_OFFSET_INNER(), offset), value)
         ip := add(ip, 1)
     }

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -2167,11 +2167,11 @@ object "EVMInterpreter" {
             
                     offset, sp := popStackItem(sp, evmGasLeft)
             
+                    checkOverflow(offset, MEM_OFFSET_INNER(), evmGasLeft)
                     checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
                     let expansionGas := expandMemory(add(offset, 32))
                     evmGasLeft := chargeGas(evmGasLeft, expansionGas)
             
-                    checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
                     let memValue := mload(add(MEM_OFFSET_INNER(), offset))
                     sp := pushStackItem(sp, memValue, evmGasLeft)
                     ip := add(ip, 1)
@@ -2185,11 +2185,11 @@ object "EVMInterpreter" {
                     offset, sp := popStackItemWithoutCheck(sp)
                     value, sp := popStackItemWithoutCheck(sp)
             
+                    checkOverflow(offset, MEM_OFFSET_INNER(), evmGasLeft)
                     checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
                     let expansionGas := expandMemory(add(offset, 32))
                     evmGasLeft := chargeGas(evmGasLeft, expansionGas)
             
-                    checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
                     mstore(add(MEM_OFFSET_INNER(), offset), value)
                     ip := add(ip, 1)
                 }
@@ -2202,11 +2202,11 @@ object "EVMInterpreter" {
                     offset, sp := popStackItemWithoutCheck(sp)
                     value, sp := popStackItemWithoutCheck(sp)
             
+                    checkOverflow(offset, MEM_OFFSET_INNER(), evmGasLeft)
                     checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
                     let expansionGas := expandMemory(add(offset, 1))
                     evmGasLeft := chargeGas(evmGasLeft, expansionGas)
             
-                    checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
                     mstore8(add(MEM_OFFSET_INNER(), offset), value)
                     ip := add(ip, 1)
                 }
@@ -5163,11 +5163,11 @@ object "EVMInterpreter" {
                 
                         offset, sp := popStackItem(sp, evmGasLeft)
                 
+                        checkOverflow(offset, MEM_OFFSET_INNER(), evmGasLeft)
                         checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
                         let expansionGas := expandMemory(add(offset, 32))
                         evmGasLeft := chargeGas(evmGasLeft, expansionGas)
                 
-                        checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
                         let memValue := mload(add(MEM_OFFSET_INNER(), offset))
                         sp := pushStackItem(sp, memValue, evmGasLeft)
                         ip := add(ip, 1)
@@ -5181,11 +5181,11 @@ object "EVMInterpreter" {
                         offset, sp := popStackItemWithoutCheck(sp)
                         value, sp := popStackItemWithoutCheck(sp)
                 
+                        checkOverflow(offset, MEM_OFFSET_INNER(), evmGasLeft)
                         checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
                         let expansionGas := expandMemory(add(offset, 32))
                         evmGasLeft := chargeGas(evmGasLeft, expansionGas)
                 
-                        checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
                         mstore(add(MEM_OFFSET_INNER(), offset), value)
                         ip := add(ip, 1)
                     }
@@ -5198,11 +5198,11 @@ object "EVMInterpreter" {
                         offset, sp := popStackItemWithoutCheck(sp)
                         value, sp := popStackItemWithoutCheck(sp)
                 
+                        checkOverflow(offset, MEM_OFFSET_INNER(), evmGasLeft)
                         checkMemOverflow(add(offset, MEM_OFFSET_INNER()), evmGasLeft)
                         let expansionGas := expandMemory(add(offset, 1))
                         evmGasLeft := chargeGas(evmGasLeft, expansionGas)
                 
-                        checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
                         mstore8(add(MEM_OFFSET_INNER(), offset), value)
                         ip := add(ip, 1)
                     }


### PR DESCRIPTION
# What ❔

Looks like checking offset for overflow happens too late. Also, earlier checking shows better benchmark results in most cases (for some reason).

```
╠═╡ Ergs/gas (-%) ╞═╡ EVMInterpreter M3B3 ╞═╣
║ CALLDATACOPY                       -1.347 ║
║ CODECOPY                           -0.738 ║
║ RETURNDATACOPY                     -1.474 ║
║ MLOAD                               2.840 ║
║ MSTORE8                             5.079 ║
║ SWAP1                               8.496 ║
║ SWAP2                               4.248 ║
║ SWAP3                               4.248 ║
║ SWAP4                               4.248 ║
║ SWAP6                               4.248 ║
║ SWAP7                               4.248 ║
║ SWAP8                               4.248 ║
║ SWAP9                               4.248 ║
║ SWAP10                              4.248 ║
║ SWAP11                              4.248 ║
║ SWAP12                              4.248 ║
║ SWAP13                              4.248 ║
║ SWAP14                              4.248 ║
║ SWAP15                              4.248 ║
║ SWAP16                              4.248 ║
║ CALL                                0.082 ║
║ STATICCALL                          0.082 ║
║ DELEGATECALL                        0.083 ║
╚═══════════════════════════════════════════╝
```

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
