### PR TITLE
[EVM-Equivalence-YUL] Simplify EXTCODESIZE

### DIFF
--- a/system-contracts/contracts/EvmInterpreterFunctions.template.yul
+++ b/system-contracts/contracts/EvmInterpreterFunctions.template.yul
@@ -264,24 +264,17 @@ function _fetchDeployedCodeWithDest(addr, _offset, _len, dest) -> codeLen {
 function _fetchDeployedCodeLen(addr) -> codeLen {
     let codeHash := _getRawCodeHash(addr)
 
-    mstore(0, codeHash)
-
-    let success := staticcall(gas(), CODE_ORACLE_SYSTEM_CONTRACT(), 0, 32, 0, 0)
-
-    switch iszero(success)
+    switch shr(248, codeHash)
     case 1 {
-        // The code oracle call can only fail in the case where the contract
-        // we are querying is the current one executing and it has not yet been
-        // deployed, i.e., if someone calls codesize (or extcodesize(address()))
-        // inside the constructor. In that case, code length is zero.
-        codeLen := 0
+        // EraVM
+        let codeLengthInWords := and(shr(224, codeHash), 0xffff)
+        codeLen := shl(5, codeLengthInWords) // codeLengthInWords * 32
     }
-    default {
-        // The first word is the true length of the bytecode
-        returndatacopy(0, 0, 32)
-        codeLen := mload(0)
+    case 2 {
+        // EVM
+        let codeLengthInBytes := and(shr(224, codeHash), 0xffff)
+        codeLen := codeLengthInBytes
     }
-
 }
 
 function getDeployedBytecode() {

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -480,9 +480,7 @@ for { } true { } {
             evmGasLeft := chargeGas(evmGasLeft, 2500)
         }
 
-        switch _isEVM(addr) 
-            case 0  { sp := pushStackItemWithoutCheck(sp, extcodesize(addr)) }
-            default { sp := pushStackItemWithoutCheck(sp, _fetchDeployedCodeLen(addr)) }
+        sp := pushStackItemWithoutCheck(sp, _fetchDeployedCodeLen(addr))
         ip := add(ip, 1)
     }
     case 0x3C { // OP_EXTCODECOPY

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -333,24 +333,17 @@ object "EVMInterpreter" {
         function _fetchDeployedCodeLen(addr) -> codeLen {
             let codeHash := _getRawCodeHash(addr)
         
-            mstore(0, codeHash)
-        
-            let success := staticcall(gas(), CODE_ORACLE_SYSTEM_CONTRACT(), 0, 32, 0, 0)
-        
-            switch iszero(success)
+            switch shr(248, codeHash)
             case 1 {
-                // The code oracle call can only fail in the case where the contract
-                // we are querying is the current one executing and it has not yet been
-                // deployed, i.e., if someone calls codesize (or extcodesize(address()))
-                // inside the constructor. In that case, code length is zero.
-                codeLen := 0
+                // EraVM
+                let codeLengthInWords := and(shr(224, codeHash), 0xffff)
+                codeLen := shl(5, codeLengthInWords) // codeLengthInWords * 32
             }
-            default {
-                // The first word is the true length of the bytecode
-                returndatacopy(0, 0, 32)
-                codeLen := mload(0)
+            case 2 {
+                // EVM
+                let codeLengthInBytes := and(shr(224, codeHash), 0xffff)
+                codeLen := codeLengthInBytes
             }
-        
         }
         
         function getDeployedBytecode() {
@@ -3299,24 +3292,17 @@ object "EVMInterpreter" {
             function _fetchDeployedCodeLen(addr) -> codeLen {
                 let codeHash := _getRawCodeHash(addr)
             
-                mstore(0, codeHash)
-            
-                let success := staticcall(gas(), CODE_ORACLE_SYSTEM_CONTRACT(), 0, 32, 0, 0)
-            
-                switch iszero(success)
+                switch shr(248, codeHash)
                 case 1 {
-                    // The code oracle call can only fail in the case where the contract
-                    // we are querying is the current one executing and it has not yet been
-                    // deployed, i.e., if someone calls codesize (or extcodesize(address()))
-                    // inside the constructor. In that case, code length is zero.
-                    codeLen := 0
+                    // EraVM
+                    let codeLengthInWords := and(shr(224, codeHash), 0xffff)
+                    codeLen := shl(5, codeLengthInWords) // codeLengthInWords * 32
                 }
-                default {
-                    // The first word is the true length of the bytecode
-                    returndatacopy(0, 0, 32)
-                    codeLen := mload(0)
+                case 2 {
+                    // EVM
+                    let codeLengthInBytes := and(shr(224, codeHash), 0xffff)
+                    codeLen := codeLengthInBytes
                 }
-            
             }
             
             function getDeployedBytecode() {

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -2010,9 +2010,7 @@ object "EVMInterpreter" {
                         evmGasLeft := chargeGas(evmGasLeft, 2500)
                     }
             
-                    switch _isEVM(addr) 
-                        case 0  { sp := pushStackItemWithoutCheck(sp, extcodesize(addr)) }
-                        default { sp := pushStackItemWithoutCheck(sp, _fetchDeployedCodeLen(addr)) }
+                    sp := pushStackItemWithoutCheck(sp, _fetchDeployedCodeLen(addr))
                     ip := add(ip, 1)
                 }
                 case 0x3C { // OP_EXTCODECOPY
@@ -4969,9 +4967,7 @@ object "EVMInterpreter" {
                             evmGasLeft := chargeGas(evmGasLeft, 2500)
                         }
                 
-                        switch _isEVM(addr) 
-                            case 0  { sp := pushStackItemWithoutCheck(sp, extcodesize(addr)) }
-                            default { sp := pushStackItemWithoutCheck(sp, _fetchDeployedCodeLen(addr)) }
+                        sp := pushStackItemWithoutCheck(sp, _fetchDeployedCodeLen(addr))
                         ip := add(ip, 1)
                     }
                     case 0x3C { // OP_EXTCODECOPY


### PR DESCRIPTION
Instead of calling an oracle and decommiting the code, the length can be obtained from the hash. Using the same logic as in `CodeOracle.yul`. In addition, we can use this logic for both types of contracts, which allows us to remove the extra call to check the contract type.

Result observed:
```
╠═╡ Ergs/gas (-%) ╞═╡ EVMInterpreter M3B3 ╞═╣
║ EXTCODESIZE                        46.828 ║
║ CALL                                0.085 ║
║ STATICCALL                          0.086 ║
║ DELEGATECALL                        0.086 ║
║ CREATE                              0.042 ║
║ CREATE2                             0.044 ║
╚═══════════════════════════════════════════╝
```
## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
