### PR TITLE
feat: added getter methods to consensus registry contract

### DIFF
--- a/l2-contracts/contracts/ConsensusRegistry.sol
+++ b/l2-contracts/contracts/ConsensusRegistry.sol
@@ -293,7 +293,18 @@ contract ConsensusRegistry is IConsensusRegistry, Initializable, Ownable2StepUpg
         emit ValidatorsCommitted(validatorsCommit);
     }
 
-    /// @notice Returns an array of `AttesterAttr` structs representing the current attester committee.
+    /// @notice Returns the current list of node owners.
+    function getNodeOwners() public view returns (address[] memory) {
+        return nodeOwners;
+    }
+
+    /// @notice Returns the current state of the node.
+    function getNode(address _nodeOwner) public view returns (Node memory) {
+        _verifyNodeOwnerExists(_nodeOwner);
+        return nodes[_nodeOwner];
+    }
+
+    /// @notice Returns an array of `CommitteeAttester` structs representing the current attester committee.
     /// @dev Collects active and non-removed attesters based on the latest commit to the committee.
     function getAttesterCommittee() public view returns (CommitteeAttester[] memory) {
         uint256 len = nodeOwners.length;

--- a/l2-contracts/contracts/ConsensusRegistry.sol
+++ b/l2-contracts/contracts/ConsensusRegistry.sol
@@ -293,15 +293,15 @@ contract ConsensusRegistry is IConsensusRegistry, Initializable, Ownable2StepUpg
         emit ValidatorsCommitted(validatorsCommit);
     }
 
-    /// @notice Returns the current list of node owners.
-    function getNodeOwners() public view returns (address[] memory) {
-        return nodeOwners;
-    }
-
-    /// @notice Returns the current state of the node.
-    function getNode(address _nodeOwner) public view returns (Node memory) {
-        _verifyNodeOwnerExists(_nodeOwner);
-        return nodes[_nodeOwner];
+    /// @notice Returns the current list of nodes.
+    function getNodes() public view returns (NodeWithOwner[] memory) {
+        uint256 len = nodeOwners.length;
+        NodeWithOwner[] memory output = new NodeWithOwner[](len);
+        for (uint256 i = 0; i < len; ++i) {
+            output[i].owner = nodeOwners[i];
+            output[i].node = nodes[nodeOwners[i]];
+        }
+        return output;
     }
 
     /// @notice Returns an array of `CommitteeAttester` structs representing the current attester committee.

--- a/l2-contracts/contracts/interfaces/IConsensusRegistry.sol
+++ b/l2-contracts/contracts/interfaces/IConsensusRegistry.sol
@@ -158,4 +158,8 @@ interface IConsensusRegistry {
     function getAttesterCommittee() external view returns (CommitteeAttester[] memory);
 
     function getValidatorCommittee() external view returns (CommitteeValidator[] memory);
+
+    function getNodeOwners() external view returns (address[] memory);
+
+    function getNode(address _nodeOwner) external view returns (Node memory);
 }

--- a/l2-contracts/contracts/interfaces/IConsensusRegistry.sol
+++ b/l2-contracts/contracts/interfaces/IConsensusRegistry.sol
@@ -6,6 +6,12 @@ pragma solidity 0.8.20;
 /// @custom:security-contact security@matterlabs.dev
 /// @title ConsensusRegistry contract interface
 interface IConsensusRegistry {
+    /// @dev Node and its owner.
+    struct NodeWithOwner {
+        address owner;
+        Node node;
+    }
+
     /// @dev Represents a consensus node.
     /// @param attesterLastUpdateCommit The latest `attestersCommit` where the node's attester attributes were updated.
     /// @param attesterLatest Attester attributes to read if `node.attesterLastUpdateCommit` < `attestersCommit`.
@@ -159,7 +165,5 @@ interface IConsensusRegistry {
 
     function getValidatorCommittee() external view returns (CommitteeValidator[] memory);
 
-    function getNodeOwners() external view returns (address[] memory);
-
-    function getNode(address _nodeOwner) external view returns (Node memory);
+    function getNodes() external view returns (NodeWithOwner[] memory);
 }


### PR DESCRIPTION
It is hard to set the desired contract state without knowing what is already there.