### PR TITLE
feat: made deploy script avoid reinitializing the chain governance

### DIFF
--- a/l1-contracts/deploy-scripts/DeployL2Contracts.sol
+++ b/l1-contracts/deploy-scripts/DeployL2Contracts.sol
@@ -318,7 +318,10 @@ contract DeployL2Script is Script {
 
     function initializeChain() internal {
         L1SharedBridge bridge = L1SharedBridge(config.l1SharedBridgeProxy);
-
+        // Early exit if chain is already initialized.
+        if (bridge.l2BridgeAddress(config.chainId) != address(0)) {
+            return;
+        }
         Utils.chainAdminMulticall({
             _chainAdmin: bridge.admin(),
             _target: config.l1SharedBridgeProxy,


### PR DESCRIPTION
This will allow to run `zk_inception chain deploy-l2-contracts` on a preexisting running chain instance and it will deploy all the missing contracts.