### PR TITLE
fix: Function Visibility Overly Permissive

### DIFF
--- a/l2-contracts/contracts/ConsensusRegistry.sol
+++ b/l2-contracts/contracts/ConsensusRegistry.sol
@@ -295,7 +295,7 @@ contract ConsensusRegistry is IConsensusRegistry, Initializable, Ownable2StepUpg
 
     /// @notice Returns an array of `AttesterAttr` structs representing the current attester committee.
     /// @dev Collects active and non-removed attesters based on the latest commit to the committee.
-    function getAttesterCommittee() public view returns (CommitteeAttester[] memory) {
+    function getAttesterCommittee() external view returns (CommitteeAttester[] memory) {
         uint256 len = nodeOwners.length;
         CommitteeAttester[] memory committee = new CommitteeAttester[](len);
         uint256 count = 0;
@@ -320,7 +320,7 @@ contract ConsensusRegistry is IConsensusRegistry, Initializable, Ownable2StepUpg
 
     /// @notice Returns an array of `ValidatorAttr` structs representing the current attester committee.
     /// @dev Collects active and non-removed validators based on the latest commit to the committee.
-    function getValidatorCommittee() public view returns (CommitteeValidator[] memory) {
+    function getValidatorCommittee() external view returns (CommitteeValidator[] memory) {
         uint256 len = nodeOwners.length;
         CommitteeValidator[] memory committee = new CommitteeValidator[](len);
         uint256 count = 0;
@@ -347,7 +347,7 @@ contract ConsensusRegistry is IConsensusRegistry, Initializable, Ownable2StepUpg
         return committee;
     }
 
-    function numNodes() public view returns (uint256) {
+    function numNodes() external view returns (uint256) {
         return nodeOwners.length;
     }
 

--- a/l2-contracts/contracts/interfaces/IConsensusRegistry.sol
+++ b/l2-contracts/contracts/interfaces/IConsensusRegistry.sol
@@ -158,4 +158,6 @@ interface IConsensusRegistry {
     function getAttesterCommittee() external view returns (CommitteeAttester[] memory);
 
     function getValidatorCommittee() external view returns (CommitteeValidator[] memory);
+
+    function numNodes() external view returns (uint256);
 }


### PR DESCRIPTION
Limited the `getAttesterCommittee`, `getValidatorCommittee`, and `numNodes` functions to external visibility. This fixes N-03.
Also added `numNodes` to the interface, which seemed to be an oversight.