### PR TITLE
Support old L2->L1 log proving format

### DIFF
--- a/l1-contracts/contracts/common/Config.sol
+++ b/l1-contracts/contracts/common/Config.sol
@@ -117,6 +117,7 @@ uint256 constant MAX_NUMBER_OF_HYPERCHAINS = 100;
 /// @dev Used as the `msg.sender` for transactions that relayed via a settlement layer.
 address constant SETTLEMENT_LAYER_RELAY_SENDER = address(uint160(0x1111111111111111111111111111111111111111));
 
+/// @dev The metadata version that is supported by the ZK Chains to prove that an L2->L1 log was included in a batch.
 uint256 constant SUPPORTED_PROOF_METADATA_VERSION = 1;
 
 struct PriorityTreeCommitment {

--- a/l1-contracts/contracts/common/Config.sol
+++ b/l1-contracts/contracts/common/Config.sol
@@ -117,6 +117,8 @@ uint256 constant MAX_NUMBER_OF_HYPERCHAINS = 100;
 /// @dev Used as the `msg.sender` for transactions that relayed via a settlement layer.
 address constant SETTLEMENT_LAYER_RELAY_SENDER = address(uint160(0x1111111111111111111111111111111111111111));
 
+uint256 constant SUPPORTED_PROOF_METADATA_VERSION = 1;
+
 struct PriorityTreeCommitment {
     uint256 nextLeafIndex;
     uint256 startIndex;

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol
@@ -126,7 +126,7 @@ contract MailboxFacet is ZkSyncHyperchainBase, IMailbox {
     ) public view returns (bool) {}
 
     function _parseProofMetadata(
-        bytes32[] calldata _proof,
+        bytes32[] calldata _proof
     ) internal pure returns (uint256 proofStartIndex, uint256 logLeafProofLen, uint256 batchLeafProofLen) {
         bytes32 proofMetadata = _proof[0];
 
@@ -150,8 +150,9 @@ contract MailboxFacet is ZkSyncHyperchainBase, IMailbox {
             bytes1 metadataVersion = bytes1(proofMetadata);
             require(uint256(uint8(metadataVersion)) == SUPPORTED_PROOF_METADATA_VERSION, "Mailbox: unsupported proof metadata version");
 
-            logLeafProofLen = uint256(uint8(_proof[1]));
-            batchLeafProofLen = uint256(uint8(_proof[2]));
+            proofStartIndex = 1;
+            logLeafProofLen = uint256(uint8(proofMetadata[1]));
+            batchLeafProofLen = uint256(uint8(proofMetadata[2]));
         } else {
             // It is the old version
 

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol
@@ -144,11 +144,14 @@ contract MailboxFacet is ZkSyncHyperchainBase, IMailbox {
 
         // We shift left by 3 bytes = 24 bits to remove the top 24 bits of the metadata.
         uint256 metadataAsUint256 = (uint256(proofMetadata) << 24);
-        
+
         if (metadataAsUint256 == 0) {
             // It is the new version
             bytes1 metadataVersion = bytes1(proofMetadata);
-            require(uint256(uint8(metadataVersion)) == SUPPORTED_PROOF_METADATA_VERSION, "Mailbox: unsupported proof metadata version");
+            require(
+                uint256(uint8(metadataVersion)) == SUPPORTED_PROOF_METADATA_VERSION,
+                "Mailbox: unsupported proof metadata version"
+            );
 
             proofStartIndex = 1;
             logLeafProofLen = uint256(uint8(proofMetadata[1]));

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol
@@ -22,7 +22,7 @@ import {UncheckedMath} from "../../../common/libraries/UncheckedMath.sol";
 import {L2ContractHelper} from "../../../common/libraries/L2ContractHelper.sol";
 import {AddressAliasHelper} from "../../../vendor/AddressAliasHelper.sol";
 import {ZkSyncHyperchainBase} from "./ZkSyncHyperchainBase.sol";
-import {REQUIRED_L2_GAS_PRICE_PER_PUBDATA, L1_GAS_PER_PUBDATA_BYTE, L2_L1_LOGS_TREE_DEFAULT_LEAF_HASH, PRIORITY_OPERATION_L2_TX_TYPE, PRIORITY_EXPIRATION, MAX_NEW_FACTORY_DEPS, SETTLEMENT_LAYER_RELAY_SENDER} from "../../../common/Config.sol";
+import {REQUIRED_L2_GAS_PRICE_PER_PUBDATA, L1_GAS_PER_PUBDATA_BYTE, L2_L1_LOGS_TREE_DEFAULT_LEAF_HASH, PRIORITY_OPERATION_L2_TX_TYPE, PRIORITY_EXPIRATION, MAX_NEW_FACTORY_DEPS, SETTLEMENT_LAYER_RELAY_SENDER, SUPPORTED_PROOF_METADATA_VERSION} from "../../../common/Config.sol";
 import {L2_BOOTLOADER_ADDRESS, L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, L2_BRIDGEHUB_ADDR} from "../../../common/L2ContractAddresses.sol";
 
 import {IL1AssetRouter} from "../../../bridge/interfaces/IL1AssetRouter.sol";
@@ -126,13 +126,40 @@ contract MailboxFacet is ZkSyncHyperchainBase, IMailbox {
     ) public view returns (bool) {}
 
     function _parseProofMetadata(
-        bytes32 _proofMetadata
-    ) internal pure returns (uint256 logLeafProofLen, uint256 batchLeafProofLen) {
-        bytes1 metadataVersion = bytes1(_proofMetadata[0]);
-        require(metadataVersion == 0x01, "Mailbox: unsupported proof metadata version");
+        bytes32[] calldata _proof,
+    ) internal pure returns (uint256 proofStartIndex, uint256 logLeafProofLen, uint256 batchLeafProofLen) {
+        bytes32 proofMetadata = _proof[0];
 
-        logLeafProofLen = uint256(uint8(_proofMetadata[1]));
-        batchLeafProofLen = uint256(uint8(_proofMetadata[2]));
+        // We support two formats of the proofs:
+        // 1. The old format, where `_proof` is just a plain Merkle proof.
+        // 2. The new format, where the first element of the `_proof` is encoded metadata, which consists of the following:
+        // - first byte: metadata version (0x01).
+        // - second byte: length of the log leaf proof (the proof that the log belongs to a batch).
+        // - third byte: length of the batch leaf proof (the proof that the batch belongs to another settlement layer, if any).
+        // - the rest of the bytes are zeroes.
+        //
+        // In the future the old version will be disabled, and only the new version will be supported.
+        // For now, we need to support both for backwards compatibility. We distinguish between those based on whether the last 29 bytes are zeroes.
+        // It is safe, since the elements of the proof are hashes and are unlikely to have 29 zero bytes in them.
+
+        // We shift left by 3 bytes = 24 bits to remove the top 24 bits of the metadata.
+        uint256 metadataAsUint256 = (uint256(proofMetadata) << 24);
+        
+        if (metadataAsUint256 == 0) {
+            // It is the new version
+            bytes1 metadataVersion = bytes1(proofMetadata);
+            require(uint256(uint8(metadataVersion)) == SUPPORTED_PROOF_METADATA_VERSION, "Mailbox: unsupported proof metadata version");
+
+            logLeafProofLen = uint256(uint8(_proof[1]));
+            batchLeafProofLen = uint256(uint8(_proof[2]));
+        } else {
+            // It is the old version
+
+            // The entire proof is a merkle path
+            proofStartIndex = 0;
+            logLeafProofLen = _proof.length;
+            batchLeafProofLen = 0;
+        }
     }
 
     function extractSlice(
@@ -174,8 +201,8 @@ contract MailboxFacet is ZkSyncHyperchainBase, IMailbox {
         uint256 ptr = 0;
         bytes32 chainIdLeaf;
         {
-            (uint256 logLeafProofLen, uint256 batchLeafProofLen) = _parseProofMetadata(_proof[ptr]);
-            ++ptr;
+            (uint256 proofStartIndex, uint256 logLeafProofLen, uint256 batchLeafProofLen) = _parseProofMetadata(_proof);
+            ptr = proofStartIndex;
 
             bytes32 batchSettlementRoot = Merkle.calculateRootMemory(
                 extractSlice(_proof, ptr, ptr + logLeafProofLen),

--- a/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/facets/Mailbox/ProvingL2LogsInclusion.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/facets/Mailbox/ProvingL2LogsInclusion.t.sol
@@ -51,12 +51,12 @@ contract MailboxL2LogsProve is MailboxTest {
         L2Message memory message = L2Message({txNumberInBatch: 0, sender: sender, data: data});
         bytes32[] memory proof = _appendProofMetadata(new bytes32[](1));
 
-        vm.expectRevert(bytes("xx"));
-        mailboxFacet.proveL2MessageInclusion({
+        _proveL2MessageInclusion({
             _batchNumber: batchNumber + 1,
             _index: 0,
             _message: message,
-            _proof: proof
+            _proof: proof,
+            _expectedError: bytes("xx")
         });
     }
 
@@ -98,16 +98,14 @@ contract MailboxL2LogsProve is MailboxTest {
             assertEq(calculatedRoot, root);
         }
 
-        bytes32[] memory fullProof = _appendProofMetadata(firstLogProof);
-
         // Prove L2 message inclusion
-        bool ret = mailboxFacet.proveL2MessageInclusion(batchNumber, firstLogIndex, message, fullProof);
+        bool ret = _proveL2MessageInclusion(batchNumber, firstLogIndex, message, firstLogProof, bytes(""));
 
         // Assert that the proof was successful
         assertEq(ret, true);
 
         // Prove L2 message inclusion for wrong leaf
-        ret = mailboxFacet.proveL2MessageInclusion(batchNumber, secondLogIndex, message, fullProof);
+        ret = _proveL2MessageInclusion(batchNumber, secondLogIndex, message, firstLogProof, bytes(""));
 
         // Assert that the proof has failed
         assertEq(ret, false);
@@ -158,25 +156,25 @@ contract MailboxL2LogsProve is MailboxTest {
             assertEq(calculatedRoot, root);
         }
 
-        bytes32[] memory fullProof = _appendProofMetadata(secondLogProof);
-
         // Prove l2 log inclusion with correct proof
-        bool ret = mailboxFacet.proveL2LogInclusion({
+        bool ret = _proveL2LogInclusion({
             _batchNumber: batchNumber,
             _index: secondLogIndex,
-            _proof: fullProof,
-            _log: log
+            _proof: secondLogProof,
+            _log: log,
+            _expectedError: bytes("")
         });
 
         // Assert that the proof was successful
         assertEq(ret, true);
 
         // Prove l2 log inclusion with wrong proof
-        ret = mailboxFacet.proveL2LogInclusion({
+        ret = _proveL2LogInclusion({
             _batchNumber: batchNumber,
             _index: firstLogIndex,
-            _proof: fullProof,
-            _log: log
+            _proof: secondLogProof,
+            _log: log,
+            _expectedError: bytes("")
         });
 
         // Assert that the proof was successful
@@ -224,16 +222,14 @@ contract MailboxL2LogsProve is MailboxTest {
             assertEq(calculatedRoot, root);
         }
 
-        bytes32[] memory fullProof = _appendProofMetadata(secondLogProof);
-
         // Prove log inclusion reverts
-        vm.expectRevert(bytes("tw"));
-        mailboxFacet.proveL2LogInclusion({
-            _batchNumber: batchNumber,
-            _index: secondLogIndex,
-            _proof: fullProof,
-            _log: log
-        });
+        _proveL2LogInclusion(
+            batchNumber,
+            secondLogIndex,
+            log,
+            secondLogProof,
+            bytes("tw")
+        );
     }
 
     function test_success_proveL1ToL2TransactionStatus() public {
@@ -275,20 +271,111 @@ contract MailboxL2LogsProve is MailboxTest {
             assertEq(calculatedRoot, root);
         }
 
-        bytes32[] memory fullProof = _appendProofMetadata(secondLogProof);
-
         // Prove L1 to L2 transaction status
-        bool ret = mailboxFacet.proveL1ToL2TransactionStatus({
+        bool ret = _proveL1ToL2TransactionStatus({
             _l2TxHash: secondL2TxHash,
             _l2BatchNumber: batchNumber,
             _l2MessageIndex: secondLogIndex,
             _l2TxNumberInBatch: 1,
-            _merkleProof: fullProof,
+            _merkleProof: secondLogProof,
             _status: txStatus
         });
-
         // Assert that the proof was successful
         assertEq(ret, true);
+    }
+
+    /// @notice Proves L1 to L2 transaction status and cross-checks new and old encoding
+    function _proveL1ToL2TransactionStatus(
+        bytes32 _l2TxHash,
+        uint256 _l2BatchNumber,
+        uint256 _l2MessageIndex,
+        uint16 _l2TxNumberInBatch,
+        bytes32[] memory _merkleProof,
+        TxStatus _status
+    ) internal returns (bool) {
+        bool retOldEncoding = mailboxFacet.proveL1ToL2TransactionStatus({
+            _l2TxHash: _l2TxHash,
+            _l2BatchNumber: _l2BatchNumber,
+            _l2MessageIndex: _l2MessageIndex,
+            _l2TxNumberInBatch: _l2TxNumberInBatch,
+            _merkleProof: _merkleProof,
+            _status: _status
+        });
+        bool retNewEncoding = mailboxFacet.proveL1ToL2TransactionStatus({
+            _l2TxHash: _l2TxHash,
+            _l2BatchNumber: _l2BatchNumber,
+            _l2MessageIndex: _l2MessageIndex,
+            _l2TxNumberInBatch: _l2TxNumberInBatch,
+            _merkleProof: _appendProofMetadata(_merkleProof),
+            _status: _status
+        });
+
+        assertEq(retOldEncoding, retNewEncoding);
+
+        return retOldEncoding;
+    }
+
+    /// @notice Proves L2 log inclusion and cross-checks new and old encoding
+    function _proveL2LogInclusion(
+        uint256 _batchNumber,
+        uint256 _index,
+        L2Log memory _log,
+        bytes32[] memory _proof,
+        bytes memory _expectedError
+    ) internal returns (bool) {
+        if (_expectedError.length > 0) {
+            vm.expectRevert(_expectedError);
+        }
+        bool retOldEncoding = mailboxFacet.proveL2LogInclusion({
+            _batchNumber: _batchNumber,
+            _index: _index,
+            _proof: _proof,
+            _log: _log
+        });
+
+        if (_expectedError.length > 0) {
+            vm.expectRevert(_expectedError);
+        }
+        bool retNewEncoding = mailboxFacet.proveL2LogInclusion({
+            _batchNumber: _batchNumber,
+            _index: _index,
+            _proof: _appendProofMetadata(_proof),
+            _log: _log
+        });
+
+        assertEq(retOldEncoding, retNewEncoding);
+        return retOldEncoding;
+    }
+
+    function _proveL2MessageInclusion(
+        uint256 _batchNumber,
+        uint256 _index,
+        L2Message memory _message,
+        bytes32[] memory _proof,
+        bytes memory _expectedError
+    ) internal returns (bool) {
+        if (_expectedError.length > 0) {
+            vm.expectRevert(_expectedError);
+        }
+        bool retOldEncoding = mailboxFacet.proveL2MessageInclusion({
+            _batchNumber: _batchNumber,
+            _index: _index,
+            _message: _message,
+            _proof: _proof
+        });
+
+        if (_expectedError.length > 0) {
+            vm.expectRevert(_expectedError);
+        }
+        bool retNewEncoding = mailboxFacet.proveL2MessageInclusion({
+            _batchNumber: _batchNumber,
+            _index: _index,
+            _message: _message,
+            _proof: _appendProofMetadata(_proof)
+        });
+
+        assertEq(retOldEncoding, retNewEncoding);
+        return retOldEncoding;
     }
 
     /// @notice Appends the proof metadata to the log proof as if the proof is for a batch that settled on L1.

--- a/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/facets/Mailbox/ProvingL2LogsInclusion.t.sol
+++ b/l1-contracts/test/foundry/unit/concrete/state-transition/chain-deps/facets/Mailbox/ProvingL2LogsInclusion.t.sol
@@ -223,13 +223,7 @@ contract MailboxL2LogsProve is MailboxTest {
         }
 
         // Prove log inclusion reverts
-        _proveL2LogInclusion(
-            batchNumber,
-            secondLogIndex,
-            log,
-            secondLogProof,
-            bytes("tw")
-        );
+        _proveL2LogInclusion(batchNumber, secondLogIndex, log, secondLogProof, bytes("tw"));
     }
 
     function test_success_proveL1ToL2TransactionStatus() public {


### PR DESCRIPTION
# What ❔

Support old format for L2->L1 logs 

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
