### PR TITLE
feat: compute migrated chain's diamond proxy address

### DIFF
--- a/l1-contracts/scripts/sync-layer.ts
+++ b/l1-contracts/scripts/sync-layer.ts
@@ -16,10 +16,14 @@ import {
   REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
   priorityTxMaxGasLimit,
   L2_BRIDGEHUB_ADDRESS,
+  computeL2Create2Address,
+  DIAMOND_CUT_DATA_ABI_STRING,
 } from "../src.ts/utils";
 
 import { Wallet as ZkWallet, Provider as ZkProvider, utils as zkUtils } from "zksync-ethers";
 import { IStateTransitionManagerFactory } from "../typechain/IStateTransitionManagerFactory";
+import { IBridgehubFactory } from "../typechain/IBridgehubFactory";
+import { IDiamondInitFactory } from "../typechain/IDiamondInitFactory";
 import { TestnetERC20TokenFactory } from "../typechain/TestnetERC20TokenFactory";
 import { BOOTLOADER_FORMAL_ADDRESS } from "zksync-ethers/build/utils";
 
@@ -29,6 +33,78 @@ async function main() {
   const program = new Command();
 
   program.version("0.1.0").name("deploy").description("deploy L1 contracts");
+
+  program
+    .command("compute-migrated-chain-address")
+    .requiredOption("--chain-id <chain-id>")
+    .option("--private-key <private-key>")
+    .action(async (cmd) => {
+      if (process.env.CONTRACTS_BASE_NETWORK_ZKSYNC !== "true") {
+        throw new Error("This script is only for zkSync network");
+      }
+
+      const provider = new ZkProvider(process.env.API_WEB3_JSON_RPC_HTTP_URL);
+      const ethProvider = new ethers.providers.JsonRpcProvider(process.env.ETH_CLIENT_WEB3_URL);
+      const deployWallet = cmd.privateKey
+        ? new ZkWallet(cmd.privateKey, provider)
+        : (ZkWallet.fromMnemonic(
+            process.env.MNEMONIC ? process.env.MNEMONIC : ethTestConfig.mnemonic,
+            "m/44'/60'/0'/0/1"
+          ).connect(provider) as ethers.Wallet | ZkWallet);
+
+      const deployer = new Deployer({
+        deployWallet,
+        addresses: deployedAddressesFromEnv(),
+        verbose: true,
+      });
+
+      deployer.addresses.StateTransition.AdminFacet = getAddressFromEnv("GATEWAY_ADMIN_FACET_ADDR");
+      deployer.addresses.StateTransition.MailboxFacet = getAddressFromEnv("GATEWAY_MAILBOX_FACET_ADDR");
+      deployer.addresses.StateTransition.ExecutorFacet = getAddressFromEnv("GATEWAY_EXECUTOR_FACET_ADDR");
+      deployer.addresses.StateTransition.GettersFacet = getAddressFromEnv("GATEWAY_GETTERS_FACET_ADDR");
+      deployer.addresses.StateTransition.DiamondInit = getAddressFromEnv("GATEWAY_DIAMOND_INIT_ADDR");
+      deployer.addresses.StateTransition.Verifier = getAddressFromEnv("GATEWAY_VERIFIER_ADDR");
+      deployer.addresses.StateTransition.StateTransitionProxy = getAddressFromEnv("GATEWAY_STATE_TRANSITION_PROXY_ADDR");
+      deployer.addresses.BlobVersionedHashRetriever = getAddressFromEnv("GATEWAY_BLOB_VERSIONED_HASH_RETRIEVER_ADDR");
+      deployer.addresses.ValidatorTimeLock = getAddressFromEnv("GATEWAY_VALIDATOR_TIMELOCK_ADDR");
+      deployer.addresses.Bridges.SharedBridgeProxy = getAddressFromEnv("CONTRACTS_L2_SHARED_BRIDGE_ADDR");
+
+      let stm = IStateTransitionManagerFactory.connect(deployer.addresses.StateTransition.StateTransitionProxy, provider);
+      let bridgehub = IBridgehubFactory.connect(deployer.addresses.Bridgehub.BridgehubProxy, ethProvider);
+      let diamondInit = IDiamondInitFactory.connect(deployer.addresses.StateTransition.DiamondInit, provider);
+      let bytes32 = (x: any) => ethers.utils.hexZeroPad(ethers.utils.hexlify(x), 32);
+
+      const diamondCut = await deployer.initialZkSyncHyperchainDiamondCut([], true);
+      let mandatoryInitData = [
+          diamondInit.interface.getSighash('initialize'),
+          bytes32(parseInt(cmd.chainId)),
+          bytes32(getAddressFromEnv("GATEWAY_BRIDGEHUB_PROXY_ADDR")),
+          bytes32(deployer.addresses.StateTransition.StateTransitionProxy),
+          bytes32(await stm.protocolVersion()),
+          bytes32(deployer.deployWallet.address),
+          bytes32(deployer.addresses.ValidatorTimeLock),
+          await bridgehub.baseTokenAssetId(cmd.chainId),
+          bytes32(deployer.addresses.Bridges.SharedBridgeProxy),
+          await stm.storedBatchZero()
+      ];
+
+      diamondCut.initCalldata = ethers.utils.hexConcat([...mandatoryInitData, diamondCut.initCalldata]);
+      let bytecode = hardhat.artifacts.readArtifactSync("DiamondProxy").bytecode;
+      let gatewayChainId = (await provider.getNetwork()).chainId;
+      let constructorData = new ethers.utils.AbiCoder().encode(
+          ["uint256", DIAMOND_CUT_DATA_ABI_STRING],
+          [gatewayChainId, diamondCut]
+      );
+
+      let address = computeL2Create2Address(
+          deployer.addresses.StateTransition.StateTransitionProxy,
+          bytecode,
+          constructorData,
+          ethers.constants.HashZero
+      );
+
+      console.log(address);
+    });
 
   program
     .command("deploy-sync-layer-contracts")
@@ -62,7 +138,7 @@ async function main() {
         : (await provider.getGasPrice()).mul(GAS_MULTIPLIER);
       console.log(`Using gas price: ${formatUnits(gasPrice, "gwei")} gwei`);
 
-      const nonce = cmd.nonce ? parseInt(cmd.nonce) : await deployWallet.getTransactionCount();
+      const nonce = await deployWallet.getTransactionCount();
       console.log(`Using nonce: ${nonce}`);
 
       const create2Salt = cmd.create2Salt ? cmd.create2Salt : ethers.utils.hexlify(ethers.utils.randomBytes(32));

--- a/l1-contracts/scripts/sync-layer.ts
+++ b/l1-contracts/scripts/sync-layer.ts
@@ -64,43 +64,48 @@ async function main() {
       deployer.addresses.StateTransition.GettersFacet = getAddressFromEnv("GATEWAY_GETTERS_FACET_ADDR");
       deployer.addresses.StateTransition.DiamondInit = getAddressFromEnv("GATEWAY_DIAMOND_INIT_ADDR");
       deployer.addresses.StateTransition.Verifier = getAddressFromEnv("GATEWAY_VERIFIER_ADDR");
-      deployer.addresses.StateTransition.StateTransitionProxy = getAddressFromEnv("GATEWAY_STATE_TRANSITION_PROXY_ADDR");
+      deployer.addresses.StateTransition.StateTransitionProxy = getAddressFromEnv(
+        "GATEWAY_STATE_TRANSITION_PROXY_ADDR"
+      );
       deployer.addresses.BlobVersionedHashRetriever = getAddressFromEnv("GATEWAY_BLOB_VERSIONED_HASH_RETRIEVER_ADDR");
       deployer.addresses.ValidatorTimeLock = getAddressFromEnv("GATEWAY_VALIDATOR_TIMELOCK_ADDR");
       deployer.addresses.Bridges.SharedBridgeProxy = getAddressFromEnv("CONTRACTS_L2_SHARED_BRIDGE_ADDR");
 
-      let stm = IStateTransitionManagerFactory.connect(deployer.addresses.StateTransition.StateTransitionProxy, provider);
-      let bridgehub = IBridgehubFactory.connect(deployer.addresses.Bridgehub.BridgehubProxy, ethProvider);
-      let diamondInit = IDiamondInitFactory.connect(deployer.addresses.StateTransition.DiamondInit, provider);
-      let bytes32 = (x: any) => ethers.utils.hexZeroPad(ethers.utils.hexlify(x), 32);
+      const stm = IStateTransitionManagerFactory.connect(
+        deployer.addresses.StateTransition.StateTransitionProxy,
+        provider
+      );
+      const bridgehub = IBridgehubFactory.connect(deployer.addresses.Bridgehub.BridgehubProxy, ethProvider);
+      const diamondInit = IDiamondInitFactory.connect(deployer.addresses.StateTransition.DiamondInit, provider);
+      const bytes32 = (x: any) => ethers.utils.hexZeroPad(ethers.utils.hexlify(x), 32);
 
       const diamondCut = await deployer.initialZkSyncHyperchainDiamondCut([], true);
-      let mandatoryInitData = [
-          diamondInit.interface.getSighash('initialize'),
-          bytes32(parseInt(cmd.chainId)),
-          bytes32(getAddressFromEnv("GATEWAY_BRIDGEHUB_PROXY_ADDR")),
-          bytes32(deployer.addresses.StateTransition.StateTransitionProxy),
-          bytes32(await stm.protocolVersion()),
-          bytes32(deployer.deployWallet.address),
-          bytes32(deployer.addresses.ValidatorTimeLock),
-          await bridgehub.baseTokenAssetId(cmd.chainId),
-          bytes32(deployer.addresses.Bridges.SharedBridgeProxy),
-          await stm.storedBatchZero()
+      const mandatoryInitData = [
+        diamondInit.interface.getSighash("initialize"),
+        bytes32(parseInt(cmd.chainId)),
+        bytes32(getAddressFromEnv("GATEWAY_BRIDGEHUB_PROXY_ADDR")),
+        bytes32(deployer.addresses.StateTransition.StateTransitionProxy),
+        bytes32(await stm.protocolVersion()),
+        bytes32(deployer.deployWallet.address),
+        bytes32(deployer.addresses.ValidatorTimeLock),
+        await bridgehub.baseTokenAssetId(cmd.chainId),
+        bytes32(deployer.addresses.Bridges.SharedBridgeProxy),
+        await stm.storedBatchZero(),
       ];
 
       diamondCut.initCalldata = ethers.utils.hexConcat([...mandatoryInitData, diamondCut.initCalldata]);
-      let bytecode = hardhat.artifacts.readArtifactSync("DiamondProxy").bytecode;
-      let gatewayChainId = (await provider.getNetwork()).chainId;
-      let constructorData = new ethers.utils.AbiCoder().encode(
-          ["uint256", DIAMOND_CUT_DATA_ABI_STRING],
-          [gatewayChainId, diamondCut]
+      const bytecode = hardhat.artifacts.readArtifactSync("DiamondProxy").bytecode;
+      const gatewayChainId = (await provider.getNetwork()).chainId;
+      const constructorData = new ethers.utils.AbiCoder().encode(
+        ["uint256", DIAMOND_CUT_DATA_ABI_STRING],
+        [gatewayChainId, diamondCut]
       );
 
-      let address = computeL2Create2Address(
-          deployer.addresses.StateTransition.StateTransitionProxy,
-          bytecode,
-          constructorData,
-          ethers.constants.HashZero
+      const address = computeL2Create2Address(
+        deployer.addresses.StateTransition.StateTransitionProxy,
+        bytecode,
+        constructorData,
+        ethers.constants.HashZero
       );
 
       console.log(address);

--- a/l1-contracts/scripts/sync-layer.ts
+++ b/l1-contracts/scripts/sync-layer.ts
@@ -22,7 +22,6 @@ import {
 
 import { Wallet as ZkWallet, Provider as ZkProvider, utils as zkUtils } from "zksync-ethers";
 import { IStateTransitionManagerFactory } from "../typechain/IStateTransitionManagerFactory";
-import { IBridgehubFactory } from "../typechain/IBridgehubFactory";
 import { IDiamondInitFactory } from "../typechain/IDiamondInitFactory";
 import { TestnetERC20TokenFactory } from "../typechain/TestnetERC20TokenFactory";
 import { BOOTLOADER_FORMAL_ADDRESS } from "zksync-ethers/build/utils";
@@ -64,20 +63,17 @@ async function main() {
       deployer.addresses.StateTransition.GettersFacet = getAddressFromEnv("GATEWAY_GETTERS_FACET_ADDR");
       deployer.addresses.StateTransition.DiamondInit = getAddressFromEnv("GATEWAY_DIAMOND_INIT_ADDR");
       deployer.addresses.StateTransition.Verifier = getAddressFromEnv("GATEWAY_VERIFIER_ADDR");
-      deployer.addresses.StateTransition.StateTransitionProxy = getAddressFromEnv(
-        "GATEWAY_STATE_TRANSITION_PROXY_ADDR"
-      );
       deployer.addresses.BlobVersionedHashRetriever = getAddressFromEnv("GATEWAY_BLOB_VERSIONED_HASH_RETRIEVER_ADDR");
       deployer.addresses.ValidatorTimeLock = getAddressFromEnv("GATEWAY_VALIDATOR_TIMELOCK_ADDR");
       deployer.addresses.Bridges.SharedBridgeProxy = getAddressFromEnv("CONTRACTS_L2_SHARED_BRIDGE_ADDR");
-
-      const stm = IStateTransitionManagerFactory.connect(
-        deployer.addresses.StateTransition.StateTransitionProxy,
-        provider
+      deployer.addresses.StateTransition.StateTransitionProxy = getAddressFromEnv(
+        "GATEWAY_STATE_TRANSITION_PROXY_ADDR"
       );
-      const bridgehub = IBridgehubFactory.connect(deployer.addresses.Bridgehub.BridgehubProxy, ethProvider);
+
+      const stm = deployer.stateTransitionManagerContract(provider);
+      const bridgehub = deployer.bridgehubContract(ethProvider);
       const diamondInit = IDiamondInitFactory.connect(deployer.addresses.StateTransition.DiamondInit, provider);
-      const bytes32 = (x: any) => ethers.utils.hexZeroPad(ethers.utils.hexlify(x), 32);
+      const bytes32 = (x: ethers.BigNumberish) => ethers.utils.hexZeroPad(ethers.utils.hexlify(x), 32);
 
       const diamondCut = await deployer.initialZkSyncHyperchainDiamondCut([], true);
       const mandatoryInitData = [

--- a/l1-contracts/src.ts/deploy.ts
+++ b/l1-contracts/src.ts/deploy.ts
@@ -174,7 +174,7 @@ export class Deployer {
 
       const hashFromSTM = await stm.initialCutHash();
       if (hash != hashFromSTM) {
-        throw new Error(`Has from STM ${hashFromSTM} does not match the computed hash ${hash}`);
+        throw new Error(`Hash from STM ${hashFromSTM} does not match the computed hash ${hash}`);
       }
     }
 
@@ -909,7 +909,7 @@ export class Deployer {
     this.addresses.Bridges.NativeTokenVaultProxy = contractAddress;
 
     const sharedBridge = this.defaultSharedBridge(this.deployWallet);
-    const data = await sharedBridge.interface.encodeFunctionData("setNativeTokenVault", [
+    const data = sharedBridge.interface.encodeFunctionData("setNativeTokenVault", [
       this.addresses.Bridges.NativeTokenVaultProxy,
     ]);
     await this.executeUpgrade(this.addresses.Bridges.SharedBridgeProxy, 0, data);


### PR DESCRIPTION
# What ❔

Script to compute a chain's diamond proxy address on gateway via CREATE2.

## Why ❔

We need to know it before the chain is migrated, to put in configs and such.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
