### PR TITLE
[EVM-Equivalence-YUL] Fix overflow checks

### DIFF
--- a/system-contracts/contracts/EvmInterpreterFunctions.template.yul
+++ b/system-contracts/contracts/EvmInterpreterFunctions.template.yul
@@ -670,12 +670,6 @@ function incrementNonce(addr) {
     }
 }
 
-function ensureAcceptableMemLocation(location) {
-    if gt(location,MAX_POSSIBLE_MEM()) {
-        revert(0,0) // Check if this is whats needed
-    }
-}
-
 function addGasIfEvmRevert(isCallerEVM,offset,size,evmGasLeft) -> newOffset,newSize {
     newOffset := offset
     newSize := size

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -411,13 +411,7 @@ for { } true { } {
         size, sp := popStackItemWithoutCheck(sp)
 
         checkOverflow(destOffset, size, evmGasLeft)
-        checkOverflow(offset, size, evmGasLeft)
-        checkOverflow(add(offset, size), MEM_OFFSET_INNER(), evmGasLeft)
         checkMemOverflowByOffset(add(destOffset,size), evmGasLeft)
-
-        if gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_MEMORY_FRAME()) {
-            $llvm_AlwaysInline_llvm$_memsetToZero(add(destOffset, MEM_OFFSET_INNER()), size)
-        }
 
         // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
         // minimum_word_size = (size + 31) / 32

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -410,7 +410,10 @@ for { } true { } {
         offset, sp := popStackItemWithoutCheck(sp)
         size, sp := popStackItemWithoutCheck(sp)
 
-        if or(gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM()), gt(add(add(destOffset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM())) {
+        checkOverflow(destOffset, size, evmGasLeft)
+        checkMemOverflowByOffset(add(destOffset,size), evmGasLeft)
+
+        if gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_MEMORY_FRAME()) {
             $llvm_AlwaysInline_llvm$_memsetToZero(add(destOffset, MEM_OFFSET_INNER()), size)
         }
 

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -411,6 +411,7 @@ for { } true { } {
         size, sp := popStackItemWithoutCheck(sp)
 
         checkOverflow(destOffset, size, evmGasLeft)
+        checkMultipleOverflow(offset, size, MEM_OFFSET_INNER(), evmGasLeft)
         checkMemOverflowByOffset(add(destOffset,size), evmGasLeft)
 
         if gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_MEMORY_FRAME()) {
@@ -453,6 +454,7 @@ for { } true { } {
         offset := add(add(offset, BYTECODE_OFFSET()), 32)
 
         checkOverflow(dst,len, evmGasLeft)
+        checkOverflow(offset,len, evmGasLeft)
         checkMemOverflow(add(dst, len), evmGasLeft)
         // Check bytecode overflow
         if gt(add(offset, len), sub(MEM_OFFSET(), 1)) {
@@ -811,6 +813,8 @@ for { } true { } {
         offset, sp := popStackItemWithoutCheck(sp)
         size, sp := popStackItemWithoutCheck(sp)
 
+        checkOverflow(offset, size, evmGasLeft)
+        checkOverflow(destOffset, size, evmGasLeft)
         checkMemOverflowByOffset(add(offset, size), evmGasLeft)
         checkMemOverflowByOffset(add(destOffset, size), evmGasLeft)
 
@@ -1403,6 +1407,7 @@ for { } true { } {
         size, sp := popStackItemWithoutCheck(sp)
 
         checkOverflow(offset,size, evmGasLeft)
+        checkMemOverflowByOffset(add(offset,size), evmGasLeft)
         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
 
         returnLen := size
@@ -1443,6 +1448,7 @@ for { } true { } {
         size, sp := popStackItemWithoutCheck(sp)
 
         checkOverflow(offset,size, evmGasLeft)
+        checkMemOverflowByOffset(add(offset, size), evmGasLeft)
         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
 
         checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -411,7 +411,8 @@ for { } true { } {
         size, sp := popStackItemWithoutCheck(sp)
 
         checkOverflow(destOffset, size, evmGasLeft)
-        checkMultipleOverflow(offset, size, MEM_OFFSET_INNER(), evmGasLeft)
+        checkOverflow(offset, size, evmGasLeft)
+        checkOverflow(add(offset, size), MEM_OFFSET_INNER(), evmGasLeft)
         checkMemOverflowByOffset(add(destOffset,size), evmGasLeft)
 
         if gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_MEMORY_FRAME()) {

--- a/system-contracts/contracts/EvmInterpreterLoop.template.yul
+++ b/system-contracts/contracts/EvmInterpreterLoop.template.yul
@@ -410,10 +410,6 @@ for { } true { } {
         offset, sp := popStackItemWithoutCheck(sp)
         size, sp := popStackItemWithoutCheck(sp)
 
-        checkMultipleOverflow(offset,size,MEM_OFFSET_INNER(), evmGasLeft)
-        checkMultipleOverflow(destOffset,size,MEM_OFFSET_INNER(), evmGasLeft)
-
-        // TODO invalid?
         if or(gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM()), gt(add(add(destOffset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM())) {
             $llvm_AlwaysInline_llvm$_memsetToZero(add(destOffset, MEM_OFFSET_INNER()), size)
         }
@@ -812,7 +808,6 @@ for { } true { } {
         offset, sp := popStackItemWithoutCheck(sp)
         size, sp := popStackItemWithoutCheck(sp)
 
-        // TODO overflow checks
         checkMemOverflowByOffset(add(offset, size), evmGasLeft)
         checkMemOverflowByOffset(add(destOffset, size), evmGasLeft)
 
@@ -1444,11 +1439,10 @@ for { } true { } {
         offset, sp := popStackItemWithoutCheck(sp)
         size, sp := popStackItemWithoutCheck(sp)
 
-        // TODO invalid?
-        ensureAcceptableMemLocation(offset)
-        ensureAcceptableMemLocation(size)
+        checkOverflow(offset,size, evmGasLeft)
         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
 
+        checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
         offset := add(offset, MEM_OFFSET_INNER())
         offset,size := addGasIfEvmRevert(isCallerEVM,offset,size,evmGasLeft)
 

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -1947,10 +1947,6 @@ object "EVMInterpreter" {
                     offset, sp := popStackItemWithoutCheck(sp)
                     size, sp := popStackItemWithoutCheck(sp)
             
-                    checkMultipleOverflow(offset,size,MEM_OFFSET_INNER(), evmGasLeft)
-                    checkMultipleOverflow(destOffset,size,MEM_OFFSET_INNER(), evmGasLeft)
-            
-                    // TODO invalid?
                     if or(gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM()), gt(add(add(destOffset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM())) {
                         $llvm_AlwaysInline_llvm$_memsetToZero(add(destOffset, MEM_OFFSET_INNER()), size)
                     }
@@ -2349,7 +2345,6 @@ object "EVMInterpreter" {
                     offset, sp := popStackItemWithoutCheck(sp)
                     size, sp := popStackItemWithoutCheck(sp)
             
-                    // TODO overflow checks
                     checkMemOverflowByOffset(add(offset, size), evmGasLeft)
                     checkMemOverflowByOffset(add(destOffset, size), evmGasLeft)
             
@@ -2981,11 +2976,10 @@ object "EVMInterpreter" {
                     offset, sp := popStackItemWithoutCheck(sp)
                     size, sp := popStackItemWithoutCheck(sp)
             
-                    // TODO invalid?
-                    ensureAcceptableMemLocation(offset)
-                    ensureAcceptableMemLocation(size)
+                    checkOverflow(offset,size, evmGasLeft)
                     evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
             
+                    checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
                     offset := add(offset, MEM_OFFSET_INNER())
                     offset,size := addGasIfEvmRevert(isCallerEVM,offset,size,evmGasLeft)
             
@@ -4913,10 +4907,6 @@ object "EVMInterpreter" {
                         offset, sp := popStackItemWithoutCheck(sp)
                         size, sp := popStackItemWithoutCheck(sp)
                 
-                        checkMultipleOverflow(offset,size,MEM_OFFSET_INNER(), evmGasLeft)
-                        checkMultipleOverflow(destOffset,size,MEM_OFFSET_INNER(), evmGasLeft)
-                
-                        // TODO invalid?
                         if or(gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM()), gt(add(add(destOffset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM())) {
                             $llvm_AlwaysInline_llvm$_memsetToZero(add(destOffset, MEM_OFFSET_INNER()), size)
                         }
@@ -5315,7 +5305,6 @@ object "EVMInterpreter" {
                         offset, sp := popStackItemWithoutCheck(sp)
                         size, sp := popStackItemWithoutCheck(sp)
                 
-                        // TODO overflow checks
                         checkMemOverflowByOffset(add(offset, size), evmGasLeft)
                         checkMemOverflowByOffset(add(destOffset, size), evmGasLeft)
                 
@@ -5947,11 +5936,10 @@ object "EVMInterpreter" {
                         offset, sp := popStackItemWithoutCheck(sp)
                         size, sp := popStackItemWithoutCheck(sp)
                 
-                        // TODO invalid?
-                        ensureAcceptableMemLocation(offset)
-                        ensureAcceptableMemLocation(size)
+                        checkOverflow(offset,size, evmGasLeft)
                         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
                 
+                        checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
                         offset := add(offset, MEM_OFFSET_INNER())
                         offset,size := addGasIfEvmRevert(isCallerEVM,offset,size,evmGasLeft)
                 

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -1942,13 +1942,7 @@ object "EVMInterpreter" {
                     size, sp := popStackItemWithoutCheck(sp)
             
                     checkOverflow(destOffset, size, evmGasLeft)
-                    checkOverflow(offset, size, evmGasLeft)
-                    checkOverflow(add(offset, size), MEM_OFFSET_INNER(), evmGasLeft)
                     checkMemOverflowByOffset(add(destOffset,size), evmGasLeft)
-            
-                    if gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_MEMORY_FRAME()) {
-                        $llvm_AlwaysInline_llvm$_memsetToZero(add(destOffset, MEM_OFFSET_INNER()), size)
-                    }
             
                     // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
                     // minimum_word_size = (size + 31) / 32
@@ -4906,13 +4900,7 @@ object "EVMInterpreter" {
                         size, sp := popStackItemWithoutCheck(sp)
                 
                         checkOverflow(destOffset, size, evmGasLeft)
-                        checkOverflow(offset, size, evmGasLeft)
-                        checkOverflow(add(offset, size), MEM_OFFSET_INNER(), evmGasLeft)
                         checkMemOverflowByOffset(add(destOffset,size), evmGasLeft)
-                
-                        if gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_MEMORY_FRAME()) {
-                            $llvm_AlwaysInline_llvm$_memsetToZero(add(destOffset, MEM_OFFSET_INNER()), size)
-                        }
                 
                         // dynamicGas = 3 * minimum_word_size + memory_expansion_cost
                         // minimum_word_size = (size + 31) / 32

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -1942,6 +1942,7 @@ object "EVMInterpreter" {
                     size, sp := popStackItemWithoutCheck(sp)
             
                     checkOverflow(destOffset, size, evmGasLeft)
+                    checkMultipleOverflow(offset, size, MEM_OFFSET_INNER(), evmGasLeft)
                     checkMemOverflowByOffset(add(destOffset,size), evmGasLeft)
             
                     if gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_MEMORY_FRAME()) {
@@ -1984,6 +1985,7 @@ object "EVMInterpreter" {
                     offset := add(add(offset, BYTECODE_OFFSET()), 32)
             
                     checkOverflow(dst,len, evmGasLeft)
+                    checkOverflow(offset,len, evmGasLeft)
                     checkMemOverflow(add(dst, len), evmGasLeft)
                     // Check bytecode overflow
                     if gt(add(offset, len), sub(MEM_OFFSET(), 1)) {
@@ -2342,6 +2344,8 @@ object "EVMInterpreter" {
                     offset, sp := popStackItemWithoutCheck(sp)
                     size, sp := popStackItemWithoutCheck(sp)
             
+                    checkOverflow(offset, size, evmGasLeft)
+                    checkOverflow(destOffset, size, evmGasLeft)
                     checkMemOverflowByOffset(add(offset, size), evmGasLeft)
                     checkMemOverflowByOffset(add(destOffset, size), evmGasLeft)
             
@@ -2934,6 +2938,7 @@ object "EVMInterpreter" {
                     size, sp := popStackItemWithoutCheck(sp)
             
                     checkOverflow(offset,size, evmGasLeft)
+                    checkMemOverflowByOffset(add(offset,size), evmGasLeft)
                     evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
             
                     returnLen := size
@@ -2974,6 +2979,7 @@ object "EVMInterpreter" {
                     size, sp := popStackItemWithoutCheck(sp)
             
                     checkOverflow(offset,size, evmGasLeft)
+                    checkMemOverflowByOffset(add(offset, size), evmGasLeft)
                     evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
             
                     checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)
@@ -4899,6 +4905,7 @@ object "EVMInterpreter" {
                         size, sp := popStackItemWithoutCheck(sp)
                 
                         checkOverflow(destOffset, size, evmGasLeft)
+                        checkMultipleOverflow(offset, size, MEM_OFFSET_INNER(), evmGasLeft)
                         checkMemOverflowByOffset(add(destOffset,size), evmGasLeft)
                 
                         if gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_MEMORY_FRAME()) {
@@ -4941,6 +4948,7 @@ object "EVMInterpreter" {
                         offset := add(add(offset, BYTECODE_OFFSET()), 32)
                 
                         checkOverflow(dst,len, evmGasLeft)
+                        checkOverflow(offset,len, evmGasLeft)
                         checkMemOverflow(add(dst, len), evmGasLeft)
                         // Check bytecode overflow
                         if gt(add(offset, len), sub(MEM_OFFSET(), 1)) {
@@ -5299,6 +5307,8 @@ object "EVMInterpreter" {
                         offset, sp := popStackItemWithoutCheck(sp)
                         size, sp := popStackItemWithoutCheck(sp)
                 
+                        checkOverflow(offset, size, evmGasLeft)
+                        checkOverflow(destOffset, size, evmGasLeft)
                         checkMemOverflowByOffset(add(offset, size), evmGasLeft)
                         checkMemOverflowByOffset(add(destOffset, size), evmGasLeft)
                 
@@ -5891,6 +5901,7 @@ object "EVMInterpreter" {
                         size, sp := popStackItemWithoutCheck(sp)
                 
                         checkOverflow(offset,size, evmGasLeft)
+                        checkMemOverflowByOffset(add(offset,size), evmGasLeft)
                         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
                 
                         returnLen := size
@@ -5931,6 +5942,7 @@ object "EVMInterpreter" {
                         size, sp := popStackItemWithoutCheck(sp)
                 
                         checkOverflow(offset,size, evmGasLeft)
+                        checkMemOverflowByOffset(add(offset, size), evmGasLeft)
                         evmGasLeft := chargeGas(evmGasLeft,expandMemory(add(offset,size)))
                 
                         checkOverflow(offset,MEM_OFFSET_INNER(), evmGasLeft)

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -1941,7 +1941,10 @@ object "EVMInterpreter" {
                     offset, sp := popStackItemWithoutCheck(sp)
                     size, sp := popStackItemWithoutCheck(sp)
             
-                    if or(gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM()), gt(add(add(destOffset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM())) {
+                    checkOverflow(destOffset, size, evmGasLeft)
+                    checkMemOverflowByOffset(add(destOffset,size), evmGasLeft)
+            
+                    if gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_MEMORY_FRAME()) {
                         $llvm_AlwaysInline_llvm$_memsetToZero(add(destOffset, MEM_OFFSET_INNER()), size)
                     }
             
@@ -4895,7 +4898,10 @@ object "EVMInterpreter" {
                         offset, sp := popStackItemWithoutCheck(sp)
                         size, sp := popStackItemWithoutCheck(sp)
                 
-                        if or(gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM()), gt(add(add(destOffset, size), MEM_OFFSET_INNER()), MAX_POSSIBLE_MEM())) {
+                        checkOverflow(destOffset, size, evmGasLeft)
+                        checkMemOverflowByOffset(add(destOffset,size), evmGasLeft)
+                
+                        if gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_MEMORY_FRAME()) {
                             $llvm_AlwaysInline_llvm$_memsetToZero(add(destOffset, MEM_OFFSET_INNER()), size)
                         }
                 

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -1942,7 +1942,8 @@ object "EVMInterpreter" {
                     size, sp := popStackItemWithoutCheck(sp)
             
                     checkOverflow(destOffset, size, evmGasLeft)
-                    checkMultipleOverflow(offset, size, MEM_OFFSET_INNER(), evmGasLeft)
+                    checkOverflow(offset, size, evmGasLeft)
+                    checkOverflow(add(offset, size), MEM_OFFSET_INNER(), evmGasLeft)
                     checkMemOverflowByOffset(add(destOffset,size), evmGasLeft)
             
                     if gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_MEMORY_FRAME()) {
@@ -4905,7 +4906,8 @@ object "EVMInterpreter" {
                         size, sp := popStackItemWithoutCheck(sp)
                 
                         checkOverflow(destOffset, size, evmGasLeft)
-                        checkMultipleOverflow(offset, size, MEM_OFFSET_INNER(), evmGasLeft)
+                        checkOverflow(offset, size, evmGasLeft)
+                        checkOverflow(add(offset, size), MEM_OFFSET_INNER(), evmGasLeft)
                         checkMemOverflowByOffset(add(destOffset,size), evmGasLeft)
                 
                         if gt(add(add(offset, size), MEM_OFFSET_INNER()), MAX_MEMORY_FRAME()) {

--- a/system-contracts/contracts/EvmInterpreterPreprocessed.yul
+++ b/system-contracts/contracts/EvmInterpreterPreprocessed.yul
@@ -739,12 +739,6 @@ object "EVMInterpreter" {
             }
         }
         
-        function ensureAcceptableMemLocation(location) {
-            if gt(location,MAX_POSSIBLE_MEM()) {
-                revert(0,0) // Check if this is whats needed
-            }
-        }
-        
         function addGasIfEvmRevert(isCallerEVM,offset,size,evmGasLeft) -> newOffset,newSize {
             newOffset := offset
             newSize := size
@@ -3696,12 +3690,6 @@ object "EVMInterpreter" {
             
                 if iszero(result) {
                     revert(0, 0)
-                }
-            }
-            
-            function ensureAcceptableMemLocation(location) {
-                if gt(location,MAX_POSSIBLE_MEM()) {
-                    revert(0,0) // Check if this is whats needed
                 }
             }
             


### PR DESCRIPTION
# What ❔
This PR removes the `// todo invalid` comments that needed fixes

In revert opcode:
Changed the wrong checks, mimicking the ones in return opcode.

In calldatacopy:
Removed the overflow checks, since it would never fall into the second one, which is the correct one.
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
