### PR TITLE
fix: ConsensusRegistry Contract's Constructor Does Not Call _disableinitializers()

### DIFF
--- a/l2-contracts/contracts/ConsensusRegistry.sol
+++ b/l2-contracts/contracts/ConsensusRegistry.sol
@@ -36,6 +36,11 @@ contract ConsensusRegistry is IConsensusRegistry, Initializable, Ownable2StepUpg
         _;
     }
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
     function initialize(address _initialOwner) external initializer {
         if (_initialOwner == address(0)) {
             revert InvalidInputNodeOwnerAddress();


### PR DESCRIPTION
Added a constructor that calls `_disableInitializers()`.