### PR TITLE
feat: add merklePath getter to FullMerkle

### DIFF
--- a/l1-contracts/contracts/bridgehub/L1BridgehubErrors.sol
+++ b/l1-contracts/contracts/bridgehub/L1BridgehubErrors.sol
@@ -23,9 +23,6 @@ error AssetIdAlreadyRegistered();
 // 0xc630ef3c
 error CTMNotRegistered();
 
-// 0x4c0f5001
-error ChainIdNotRegistered();
-
 // 0xb78dbaa7
 error SecondBridgeAddressTooLow(address secondBridgeAddress, address minSecondBridgeAddress);
 

--- a/l1-contracts/contracts/bridgehub/MessageRoot.sol
+++ b/l1-contracts/contracts/bridgehub/MessageRoot.sol
@@ -8,6 +8,7 @@ import {IBridgehub} from "./IBridgehub.sol";
 import {IMessageRoot} from "./IMessageRoot.sol";
 import {ReentrancyGuard} from "../common/ReentrancyGuard.sol";
 import {OnlyBridgehub, OnlyChain, ChainExists, MessageRootNotRegistered, TooManyChains} from "./L1BridgehubErrors.sol";
+import {ChainIdNotRegistered} from "../common/L1ContractErrors.sol";
 import {FullMerkle} from "../common/libraries/FullMerkle.sol";
 
 import {MessageHashing} from "../common/libraries/MessageHashing.sol";
@@ -166,5 +167,17 @@ contract MessageRoot is IMessageRoot, ReentrancyGuard {
         sharedTree.pushNewLeaf(MessageHashing.chainIdLeafHash(initialHash, _chainId));
 
         emit AddedChain(_chainId, cachedChainCount);
+    }
+
+    /**
+     * @dev Returns merkle path in `sharedTree` for a certain chain.
+     * @param _chainId Id of the chain to get merkle path for.
+     */
+    function getMerklePathForChain(uint256 _chainId) public view returns (bytes32[] memory) {
+        if (!chainRegistered(_chainId)) {
+            revert ChainIdNotRegistered(_chainId);
+        }
+        uint256 index = chainIndex[_chainId];
+        return sharedTree.merklePath(index);
     }
 }

--- a/l1-contracts/contracts/bridgehub/MessageRoot.sol
+++ b/l1-contracts/contracts/bridgehub/MessageRoot.sol
@@ -171,7 +171,7 @@ contract MessageRoot is IMessageRoot, ReentrancyGuard {
 
     /// @dev Returns merkle path in `sharedTree` for a certain chain.
     /// @param _chainId Id of the chain to get merkle path for.
-    function getMerklePathForChain(uint256 _chainId) public view returns (bytes32[] memory) {
+    function getMerklePathForChain(uint256 _chainId) external view returns (bytes32[] memory) {
         if (!chainRegistered(_chainId)) {
             revert ChainIdNotRegistered(_chainId);
         }

--- a/l1-contracts/contracts/bridgehub/MessageRoot.sol
+++ b/l1-contracts/contracts/bridgehub/MessageRoot.sol
@@ -169,10 +169,8 @@ contract MessageRoot is IMessageRoot, ReentrancyGuard {
         emit AddedChain(_chainId, cachedChainCount);
     }
 
-    /**
-     * @dev Returns merkle path in `sharedTree` for a certain chain.
-     * @param _chainId Id of the chain to get merkle path for.
-     */
+    /// @dev Returns merkle path in `sharedTree` for a certain chain.
+    /// @param _chainId Id of the chain to get merkle path for.
     function getMerklePathForChain(uint256 _chainId) public view returns (bytes32[] memory) {
         if (!chainRegistered(_chainId)) {
             revert ChainIdNotRegistered(_chainId);

--- a/l1-contracts/contracts/common/libraries/FullMerkle.sol
+++ b/l1-contracts/contracts/common/libraries/FullMerkle.sol
@@ -144,4 +144,26 @@ library FullMerkle {
     function root(FullTree storage self) internal view returns (bytes32) {
         return self._nodes[self._height][0];
     }
+
+    /**
+     * @dev Returns merkle path for a certain leaf index.
+     * @param _index The index of the leaf to calculate proof for.
+     */
+    function merklePath(FullTree storage self, uint256 _index) public view returns (bytes32[] memory) {
+        uint256 maxNodeNumber = self._leafNumber - 1;
+        if (_index > maxNodeNumber) {
+            revert MerkleWrongIndex(_index, maxNodeNumber);
+        }
+        bytes32[] memory proof = new bytes32[](self._height);
+        for (uint256 i = 0; i < self._height; i = i.uncheckedInc()) {
+            if (_index % 2 == 0) {
+                proof[i] = maxNodeNumber == _index ? self._zeros[i] : self._nodes[i][_index + 1];
+            } else {
+                proof[i] = self._nodes[i][_index - 1];
+            }
+            _index /= 2;
+            maxNodeNumber /= 2;
+        }
+        return proof;
+    }
 }

--- a/l1-contracts/contracts/common/libraries/FullMerkle.sol
+++ b/l1-contracts/contracts/common/libraries/FullMerkle.sol
@@ -149,7 +149,7 @@ library FullMerkle {
      * @dev Returns merkle path for a certain leaf index.
      * @param _index The index of the leaf to calculate proof for.
      */
-    function merklePath(FullTree storage self, uint256 _index) public view returns (bytes32[] memory) {
+    function merklePath(FullTree storage self, uint256 _index) internal view returns (bytes32[] memory) {
         uint256 maxNodeNumber = self._leafNumber - 1;
         if (_index > maxNodeNumber) {
             revert MerkleWrongIndex(_index, maxNodeNumber);

--- a/l1-contracts/contracts/dev-contracts/test/FullMerkleTest.sol
+++ b/l1-contracts/contracts/dev-contracts/test/FullMerkleTest.sol
@@ -52,4 +52,8 @@ contract FullMerkleTest {
     function zeros(uint256 _index) external view returns (bytes32) {
         return tree._zeros[_index];
     }
+
+    function merklePath(uint256 _index) external view returns (bytes32[] memory) {
+        return tree.merklePath(_index);
+    }
 }

--- a/l1-contracts/test/foundry/l1/unit/concrete/common/libraries/FullMerkle/MerklePath.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/common/libraries/FullMerkle/MerklePath.t.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {FullMerkleTest} from "./_FullMerkle_Shared.t.sol";
+import {MerkleWrongIndex} from "contracts/common/L1ContractErrors.sol";
+
+contract MerklePathTest is FullMerkleTest {
+    function test_revertWhen_wrongIndex() public {
+        // Inserting two leaves
+        bytes32 leaf0 = keccak256("Leaf 0");
+        bytes32 leaf1 = keccak256("Leaf 1");
+        merkleTest.pushNewLeaf(leaf0);
+        merkleTest.pushNewLeaf(leaf1);
+
+        // Check that getting merkle path for leaf with index 2 reverts.
+        vm.expectRevert(abi.encodeWithSelector(MerkleWrongIndex.selector, 2, 1));
+        merkleTest.merklePath(2);
+    }
+
+    function test_merklePath() public {
+        // Inserting two leaves
+        bytes32 leaf0 = keccak256("Leaf 0");
+        bytes32 leaf1 = keccak256("Leaf 1");
+        merkleTest.pushNewLeaf(leaf0);
+        merkleTest.pushNewLeaf(leaf1);
+
+        // Check proof for both leaves
+        bytes32[] memory expectedProof = new bytes32[](1);
+
+        bytes32[] memory proofFor0 = merkleTest.merklePath(0);
+        expectedProof[0] = leaf1;
+        assertEq(proofFor0, expectedProof, "Incorrect proof for leaf #0 in tree with 2 leaves");
+
+        bytes32[] memory proofFor1 = merkleTest.merklePath(1);
+        expectedProof[0] = leaf0;
+        assertEq(proofFor1, expectedProof, "Incorrect proof for leaf #1 in tree with 2 leaves");
+
+        // Add one more leaf
+        bytes32 leaf2 = keccak256("Leaf 2");
+        merkleTest.pushNewLeaf(leaf2);
+
+        // Check proofs again
+        bytes32 node10 = keccak(leaf0, leaf1);
+        bytes32 node11 = keccak(leaf2, zeroHash);
+
+        proofFor0 = merkleTest.merklePath(0);
+        expectedProof = new bytes32[](2);
+        expectedProof[0] = leaf1;
+        expectedProof[1] = node11;
+        assertEq(proofFor0, expectedProof, "Incorrect proof for leaf #0 in tree with 3 leaves");
+
+        proofFor1 = merkleTest.merklePath(1);
+        expectedProof[0] = leaf0;
+        expectedProof[1] = node11;
+        assertEq(proofFor1, expectedProof, "Incorrect proof for leaf #1 in tree with 3 leaves");
+
+        bytes32[] memory proofFor2 = merkleTest.merklePath(2);
+        expectedProof[0] = zeroHash;
+        expectedProof[1] = node10;
+        assertEq(proofFor2, expectedProof, "Incorrect proof for leaf #2 in tree with 3 leaves");
+    }
+}


### PR DESCRIPTION
# What ❔

Adds `merklePath` getter to `FullMerkle`

## Why ❔

Node has to somehow get these proofs to prove L2->L1 log inclusion and interop message in future. This method allows integration to be more performant: (single `eth_call`) vs (bunch of `eth_getStorageAt` + calc proof)

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
