### PR TITLE
[EVM-Equivalence-YUL] Remove pop push check

### DIFF
--- a/system-contracts/contracts/EvmInterpreterFunctions.template.yul
+++ b/system-contracts/contracts/EvmInterpreterFunctions.template.yul
@@ -164,15 +164,6 @@ function popStackCheck(sp, evmGasLeft, numInputs) {
     }
 }
 
-function popPushStackCheck(sp, evmGasLeft, numInputs) {
-    let popCheck := lt(sub(sp, mul(0x20, sub(numInputs, 1))), STACK_OFFSET())
-    let pushOffset := sub(sp, mul(0x20, numInputs))
-    let pushCheck := or(gt(pushOffset, BYTECODE_OFFSET()), eq(pushOffset, BYTECODE_OFFSET()))
-    if or(popCheck, pushCheck) {
-        revertWithGas(evmGasLeft)
-    }
-}
-
 function getCodeAddress() -> addr {
     addr := verbatim_0i_1o("code_source")
 }

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -19,7 +19,7 @@ for { } true { } {
 
         let a, b
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         a, sp := popStackItemWithoutCheck(sp)
         b, sp := popStackItemWithoutCheck(sp)
 
@@ -31,7 +31,7 @@ for { } true { } {
 
         let a, b
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         a, sp := popStackItemWithoutCheck(sp)
         b, sp := popStackItemWithoutCheck(sp)
 
@@ -43,7 +43,7 @@ for { } true { } {
 
         let a, b
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         a, sp := popStackItemWithoutCheck(sp)
         b, sp := popStackItemWithoutCheck(sp)
 
@@ -55,7 +55,7 @@ for { } true { } {
 
         let a, b
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         a, sp := popStackItemWithoutCheck(sp)
         b, sp := popStackItemWithoutCheck(sp)
 
@@ -67,7 +67,7 @@ for { } true { } {
 
         let a, b
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         a, sp := popStackItemWithoutCheck(sp)
         b, sp := popStackItemWithoutCheck(sp)
 
@@ -79,7 +79,7 @@ for { } true { } {
 
         let a, b
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         a, sp := popStackItemWithoutCheck(sp)
         b, sp := popStackItemWithoutCheck(sp)
 
@@ -91,7 +91,7 @@ for { } true { } {
 
         let a, b
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         a, sp := popStackItemWithoutCheck(sp)
         b, sp := popStackItemWithoutCheck(sp)
 
@@ -103,7 +103,7 @@ for { } true { } {
 
         let a, b, N
 
-        popPushStackCheck(sp, evmGasLeft, 3)
+        popStackCheck(sp, evmGasLeft, 3)
         a, sp := popStackItemWithoutCheck(sp)
         b, sp := popStackItemWithoutCheck(sp)
         N, sp := popStackItemWithoutCheck(sp)
@@ -129,7 +129,7 @@ for { } true { } {
 
         let a, exponent
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         a, sp := popStackItemWithoutCheck(sp)
         exponent, sp := popStackItemWithoutCheck(sp)
 
@@ -148,7 +148,7 @@ for { } true { } {
 
         let b, x
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         b, sp := popStackItemWithoutCheck(sp)
         x, sp := popStackItemWithoutCheck(sp)
 
@@ -160,7 +160,7 @@ for { } true { } {
 
         let a, b
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         a, sp := popStackItemWithoutCheck(sp)
         b, sp := popStackItemWithoutCheck(sp)
 
@@ -172,7 +172,7 @@ for { } true { } {
 
         let a, b
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         a, sp := popStackItemWithoutCheck(sp)
         b, sp := popStackItemWithoutCheck(sp)
 
@@ -184,7 +184,7 @@ for { } true { } {
 
         let a, b
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         a, sp := popStackItemWithoutCheck(sp)
         b, sp := popStackItemWithoutCheck(sp)
 
@@ -196,7 +196,7 @@ for { } true { } {
 
         let a, b
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         a, sp := popStackItemWithoutCheck(sp)
         b, sp := popStackItemWithoutCheck(sp)
 
@@ -208,7 +208,7 @@ for { } true { } {
 
         let a, b
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         a, sp := popStackItemWithoutCheck(sp)
         b, sp := popStackItemWithoutCheck(sp)
 
@@ -220,7 +220,7 @@ for { } true { } {
 
         let a
 
-        popPushStackCheck(sp, evmGasLeft, 1)
+        popStackCheck(sp, evmGasLeft, 1)
         a, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, iszero(a))
@@ -231,7 +231,7 @@ for { } true { } {
 
         let a, b
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         a, sp := popStackItemWithoutCheck(sp)
         b, sp := popStackItemWithoutCheck(sp)
 
@@ -243,7 +243,7 @@ for { } true { } {
 
         let a, b
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         a, sp := popStackItemWithoutCheck(sp)
         b, sp := popStackItemWithoutCheck(sp)
 
@@ -255,7 +255,7 @@ for { } true { } {
 
         let a, b
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         a, sp := popStackItemWithoutCheck(sp)
         b, sp := popStackItemWithoutCheck(sp)
 
@@ -267,7 +267,7 @@ for { } true { } {
 
         let a
 
-        popPushStackCheck(sp, evmGasLeft, 1)
+        popStackCheck(sp, evmGasLeft, 1)
         a, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, not(a))
@@ -278,7 +278,7 @@ for { } true { } {
 
         let i, x
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         i, sp := popStackItemWithoutCheck(sp)
         x, sp := popStackItemWithoutCheck(sp)
 
@@ -290,7 +290,7 @@ for { } true { } {
 
         let shift, value
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         shift, sp := popStackItemWithoutCheck(sp)
         value, sp := popStackItemWithoutCheck(sp)
 
@@ -302,7 +302,7 @@ for { } true { } {
 
         let shift, value
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         shift, sp := popStackItemWithoutCheck(sp)
         value, sp := popStackItemWithoutCheck(sp)
 
@@ -314,7 +314,7 @@ for { } true { } {
 
         let shift, value
 
-        popPushStackCheck(sp, evmGasLeft, 2)
+        popStackCheck(sp, evmGasLeft, 2)
         shift, sp := popStackItemWithoutCheck(sp)
         value, sp := popStackItemWithoutCheck(sp)
 
@@ -388,7 +388,7 @@ for { } true { } {
 
         let i
 
-        popPushStackCheck(sp, evmGasLeft, 1)
+        popStackCheck(sp, evmGasLeft, 1)
         i, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, calldataload(i))
@@ -558,7 +558,7 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, 20)
 
         let blockNumber
-        popPushStackCheck(sp, evmGasLeft, 1)
+        popStackCheck(sp, evmGasLeft, 1)
         blockNumber, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, blockhash(blockNumber))
@@ -796,7 +796,7 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, 100)
 
         let key
-        popPushStackCheck(sp, evmGasLeft, 1)
+        popStackCheck(sp, evmGasLeft, 1)
         key, sp := popStackItemWithoutCheck(sp)
 
         sp := pushStackItemWithoutCheck(sp, tload(key))

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -362,7 +362,7 @@ for { } true { } {
             evmGasLeft := chargeGas(evmGasLeft, 2500)
         }
 
-        sp := pushStackItem(sp, balance(addr), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, balance(addr))
         ip := add(ip, 1)
     }
     case 0x32 { // OP_ORIGIN
@@ -495,8 +495,8 @@ for { } true { } {
         // sp := pushStackItem(sp, extcodesize(addr), evmGasLeft)
 
         switch _isEVM(addr) 
-            case 0  { sp := pushStackItem(sp, extcodesize(addr), evmGasLeft) }
-            default { sp := pushStackItem(sp, _fetchDeployedCodeLen(addr), evmGasLeft) }
+            case 0  { sp := pushStackItemWithoutCheck(sp, extcodesize(addr)) }
+            default { sp := pushStackItemWithoutCheck(sp, _fetchDeployedCodeLen(addr)) }
         ip := add(ip, 1)
     }
     case 0x3C { // OP_EXTCODECOPY
@@ -549,10 +549,10 @@ for { } true { } {
 
         ip := add(ip, 1)
         if iszero(addr) {
-            sp := pushStackItem(sp, 0, evmGasLeft)
+            sp := pushStackItemWithoutCheck(sp, 0)
             continue
         }
-        sp := pushStackItem(sp, extcodehash(addr), evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, extcodehash(addr))
     }
     case 0x40 { // OP_BLOCKHASH
         evmGasLeft := chargeGas(evmGasLeft, 20)
@@ -625,7 +625,7 @@ for { } true { } {
         evmGasLeft := chargeGas(evmGasLeft, expansionGas)
 
         let memValue := mload(add(MEM_OFFSET_INNER(), offset))
-        sp := pushStackItem(sp, memValue, evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp, memValue)
         ip := add(ip, 1)
     }
     case 0x52 { // OP_MSTORE
@@ -682,7 +682,7 @@ for { } true { } {
             let _wasW, _orgV := warmSlot(key, value)
         }
 
-        sp := pushStackItem(sp,value, evmGasLeft)
+        sp := pushStackItemWithoutCheck(sp,value)
         ip := add(ip, 1)
     }
     case 0x55 { // OP_SSTORE

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -1901,7 +1901,7 @@ object "EVMInterpreter" {
                         evmGasLeft := chargeGas(evmGasLeft, 2500)
                     }
             
-                    sp := pushStackItem(sp, balance(addr), evmGasLeft)
+                    sp := pushStackItemWithoutCheck(sp, balance(addr))
                     ip := add(ip, 1)
                 }
                 case 0x32 { // OP_ORIGIN
@@ -2034,8 +2034,8 @@ object "EVMInterpreter" {
                     // sp := pushStackItem(sp, extcodesize(addr), evmGasLeft)
             
                     switch _isEVM(addr) 
-                        case 0  { sp := pushStackItem(sp, extcodesize(addr), evmGasLeft) }
-                        default { sp := pushStackItem(sp, _fetchDeployedCodeLen(addr), evmGasLeft) }
+                        case 0  { sp := pushStackItemWithoutCheck(sp, extcodesize(addr)) }
+                        default { sp := pushStackItemWithoutCheck(sp, _fetchDeployedCodeLen(addr)) }
                     ip := add(ip, 1)
                 }
                 case 0x3C { // OP_EXTCODECOPY
@@ -2088,10 +2088,10 @@ object "EVMInterpreter" {
             
                     ip := add(ip, 1)
                     if iszero(addr) {
-                        sp := pushStackItem(sp, 0, evmGasLeft)
+                        sp := pushStackItemWithoutCheck(sp, 0)
                         continue
                     }
-                    sp := pushStackItem(sp, extcodehash(addr), evmGasLeft)
+                    sp := pushStackItemWithoutCheck(sp, extcodehash(addr))
                 }
                 case 0x40 { // OP_BLOCKHASH
                     evmGasLeft := chargeGas(evmGasLeft, 20)
@@ -2164,7 +2164,7 @@ object "EVMInterpreter" {
                     evmGasLeft := chargeGas(evmGasLeft, expansionGas)
             
                     let memValue := mload(add(MEM_OFFSET_INNER(), offset))
-                    sp := pushStackItem(sp, memValue, evmGasLeft)
+                    sp := pushStackItemWithoutCheck(sp, memValue)
                     ip := add(ip, 1)
                 }
                 case 0x52 { // OP_MSTORE
@@ -2221,7 +2221,7 @@ object "EVMInterpreter" {
                         let _wasW, _orgV := warmSlot(key, value)
                     }
             
-                    sp := pushStackItem(sp,value, evmGasLeft)
+                    sp := pushStackItemWithoutCheck(sp,value)
                     ip := add(ip, 1)
                 }
                 case 0x55 { // OP_SSTORE
@@ -4888,7 +4888,7 @@ object "EVMInterpreter" {
                             evmGasLeft := chargeGas(evmGasLeft, 2500)
                         }
                 
-                        sp := pushStackItem(sp, balance(addr), evmGasLeft)
+                        sp := pushStackItemWithoutCheck(sp, balance(addr))
                         ip := add(ip, 1)
                     }
                     case 0x32 { // OP_ORIGIN
@@ -5021,8 +5021,8 @@ object "EVMInterpreter" {
                         // sp := pushStackItem(sp, extcodesize(addr), evmGasLeft)
                 
                         switch _isEVM(addr) 
-                            case 0  { sp := pushStackItem(sp, extcodesize(addr), evmGasLeft) }
-                            default { sp := pushStackItem(sp, _fetchDeployedCodeLen(addr), evmGasLeft) }
+                            case 0  { sp := pushStackItemWithoutCheck(sp, extcodesize(addr)) }
+                            default { sp := pushStackItemWithoutCheck(sp, _fetchDeployedCodeLen(addr)) }
                         ip := add(ip, 1)
                     }
                     case 0x3C { // OP_EXTCODECOPY
@@ -5075,10 +5075,10 @@ object "EVMInterpreter" {
                 
                         ip := add(ip, 1)
                         if iszero(addr) {
-                            sp := pushStackItem(sp, 0, evmGasLeft)
+                            sp := pushStackItemWithoutCheck(sp, 0)
                             continue
                         }
-                        sp := pushStackItem(sp, extcodehash(addr), evmGasLeft)
+                        sp := pushStackItemWithoutCheck(sp, extcodehash(addr))
                     }
                     case 0x40 { // OP_BLOCKHASH
                         evmGasLeft := chargeGas(evmGasLeft, 20)
@@ -5151,7 +5151,7 @@ object "EVMInterpreter" {
                         evmGasLeft := chargeGas(evmGasLeft, expansionGas)
                 
                         let memValue := mload(add(MEM_OFFSET_INNER(), offset))
-                        sp := pushStackItem(sp, memValue, evmGasLeft)
+                        sp := pushStackItemWithoutCheck(sp, memValue)
                         ip := add(ip, 1)
                     }
                     case 0x52 { // OP_MSTORE
@@ -5208,7 +5208,7 @@ object "EVMInterpreter" {
                             let _wasW, _orgV := warmSlot(key, value)
                         }
                 
-                        sp := pushStackItem(sp,value, evmGasLeft)
+                        sp := pushStackItemWithoutCheck(sp,value)
                         ip := add(ip, 1)
                     }
                     case 0x55 { // OP_SSTORE

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -238,15 +238,6 @@ object "EVMInterpreter" {
             }
         }
         
-        function popPushStackCheck(sp, evmGasLeft, numInputs) {
-            let popCheck := lt(sub(sp, mul(0x20, sub(numInputs, 1))), STACK_OFFSET())
-            let pushOffset := sub(sp, mul(0x20, numInputs))
-            let pushCheck := or(gt(pushOffset, BYTECODE_OFFSET()), eq(pushOffset, BYTECODE_OFFSET()))
-            if or(popCheck, pushCheck) {
-                revertWithGas(evmGasLeft)
-            }
-        }
-        
         function getCodeAddress() -> addr {
             addr := verbatim_0i_1o("code_source")
         }
@@ -1567,7 +1558,7 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     a, sp := popStackItemWithoutCheck(sp)
                     b, sp := popStackItemWithoutCheck(sp)
             
@@ -1579,7 +1570,7 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     a, sp := popStackItemWithoutCheck(sp)
                     b, sp := popStackItemWithoutCheck(sp)
             
@@ -1591,7 +1582,7 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     a, sp := popStackItemWithoutCheck(sp)
                     b, sp := popStackItemWithoutCheck(sp)
             
@@ -1603,7 +1594,7 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     a, sp := popStackItemWithoutCheck(sp)
                     b, sp := popStackItemWithoutCheck(sp)
             
@@ -1615,7 +1606,7 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     a, sp := popStackItemWithoutCheck(sp)
                     b, sp := popStackItemWithoutCheck(sp)
             
@@ -1627,7 +1618,7 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     a, sp := popStackItemWithoutCheck(sp)
                     b, sp := popStackItemWithoutCheck(sp)
             
@@ -1639,7 +1630,7 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     a, sp := popStackItemWithoutCheck(sp)
                     b, sp := popStackItemWithoutCheck(sp)
             
@@ -1651,7 +1642,7 @@ object "EVMInterpreter" {
             
                     let a, b, N
             
-                    popPushStackCheck(sp, evmGasLeft, 3)
+                    popStackCheck(sp, evmGasLeft, 3)
                     a, sp := popStackItemWithoutCheck(sp)
                     b, sp := popStackItemWithoutCheck(sp)
                     N, sp := popStackItemWithoutCheck(sp)
@@ -1677,7 +1668,7 @@ object "EVMInterpreter" {
             
                     let a, exponent
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     a, sp := popStackItemWithoutCheck(sp)
                     exponent, sp := popStackItemWithoutCheck(sp)
             
@@ -1696,7 +1687,7 @@ object "EVMInterpreter" {
             
                     let b, x
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     b, sp := popStackItemWithoutCheck(sp)
                     x, sp := popStackItemWithoutCheck(sp)
             
@@ -1708,7 +1699,7 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     a, sp := popStackItemWithoutCheck(sp)
                     b, sp := popStackItemWithoutCheck(sp)
             
@@ -1720,7 +1711,7 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     a, sp := popStackItemWithoutCheck(sp)
                     b, sp := popStackItemWithoutCheck(sp)
             
@@ -1732,7 +1723,7 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     a, sp := popStackItemWithoutCheck(sp)
                     b, sp := popStackItemWithoutCheck(sp)
             
@@ -1744,7 +1735,7 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     a, sp := popStackItemWithoutCheck(sp)
                     b, sp := popStackItemWithoutCheck(sp)
             
@@ -1756,7 +1747,7 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     a, sp := popStackItemWithoutCheck(sp)
                     b, sp := popStackItemWithoutCheck(sp)
             
@@ -1768,7 +1759,7 @@ object "EVMInterpreter" {
             
                     let a
             
-                    popPushStackCheck(sp, evmGasLeft, 1)
+                    popStackCheck(sp, evmGasLeft, 1)
                     a, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, iszero(a))
@@ -1779,7 +1770,7 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     a, sp := popStackItemWithoutCheck(sp)
                     b, sp := popStackItemWithoutCheck(sp)
             
@@ -1791,7 +1782,7 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     a, sp := popStackItemWithoutCheck(sp)
                     b, sp := popStackItemWithoutCheck(sp)
             
@@ -1803,7 +1794,7 @@ object "EVMInterpreter" {
             
                     let a, b
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     a, sp := popStackItemWithoutCheck(sp)
                     b, sp := popStackItemWithoutCheck(sp)
             
@@ -1815,7 +1806,7 @@ object "EVMInterpreter" {
             
                     let a
             
-                    popPushStackCheck(sp, evmGasLeft, 1)
+                    popStackCheck(sp, evmGasLeft, 1)
                     a, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, not(a))
@@ -1826,7 +1817,7 @@ object "EVMInterpreter" {
             
                     let i, x
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     i, sp := popStackItemWithoutCheck(sp)
                     x, sp := popStackItemWithoutCheck(sp)
             
@@ -1838,7 +1829,7 @@ object "EVMInterpreter" {
             
                     let shift, value
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     shift, sp := popStackItemWithoutCheck(sp)
                     value, sp := popStackItemWithoutCheck(sp)
             
@@ -1850,7 +1841,7 @@ object "EVMInterpreter" {
             
                     let shift, value
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     shift, sp := popStackItemWithoutCheck(sp)
                     value, sp := popStackItemWithoutCheck(sp)
             
@@ -1862,7 +1853,7 @@ object "EVMInterpreter" {
             
                     let shift, value
             
-                    popPushStackCheck(sp, evmGasLeft, 2)
+                    popStackCheck(sp, evmGasLeft, 2)
                     shift, sp := popStackItemWithoutCheck(sp)
                     value, sp := popStackItemWithoutCheck(sp)
             
@@ -1936,7 +1927,7 @@ object "EVMInterpreter" {
             
                     let i
             
-                    popPushStackCheck(sp, evmGasLeft, 1)
+                    popStackCheck(sp, evmGasLeft, 1)
                     i, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, calldataload(i))
@@ -2106,7 +2097,7 @@ object "EVMInterpreter" {
                     evmGasLeft := chargeGas(evmGasLeft, 20)
             
                     let blockNumber
-                    popPushStackCheck(sp, evmGasLeft, 1)
+                    popStackCheck(sp, evmGasLeft, 1)
                     blockNumber, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, blockhash(blockNumber))
@@ -2344,7 +2335,7 @@ object "EVMInterpreter" {
                     evmGasLeft := chargeGas(evmGasLeft, 100)
             
                     let key
-                    popPushStackCheck(sp, evmGasLeft, 1)
+                    popStackCheck(sp, evmGasLeft, 1)
                     key, sp := popStackItemWithoutCheck(sp)
             
                     sp := pushStackItemWithoutCheck(sp, tload(key))
@@ -3230,15 +3221,6 @@ object "EVMInterpreter" {
             
             function popStackCheck(sp, evmGasLeft, numInputs) {
                 if lt(sub(sp, mul(0x20, sub(numInputs, 1))), STACK_OFFSET()) {
-                    revertWithGas(evmGasLeft)
-                }
-            }
-            
-            function popPushStackCheck(sp, evmGasLeft, numInputs) {
-                let popCheck := lt(sub(sp, mul(0x20, sub(numInputs, 1))), STACK_OFFSET())
-                let pushOffset := sub(sp, mul(0x20, numInputs))
-                let pushCheck := or(gt(pushOffset, BYTECODE_OFFSET()), eq(pushOffset, BYTECODE_OFFSET()))
-                if or(popCheck, pushCheck) {
                     revertWithGas(evmGasLeft)
                 }
             }
@@ -4563,7 +4545,7 @@ object "EVMInterpreter" {
                 
                         let a, b
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         a, sp := popStackItemWithoutCheck(sp)
                         b, sp := popStackItemWithoutCheck(sp)
                 
@@ -4575,7 +4557,7 @@ object "EVMInterpreter" {
                 
                         let a, b
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         a, sp := popStackItemWithoutCheck(sp)
                         b, sp := popStackItemWithoutCheck(sp)
                 
@@ -4587,7 +4569,7 @@ object "EVMInterpreter" {
                 
                         let a, b
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         a, sp := popStackItemWithoutCheck(sp)
                         b, sp := popStackItemWithoutCheck(sp)
                 
@@ -4599,7 +4581,7 @@ object "EVMInterpreter" {
                 
                         let a, b
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         a, sp := popStackItemWithoutCheck(sp)
                         b, sp := popStackItemWithoutCheck(sp)
                 
@@ -4611,7 +4593,7 @@ object "EVMInterpreter" {
                 
                         let a, b
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         a, sp := popStackItemWithoutCheck(sp)
                         b, sp := popStackItemWithoutCheck(sp)
                 
@@ -4623,7 +4605,7 @@ object "EVMInterpreter" {
                 
                         let a, b
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         a, sp := popStackItemWithoutCheck(sp)
                         b, sp := popStackItemWithoutCheck(sp)
                 
@@ -4635,7 +4617,7 @@ object "EVMInterpreter" {
                 
                         let a, b
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         a, sp := popStackItemWithoutCheck(sp)
                         b, sp := popStackItemWithoutCheck(sp)
                 
@@ -4647,7 +4629,7 @@ object "EVMInterpreter" {
                 
                         let a, b, N
                 
-                        popPushStackCheck(sp, evmGasLeft, 3)
+                        popStackCheck(sp, evmGasLeft, 3)
                         a, sp := popStackItemWithoutCheck(sp)
                         b, sp := popStackItemWithoutCheck(sp)
                         N, sp := popStackItemWithoutCheck(sp)
@@ -4673,7 +4655,7 @@ object "EVMInterpreter" {
                 
                         let a, exponent
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         a, sp := popStackItemWithoutCheck(sp)
                         exponent, sp := popStackItemWithoutCheck(sp)
                 
@@ -4692,7 +4674,7 @@ object "EVMInterpreter" {
                 
                         let b, x
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         b, sp := popStackItemWithoutCheck(sp)
                         x, sp := popStackItemWithoutCheck(sp)
                 
@@ -4704,7 +4686,7 @@ object "EVMInterpreter" {
                 
                         let a, b
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         a, sp := popStackItemWithoutCheck(sp)
                         b, sp := popStackItemWithoutCheck(sp)
                 
@@ -4716,7 +4698,7 @@ object "EVMInterpreter" {
                 
                         let a, b
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         a, sp := popStackItemWithoutCheck(sp)
                         b, sp := popStackItemWithoutCheck(sp)
                 
@@ -4728,7 +4710,7 @@ object "EVMInterpreter" {
                 
                         let a, b
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         a, sp := popStackItemWithoutCheck(sp)
                         b, sp := popStackItemWithoutCheck(sp)
                 
@@ -4740,7 +4722,7 @@ object "EVMInterpreter" {
                 
                         let a, b
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         a, sp := popStackItemWithoutCheck(sp)
                         b, sp := popStackItemWithoutCheck(sp)
                 
@@ -4752,7 +4734,7 @@ object "EVMInterpreter" {
                 
                         let a, b
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         a, sp := popStackItemWithoutCheck(sp)
                         b, sp := popStackItemWithoutCheck(sp)
                 
@@ -4764,7 +4746,7 @@ object "EVMInterpreter" {
                 
                         let a
                 
-                        popPushStackCheck(sp, evmGasLeft, 1)
+                        popStackCheck(sp, evmGasLeft, 1)
                         a, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, iszero(a))
@@ -4775,7 +4757,7 @@ object "EVMInterpreter" {
                 
                         let a, b
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         a, sp := popStackItemWithoutCheck(sp)
                         b, sp := popStackItemWithoutCheck(sp)
                 
@@ -4787,7 +4769,7 @@ object "EVMInterpreter" {
                 
                         let a, b
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         a, sp := popStackItemWithoutCheck(sp)
                         b, sp := popStackItemWithoutCheck(sp)
                 
@@ -4799,7 +4781,7 @@ object "EVMInterpreter" {
                 
                         let a, b
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         a, sp := popStackItemWithoutCheck(sp)
                         b, sp := popStackItemWithoutCheck(sp)
                 
@@ -4811,7 +4793,7 @@ object "EVMInterpreter" {
                 
                         let a
                 
-                        popPushStackCheck(sp, evmGasLeft, 1)
+                        popStackCheck(sp, evmGasLeft, 1)
                         a, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, not(a))
@@ -4822,7 +4804,7 @@ object "EVMInterpreter" {
                 
                         let i, x
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         i, sp := popStackItemWithoutCheck(sp)
                         x, sp := popStackItemWithoutCheck(sp)
                 
@@ -4834,7 +4816,7 @@ object "EVMInterpreter" {
                 
                         let shift, value
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         shift, sp := popStackItemWithoutCheck(sp)
                         value, sp := popStackItemWithoutCheck(sp)
                 
@@ -4846,7 +4828,7 @@ object "EVMInterpreter" {
                 
                         let shift, value
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         shift, sp := popStackItemWithoutCheck(sp)
                         value, sp := popStackItemWithoutCheck(sp)
                 
@@ -4858,7 +4840,7 @@ object "EVMInterpreter" {
                 
                         let shift, value
                 
-                        popPushStackCheck(sp, evmGasLeft, 2)
+                        popStackCheck(sp, evmGasLeft, 2)
                         shift, sp := popStackItemWithoutCheck(sp)
                         value, sp := popStackItemWithoutCheck(sp)
                 
@@ -4932,7 +4914,7 @@ object "EVMInterpreter" {
                 
                         let i
                 
-                        popPushStackCheck(sp, evmGasLeft, 1)
+                        popStackCheck(sp, evmGasLeft, 1)
                         i, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, calldataload(i))
@@ -5102,7 +5084,7 @@ object "EVMInterpreter" {
                         evmGasLeft := chargeGas(evmGasLeft, 20)
                 
                         let blockNumber
-                        popPushStackCheck(sp, evmGasLeft, 1)
+                        popStackCheck(sp, evmGasLeft, 1)
                         blockNumber, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, blockhash(blockNumber))
@@ -5340,7 +5322,7 @@ object "EVMInterpreter" {
                         evmGasLeft := chargeGas(evmGasLeft, 100)
                 
                         let key
-                        popPushStackCheck(sp, evmGasLeft, 1)
+                        popStackCheck(sp, evmGasLeft, 1)
                         key, sp := popStackItemWithoutCheck(sp)
                 
                         sp := pushStackItemWithoutCheck(sp, tload(key))


### PR DESCRIPTION
# What ❔
This function is meant to check that we can push to the stack after we popped it:

https://github.com/matter-labs/era-contracts/blob/462f011231a70099cec9bec0dc4c0ae709b9e039/system-contracts/contracts/EvmInterpreterFunctions.template.yul#L167-L174

However, it is guaranteed since we will put no more elements into the stack than we will pop

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
