### PR TITLE
feat(EVM-emulator): add all unused opcodes

### DIFF
--- a/system-contracts/contracts/EvmInterpreter.yul
+++ b/system-contracts/contracts/EvmInterpreter.yul
@@ -144,23 +144,8 @@ object "EVMInterpreter" {
             max_uint := 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
         }
         
-        // Essentially a NOP that will not get optimized away by the compiler
-        function $llvm_NoInline_llvm$_unoptimized() {
-            pop(1)
-        }
-        
-        function printHex(value) {
-            mstore(add(DEBUG_SLOT_OFFSET(), 0x20), 0x00debdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebde)
-            mstore(add(DEBUG_SLOT_OFFSET(), 0x40), value)
-            mstore(DEBUG_SLOT_OFFSET(), 0x4A15830341869CAA1E99840C97043A1EA15D2444DA366EFFF5C43B4BEF299681)
-            $llvm_NoInline_llvm$_unoptimized()
-        }
-        
-        function printString(value) {
-            mstore(add(DEBUG_SLOT_OFFSET(), 0x20), 0x00debdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdf)
-            mstore(add(DEBUG_SLOT_OFFSET(), 0x40), value)
-            mstore(DEBUG_SLOT_OFFSET(), 0x4A15830341869CAA1E99840C97043A1EA15D2444DA366EFFF5C43B4BEF299681)
-            $llvm_NoInline_llvm$_unoptimized()
+        function $llvm_NoInline_llvm$_revert() {
+            revert(0, 0)
         }
         
         // It is the responsibility of the caller to ensure that ip >= BYTECODE_OFFSET + 32
@@ -2841,10 +2826,341 @@ object "EVMInterpreter" {
             
                     revertWithGas(evmGasLeft)
                 }
+                case 0x0C { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x0D { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x0E { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x0F { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x1E { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x1F { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x21 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x22 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x23 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x24 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x25 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x26 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x27 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x28 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x29 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x2A { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x2B { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x2C { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x2D { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x2E { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x2F { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x49 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x4A { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x4B { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x4C { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x4D { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x4E { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0x4F { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xA5 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xA6 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xA7 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xA8 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xA9 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xAA { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xAB { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xAC { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xAD { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xAE { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xAF { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xB0 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xB1 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xB2 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xB3 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xB4 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xB5 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xB6 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xB7 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xB8 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xB9 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xBA { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xBB { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xBC { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xBD { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xBE { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xBF { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xC0 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xC1 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xC2 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xC3 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xC4 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xC5 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xC6 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xC7 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xC8 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xC9 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xCA { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xCB { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xCC { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xCD { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xCE { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xCF { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xD0 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xD1 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xD2 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xD3 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xD4 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xD5 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xD6 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xD7 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xD8 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xD9 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xDA { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xDB { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xDC { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xDD { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xDE { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xDF { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xE0 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xE1 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xE2 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xE3 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xE4 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xE5 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xE6 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xE7 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xE8 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xE9 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xEA { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xEB { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xEC { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xED { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xEE { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xEF { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xF2 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xF6 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xF7 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xF8 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xF9 { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xFB { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xFC { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
+                case 0xFF { // Unused opcode
+                    $llvm_NoInline_llvm$_revert()
+                }
                 default {
-                    printString("INVALID OPCODE")
-                    printHex(opcode)
-                    revert(0, 0)
+                    $llvm_NoInline_llvm$_revert()
                 }
             }
             
@@ -2942,23 +3258,8 @@ object "EVMInterpreter" {
                 max_uint := 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
             }
             
-            // Essentially a NOP that will not get optimized away by the compiler
-            function $llvm_NoInline_llvm$_unoptimized() {
-                pop(1)
-            }
-            
-            function printHex(value) {
-                mstore(add(DEBUG_SLOT_OFFSET(), 0x20), 0x00debdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebde)
-                mstore(add(DEBUG_SLOT_OFFSET(), 0x40), value)
-                mstore(DEBUG_SLOT_OFFSET(), 0x4A15830341869CAA1E99840C97043A1EA15D2444DA366EFFF5C43B4BEF299681)
-                $llvm_NoInline_llvm$_unoptimized()
-            }
-            
-            function printString(value) {
-                mstore(add(DEBUG_SLOT_OFFSET(), 0x20), 0x00debdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdf)
-                mstore(add(DEBUG_SLOT_OFFSET(), 0x40), value)
-                mstore(DEBUG_SLOT_OFFSET(), 0x4A15830341869CAA1E99840C97043A1EA15D2444DA366EFFF5C43B4BEF299681)
-                $llvm_NoInline_llvm$_unoptimized()
+            function $llvm_NoInline_llvm$_revert() {
+                revert(0, 0)
             }
             
             // It is the responsibility of the caller to ensure that ip >= BYTECODE_OFFSET + 32
@@ -5639,10 +5940,341 @@ object "EVMInterpreter" {
                 
                         revertWithGas(evmGasLeft)
                     }
+                    case 0x0C { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x0D { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x0E { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x0F { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x1E { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x1F { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x21 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x22 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x23 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x24 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x25 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x26 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x27 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x28 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x29 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x2A { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x2B { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x2C { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x2D { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x2E { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x2F { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x49 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x4A { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x4B { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x4C { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x4D { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x4E { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0x4F { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xA5 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xA6 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xA7 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xA8 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xA9 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xAA { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xAB { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xAC { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xAD { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xAE { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xAF { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xB0 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xB1 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xB2 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xB3 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xB4 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xB5 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xB6 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xB7 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xB8 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xB9 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xBA { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xBB { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xBC { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xBD { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xBE { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xBF { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xC0 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xC1 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xC2 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xC3 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xC4 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xC5 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xC6 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xC7 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xC8 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xC9 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xCA { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xCB { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xCC { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xCD { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xCE { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xCF { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xD0 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xD1 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xD2 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xD3 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xD4 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xD5 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xD6 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xD7 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xD8 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xD9 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xDA { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xDB { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xDC { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xDD { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xDE { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xDF { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xE0 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xE1 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xE2 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xE3 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xE4 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xE5 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xE6 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xE7 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xE8 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xE9 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xEA { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xEB { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xEC { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xED { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xEE { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xEF { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xF2 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xF6 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xF7 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xF8 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xF9 { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xFB { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xFC { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
+                    case 0xFF { // Unused opcode
+                        $llvm_NoInline_llvm$_revert()
+                    }
                     default {
-                        printString("INVALID OPCODE")
-                        printHex(opcode)
-                        revert(0, 0)
+                        $llvm_NoInline_llvm$_revert()
                     }
                 }
                 

--- a/system-contracts/evm-interpreter/EvmInterpreterFunctions.template.yul
+++ b/system-contracts/evm-interpreter/EvmInterpreterFunctions.template.yul
@@ -62,23 +62,8 @@ function MAX_UINT() -> max_uint {
     max_uint := 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 }
 
-// Essentially a NOP that will not get optimized away by the compiler
-function $llvm_NoInline_llvm$_unoptimized() {
-    pop(1)
-}
-
-function printHex(value) {
-    mstore(add(DEBUG_SLOT_OFFSET(), 0x20), 0x00debdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebde)
-    mstore(add(DEBUG_SLOT_OFFSET(), 0x40), value)
-    mstore(DEBUG_SLOT_OFFSET(), 0x4A15830341869CAA1E99840C97043A1EA15D2444DA366EFFF5C43B4BEF299681)
-    $llvm_NoInline_llvm$_unoptimized()
-}
-
-function printString(value) {
-    mstore(add(DEBUG_SLOT_OFFSET(), 0x20), 0x00debdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdebdf)
-    mstore(add(DEBUG_SLOT_OFFSET(), 0x40), value)
-    mstore(DEBUG_SLOT_OFFSET(), 0x4A15830341869CAA1E99840C97043A1EA15D2444DA366EFFF5C43B4BEF299681)
-    $llvm_NoInline_llvm$_unoptimized()
+function $llvm_NoInline_llvm$_revert() {
+    revert(0, 0)
 }
 
 // It is the responsibility of the caller to ensure that ip >= BYTECODE_OFFSET + 32

--- a/system-contracts/evm-interpreter/EvmInterpreterLoop.template.yul
+++ b/system-contracts/evm-interpreter/EvmInterpreterLoop.template.yul
@@ -1435,9 +1435,340 @@ for { } true { } {
 
         revertWithGas(evmGasLeft)
     }
+    case 0x0C { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x0D { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x0E { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x0F { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x1E { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x1F { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x21 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x22 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x23 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x24 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x25 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x26 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x27 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x28 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x29 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x2A { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x2B { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x2C { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x2D { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x2E { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x2F { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x49 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x4A { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x4B { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x4C { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x4D { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x4E { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0x4F { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xA5 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xA6 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xA7 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xA8 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xA9 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xAA { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xAB { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xAC { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xAD { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xAE { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xAF { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xB0 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xB1 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xB2 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xB3 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xB4 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xB5 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xB6 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xB7 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xB8 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xB9 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xBA { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xBB { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xBC { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xBD { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xBE { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xBF { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xC0 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xC1 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xC2 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xC3 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xC4 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xC5 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xC6 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xC7 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xC8 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xC9 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xCA { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xCB { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xCC { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xCD { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xCE { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xCF { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xD0 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xD1 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xD2 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xD3 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xD4 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xD5 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xD6 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xD7 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xD8 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xD9 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xDA { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xDB { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xDC { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xDD { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xDE { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xDF { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xE0 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xE1 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xE2 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xE3 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xE4 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xE5 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xE6 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xE7 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xE8 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xE9 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xEA { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xEB { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xEC { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xED { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xEE { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xEF { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xF2 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xF6 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xF7 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xF8 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xF9 { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xFB { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xFC { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
+    case 0xFF { // Unused opcode
+        $llvm_NoInline_llvm$_revert()
+    }
     default {
-        printString("INVALID OPCODE")
-        printHex(opcode)
-        revert(0, 0)
+        $llvm_NoInline_llvm$_revert()
     }
 }


### PR DESCRIPTION
# What ❔
This PR adds all unused opcodes.
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔
Since opcodes are 8-bit long and if we implement all cases in the switch of that range (0-255), LLVM will optimize out default case (as it is shown [here](https://godbolt.org/z/sc5rdv361) where for default case will generate unreachable BB), thus will remove checks before jump table instruction. As a result, this will remove 1 instruction that is executed in a loop header for each opcode.
Before this patch, we had following assembly generated in a loop header:
```
	sub.s	31, r14, r1
	ldmi.h	r1, r2, r14
	and	255, r2, r2
	sub.s!	255, r2, r0        <- This check is not needed
	jump.ne	code[@JTI3_0+r2]
	jump	@.BB3_1053         <- This branch is not needed
```
After this patch:
```
	sub.s	31, r14, r1
	ldmi.h	r1, r2, r14
	and	255, r2, r2
	jump	code[@JTI3_0+r2]
```
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
