### PR TITLE
add TimestampAsserter to sync-layer-stable

### DIFF
--- a/l1-contracts/deploy-scripts/DeployL2Contracts.sol
+++ b/l1-contracts/deploy-scripts/DeployL2Contracts.sol
@@ -35,6 +35,7 @@ contract DeployL2Script is Script {
         address consensusRegistryImplementation;
         address consensusRegistryProxy;
         address multicall3;
+        address timestampAsserter;
     }
 
     function run() public {
@@ -55,6 +56,7 @@ contract DeployL2Script is Script {
         deployConsensusRegistry();
         deployConsensusRegistryProxy();
         deployMulticall3();
+        deployTimestampAsserter();
 
         saveOutput();
     }
@@ -110,6 +112,7 @@ contract DeployL2Script is Script {
         vm.serializeAddress("root", "multicall3", deployed.multicall3);
         vm.serializeAddress("root", "consensus_registry_implementation", deployed.consensusRegistryImplementation);
         vm.serializeAddress("root", "consensus_registry_proxy", deployed.consensusRegistryProxy);
+        vm.serializeAddress("root", "timestamp_asserter", deployed.timestampAsserter);
         string memory toml = vm.serializeAddress("root", "l2_default_upgrader", deployed.forceDeployUpgraderAddress);
 
         string memory root = vm.projectRoot();
@@ -175,6 +178,19 @@ contract DeployL2Script is Script {
         deployed.multicall3 = Utils.deployThroughL1({
             bytecode: L2ContractsBytecodesLib.readMulticall3Bytecode(),
             constructorargs: constructorData,
+            create2salt: "",
+            l2GasLimit: Utils.MAX_PRIORITY_TX_GAS,
+            factoryDeps: new bytes[](0),
+            chainId: config.chainId,
+            bridgehubAddress: config.bridgehubAddress,
+            l1SharedBridgeProxy: config.l1SharedBridgeProxy
+        });
+    }
+
+    function deployTimestampAsserter() internal {
+        deployed.timestampAsserter = Utils.deployThroughL1({
+            bytecode: L2ContractsBytecodesLib.readTimestampAsserterBytecode(),
+            constructorargs: "",
             create2salt: "",
             l2GasLimit: Utils.MAX_PRIORITY_TX_GAS,
             factoryDeps: new bytes[](0),

--- a/l1-contracts/deploy-scripts/L2ContractsBytecodesLib.sol
+++ b/l1-contracts/deploy-scripts/L2ContractsBytecodesLib.sol
@@ -308,7 +308,7 @@ library L2ContractsBytecodesLib {
     function readTimestampAsserterBytecode() internal view returns (bytes memory) {
         return
             Utils.readHardhatBytecode(
-            "/../l2-contracts/artifacts-zk/contracts/dev-contracts/TimestampAsserter.sol/TimestampAsserter.json"
-        );
+                "/../l2-contracts/artifacts-zk/contracts/dev-contracts/TimestampAsserter.sol/TimestampAsserter.json"
+            );
     }
 }

--- a/l1-contracts/deploy-scripts/L2ContractsBytecodesLib.sol
+++ b/l1-contracts/deploy-scripts/L2ContractsBytecodesLib.sol
@@ -302,4 +302,13 @@ library L2ContractsBytecodesLib {
                 "/../l1-contracts/artifacts-zk/contracts/governance/L2ProxyAdminDeployer.sol/L2ProxyAdminDeployer.json"
             );
     }
+
+    /// @notice Reads the bytecode of the TimestampAsserter contract.
+    /// @return The bytecode of the TimestampAsserter contract.
+    function readTimestampAsserterBytecode() internal view returns (bytes memory) {
+        return
+            Utils.readHardhatBytecode(
+            "/../l2-contracts/artifacts-zk/contracts/dev-contracts/TimestampAsserter.sol/TimestampAsserter.json"
+        );
+    }
 }

--- a/l2-contracts/contracts/dev-contracts/ITimestampAsserter.sol
+++ b/l2-contracts/contracts/dev-contracts/ITimestampAsserter.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+interface ITimestampAsserter {
+    function assertTimestampInRange(uint256 start, uint256 end) external view;
+}

--- a/l2-contracts/contracts/dev-contracts/TimestampAsserter.sol
+++ b/l2-contracts/contracts/dev-contracts/TimestampAsserter.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {ITimestampAsserter} from "./ITimestampAsserter.sol";
+
+error TimestampOutOfRange(uint256 currentTimestamp, uint256 start, uint256 end);
+
+/// @title TimestampAsserter
+/// @author Matter Labs
+/// @custom:security-contact security@matterlabs.dev
+/// @dev A contract that verifies if the current block timestamp falls within a specified range.
+/// This is useful for custom account abstraction where time-bound checks are needed but accessing block.timestamp
+/// directly is not possible.
+contract TimestampAsserter is ITimestampAsserter {
+    function assertTimestampInRange(uint256 _start, uint256 _end) external view {
+        if (block.timestamp < _start || block.timestamp > _end) {
+            revert TimestampOutOfRange(block.timestamp, _start, _end);
+        }
+    }
+}


### PR DESCRIPTION
# What ❔

Adds TimestampAsserter to sync-layer-stable

## Why ❔

Required to port zksync-era:main changes to sync-layer-stable

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
