### PR TITLE
[EVM-Equivalence-YUL] Execute JUMPDEST immediately after JUMP/JUMPI

### DIFF
--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -742,6 +742,10 @@ for { } true { } {
         if iszero(eq(nextOpcode, 0x5B)) {
             revertWithGas(evmGasLeft)
         }
+
+        // execute JUMPDEST immediately
+        evmGasLeft := chargeGas(evmGasLeft, 1)
+        ip := add(ip, 1)
     }
     case 0x57 { // OP_JUMPI
         evmGasLeft := chargeGas(evmGasLeft, 10)
@@ -764,6 +768,10 @@ for { } true { } {
         if iszero(eq(nextOpcode, 0x5B)) {
             revertWithGas(evmGasLeft)
         }
+
+        // execute JUMPDEST immediately
+        evmGasLeft := chargeGas(evmGasLeft, 1)
+        ip := add(ip, 1)
     }
     case 0x58 { // OP_PC
         evmGasLeft := chargeGas(evmGasLeft, 2)

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -2290,6 +2290,10 @@ object "EVMInterpreter" {
                     if iszero(eq(nextOpcode, 0x5B)) {
                         revertWithGas(evmGasLeft)
                     }
+            
+                    // execute JUMPDEST immediately
+                    evmGasLeft := chargeGas(evmGasLeft, 1)
+                    ip := add(ip, 1)
                 }
                 case 0x57 { // OP_JUMPI
                     evmGasLeft := chargeGas(evmGasLeft, 10)
@@ -2312,6 +2316,10 @@ object "EVMInterpreter" {
                     if iszero(eq(nextOpcode, 0x5B)) {
                         revertWithGas(evmGasLeft)
                     }
+            
+                    // execute JUMPDEST immediately
+                    evmGasLeft := chargeGas(evmGasLeft, 1)
+                    ip := add(ip, 1)
                 }
                 case 0x58 { // OP_PC
                     evmGasLeft := chargeGas(evmGasLeft, 2)
@@ -5286,6 +5294,10 @@ object "EVMInterpreter" {
                         if iszero(eq(nextOpcode, 0x5B)) {
                             revertWithGas(evmGasLeft)
                         }
+                
+                        // execute JUMPDEST immediately
+                        evmGasLeft := chargeGas(evmGasLeft, 1)
+                        ip := add(ip, 1)
                     }
                     case 0x57 { // OP_JUMPI
                         evmGasLeft := chargeGas(evmGasLeft, 10)
@@ -5308,6 +5320,10 @@ object "EVMInterpreter" {
                         if iszero(eq(nextOpcode, 0x5B)) {
                             revertWithGas(evmGasLeft)
                         }
+                
+                        // execute JUMPDEST immediately
+                        evmGasLeft := chargeGas(evmGasLeft, 1)
+                        ip := add(ip, 1)
                     }
                     case 0x58 { // OP_PC
                         evmGasLeft := chargeGas(evmGasLeft, 2)


### PR DESCRIPTION
# What ❔

Since we don't check whether `JUMPDEST` is a valid **opcode** anyway, we can avoid re-reading the same opcode after jumps.

Benchmark results (without the latest compiler optimizations):

```
╠═╡ Ergs/gas (-%) ╞═╡ EVMInterpreter M3B3 ╞═╣
║ JUMP                               23.558 ║
║ JUMPI                              20.502 ║
║ DUP3                               -4.715 ║
║ CALL                                0.259 ║
║ STATICCALL                          0.259 ║
║ DELEGATECALL                        0.264 ║
╚═══════════════════════════════════════════╝
```

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
