### PR TITLE
fix: add deploy timestamp asserter command

### DIFF
--- a/l1-contracts/deploy-scripts/DeployL2Contracts.sol
+++ b/l1-contracts/deploy-scripts/DeployL2Contracts.sol
@@ -122,6 +122,15 @@ contract DeployL2Script is Script {
         saveOutput();
     }
 
+    function runDeployTimestampAsserter() public {
+        initializeConfig();
+        loadContracts(false);
+
+        deployTimestampAsserter()();
+
+        saveOutput();
+    }
+
     function loadContracts(bool legacyBridge) internal {
         //HACK: Meanwhile we are not integrated foundry zksync we use contracts that has been built using hardhat
         contracts.l2StandardErc20FactoryBytecode = Utils.readFoundryBytecode(


### PR DESCRIPTION
Add `runDeployTimstampAsserter` command to the deployment scripts to be called from the `zkstack`.