### PR TITLE
Small PR to Fix "Ethers" and "ETH" encoding

### DIFF
--- a/l1-contracts/contracts/bridge/L1SharedBridge.sol
+++ b/l1-contracts/contracts/bridge/L1SharedBridge.sol
@@ -413,8 +413,8 @@ contract L1SharedBridge is IL1SharedBridge, ReentrancyGuard, Ownable2StepUpgrade
     /// @dev Receives and parses (name, symbol, decimals) from the token contract
     function _getERC20Getters(address _token) internal view returns (bytes memory) {
         if (_token == ETH_TOKEN_ADDRESS) {
-            bytes memory name = bytes("Ether");
-            bytes memory symbol = bytes("ETH");
+            bytes memory name = abi.encode("Ether");
+            bytes memory symbol = abi.encode("ETH");
             bytes memory decimals = abi.encode(uint8(18));
             return abi.encode(name, symbol, decimals); // when depositing eth to a non-eth based chain it is an ERC20
         }


### PR DESCRIPTION
# What ❔

Bytes encoding of strings replaced with "abi.encode".

## Why ❔

These bytes arrays are not valid abi encoding and thus cannot be decoded in the decodeString function of the L2StandardERC20 contract.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
