### PR TITLE
feat(EVM-emulator): tweak LLVM options for lazy stack implementation

### DIFF
--- a/system-contracts/contracts/EvmEmulator.yul.llvm.options
+++ b/system-contracts/contracts/EvmEmulator.yul.llvm.options
@@ -1,1 +1,1 @@
-'-eravm-jump-table-density-threshold=10 -tail-dup-size=4 -eravm-enable-split-loop-phi-live-ranges -tail-merge-only-bbs-without-succ'
+'-eravm-jump-table-density-threshold=10 -tail-dup-size=6 -eravm-enable-split-loop-phi-live-ranges -tail-merge-only-bbs-without-succ -join-globalcopies -disable-early-taildup'


### PR DESCRIPTION
# What ❔
Tweak LLVM options for lazy stack implementation of EvmEmulator.
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔
To improve performance numbers (which can be seen [here](https://github.com/matter-labs/era-compiler-tester/pull/98)).
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
