### PR TITLE
[EVM-Equivalence-YUL] Use transient storage for evm frames in EvmGasManager

### DIFF
--- a/system-contracts/contracts/EvmGasManager.sol
+++ b/system-contracts/contracts/EvmGasManager.sol
@@ -11,6 +11,7 @@ uint160 constant PRECOMPILES_END = 0xffff;
 // Denotes that passGas has been consumed
 uint256 constant INF_PASS_GAS = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
 uint256 constant EVM_STACK_SLOT = 2;
+
 contract EvmGasManager {
     // We need strust to use `storage` pointers
     struct WarmAccountInfo {
@@ -139,7 +140,7 @@ contract EvmGasManager {
             stackDepth := tload(EVM_STACK_SLOT)
         }
         if (stackDepth == 0) return (INF_PASS_GAS, false);
-        
+
         assembly {
             let stackPointer := add(EVM_STACK_SLOT, mul(2, stackDepth))
             passGas := tload(stackPointer)
@@ -156,6 +157,6 @@ contract EvmGasManager {
         require(stackDepth != 0);
         assembly {
             tstore(EVM_STACK_SLOT, sub(stackDepth, 1))
-        }       
+        }
     }
 }


### PR DESCRIPTION
Observed results:

```
╠═╡ Ergs/gas (-%) ╞═╡ EVMInterpreter M3B3 ╞═╣
║ SHA3                                4.222 ║
║ RETURNDATACOPY                      1.453 ║
║ MLOAD                               3.204 ║
║ MSTORE                              2.923 ║
║ MSTORE8                             2.675 ║
║ CALL                               31.418 ║
║ STATICCALL                         33.110 ║
║ DELEGATECALL                       31.997 ║
║ CREATE                             15.709 ║
║ CREATE2                            16.476 ║
╚═══════════════════════════════════════════╝
```

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
