### PR TITLE
fix(EVM): Store unpadded EVM bytecode length in versioned bytecode hash

### DIFF
--- a/system-contracts/contracts/ContractDeployer.sol
+++ b/system-contracts/contracts/ContractDeployer.sol
@@ -250,7 +250,12 @@ contract ContractDeployer is IContractDeployer, SystemContractBase {
         address _newAddress,
         bytes calldata _initCode
     ) external payable onlySystemCallFromEvmEmulator returns (uint256, address) {
-        uint256 constructorReturnEvmGas = _performDeployOnAddressEVM(msg.sender, _newAddress, AccountAbstractionVersion.None, _initCode);
+        uint256 constructorReturnEvmGas = _performDeployOnAddressEVM(
+            msg.sender,
+            _newAddress,
+            AccountAbstractionVersion.None,
+            _initCode
+        );
         return (constructorReturnEvmGas, _newAddress);
     }
 
@@ -582,7 +587,7 @@ contract ContractDeployer is IContractDeployer, SystemContractBase {
             SystemContractHelper.setValueForNextFarCall(uint128(value));
         }
 
-        bytes memory paddedBytecode = EfficientCall.mimicCall({
+        bytes memory bytecode = EfficientCall.mimicCall({
             _gas: gasleft(), // note: native gas, not EVM gas
             _address: _newAddress,
             _data: _input,
@@ -593,18 +598,18 @@ contract ContractDeployer is IContractDeployer, SystemContractBase {
 
         // Returned data bytes have structure: bytecode.constructorReturnEvmGas
         assembly {
-            let dataLen := mload(paddedBytecode)
-            constructorReturnEvmGas := mload(add(paddedBytecode, dataLen))
-            mstore(paddedBytecode, sub(dataLen, 0x20)) // shrink paddedBytecode
+            let dataLen := mload(bytecode)
+            constructorReturnEvmGas := mload(add(bytecode, dataLen))
+            mstore(bytecode, sub(dataLen, 0x20))
         }
 
-        bytes32 versionedCodeHash = KNOWN_CODE_STORAGE_CONTRACT.publishEVMBytecode(paddedBytecode);
+        bytes32 versionedCodeHash = KNOWN_CODE_STORAGE_CONTRACT.publishEVMBytecode(bytecode);
         ACCOUNT_CODE_STORAGE_SYSTEM_CONTRACT.storeAccountConstructedCodeHash(_newAddress, versionedCodeHash);
 
         bytes32 evmBytecodeHash;
         assembly {
-            let bytecodeLen := mload(add(paddedBytecode, 0x20))
-            evmBytecodeHash := keccak256(add(paddedBytecode, 0x40), bytecodeLen)
+            let bytecodeLen := mload(bytecode)
+            evmBytecodeHash := keccak256(add(bytecode, 0x20), bytecodeLen)
         }
 
         _setEvmCodeHash(_newAddress, evmBytecodeHash);

--- a/system-contracts/contracts/EvmEmulator.yul
+++ b/system-contracts/contracts/EvmEmulator.yul
@@ -1783,7 +1783,17 @@ object "EvmEmulator" {
                         evmGasLeft := chargeGas(evmGasLeft, 2500)
                     }
             
-                    stackHead := extcodesize(addr)
+                    let rawCodeHash := getRawCodeHash(addr)
+                    switch shr(248, rawCodeHash)
+                    case 1 {
+                        stackHead := extcodesize(addr)
+                    }
+                    case 2 {
+                        stackHead := and(shr(224, rawCodeHash), 0xffff)
+                    }
+                    default {
+                        stackHead := 0
+                    }
             
                     ip := add(ip, 1)
                 }
@@ -4897,7 +4907,17 @@ object "EvmEmulator" {
                             evmGasLeft := chargeGas(evmGasLeft, 2500)
                         }
                 
-                        stackHead := extcodesize(addr)
+                        let rawCodeHash := getRawCodeHash(addr)
+                        switch shr(248, rawCodeHash)
+                        case 1 {
+                            stackHead := extcodesize(addr)
+                        }
+                        case 2 {
+                            stackHead := and(shr(224, rawCodeHash), 0xffff)
+                        }
+                        default {
+                            stackHead := 0
+                        }
                 
                         ip := add(ip, 1)
                     }

--- a/system-contracts/contracts/KnownCodesStorage.sol
+++ b/system-contracts/contracts/KnownCodesStorage.sol
@@ -87,11 +87,13 @@ contract KnownCodesStorage is IKnownCodesStorage, SystemContractBase {
 
     /// @notice The method used by ContractDeployer to publish EVM bytecode
     /// @dev Bytecode should be padded by EraVM rules
+    /// @param paddedBytecode The length of EVM bytecode in bytes
     /// @param paddedBytecode The bytecode to be published
     function publishEVMBytecode(
+        uint256 evmBytecodeLen,
         bytes calldata paddedBytecode
     ) external payable onlyCallFrom(address(DEPLOYER_SYSTEM_CONTRACT)) returns (bytes32) {
-        bytes32 vesionedBytecodeHash = Utils.hashEVMBytecode(paddedBytecode);
+        bytes32 vesionedBytecodeHash = Utils.hashEVMBytecode(evmBytecodeLen, paddedBytecode);
 
         if (getMarker(vesionedBytecodeHash) == 0) {
             L1_MESSENGER_CONTRACT.sendToL1(paddedBytecode);

--- a/system-contracts/contracts/SystemContractErrors.sol
+++ b/system-contracts/contracts/SystemContractErrors.sol
@@ -145,5 +145,6 @@ enum BytecodeError {
     Length,
     WordsMustBeOdd,
     DictionaryLength,
-    EvmBytecodeLength
+    EvmBytecodeLength,
+    EvmBytecodeLengthTooBig
 }

--- a/system-contracts/contracts/interfaces/IKnownCodesStorage.sol
+++ b/system-contracts/contracts/interfaces/IKnownCodesStorage.sol
@@ -17,5 +17,5 @@ interface IKnownCodesStorage {
 
     function getMarker(bytes32 _hash) external view returns (uint256);
 
-    function publishEVMBytecode(bytes calldata bytecode) external payable returns (bytes32);
+    function publishEVMBytecode(uint256 evmBytecodeLen, bytes calldata bytecode) external payable returns (bytes32);
 }

--- a/system-contracts/contracts/libraries/Utils.sol
+++ b/system-contracts/contracts/libraries/Utils.sol
@@ -138,29 +138,43 @@ library Utils {
     uint256 internal constant MAX_EVM_BYTECODE_LENGTH = (2 ** 16) - 1;
 
     /// @notice Validate the bytecode format and calculate its hash.
-    /// @param _bytecode The EVM bytecode to hash.
+    /// @param _evmBytecodeLen The length of original EVM bytecode in bytes
+    /// @param _paddedBytecode The padded EVM bytecode to hash.
     /// @return hashedEVMBytecode The 32-byte hash of the EVM bytecode.
     /// Note: The function reverts the execution if the bytecode has non expected format:
+    /// - Bytecode bytes length is not a multiple of 32
     /// - Bytecode bytes length is greater than 2^16 - 1 bytes
+    /// - Bytecode words length is not odd
     function hashEVMBytecode(
-        uint256 evmBytecodeLen,
-        bytes calldata _bytecode
+        uint256 _evmBytecodeLen,
+        bytes calldata _paddedBytecode
     ) internal view returns (bytes32 hashedEVMBytecode) {
-        if (evmBytecodeLen > MAX_EVM_BYTECODE_LENGTH) {
-            revert MalformedBytecode(BytecodeError.EvmBytecodeLength);
-        }
-
-        if (evmBytecodeLen > _bytecode.length) {
+        // Note that the length of the bytecode must be provided in 32-byte words.
+        if (_paddedBytecode.length % 32 != 0) {
             revert MalformedBytecode(BytecodeError.Length);
         }
 
+        if (_evmBytecodeLen > _paddedBytecode.length) {
+            revert MalformedBytecode(BytecodeError.EvmBytecodeLength);
+        }
+
+        if (_evmBytecodeLen > MAX_EVM_BYTECODE_LENGTH) {
+            revert MalformedBytecode(BytecodeError.EvmBytecodeLengthTooBig);
+        }
+
+        uint256 lengthInWords = _paddedBytecode.length / 32;
+        // bytecode length in words must be odd
+        if (lengthInWords % 2 == 0) {
+            revert MalformedBytecode(BytecodeError.WordsMustBeOdd);
+        }
+
         hashedEVMBytecode =
-            EfficientCall.sha(_bytecode) &
+            EfficientCall.sha(_paddedBytecode) &
             0x00000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
 
         // Setting the version of the hash
         hashedEVMBytecode = (hashedEVMBytecode | bytes32(uint256(EVM_BYTECODE_FLAG) << 248));
-        hashedEVMBytecode = hashedEVMBytecode | bytes32(evmBytecodeLen << 224);
+        hashedEVMBytecode = hashedEVMBytecode | bytes32(_evmBytecodeLen << 224);
     }
 
     /// @notice Calculates the address of a deployed contract via create2 on the EVM

--- a/system-contracts/contracts/libraries/Utils.sol
+++ b/system-contracts/contracts/libraries/Utils.sol
@@ -142,9 +142,16 @@ library Utils {
     /// @return hashedEVMBytecode The 32-byte hash of the EVM bytecode.
     /// Note: The function reverts the execution if the bytecode has non expected format:
     /// - Bytecode bytes length is greater than 2^16 - 1 bytes
-    function hashEVMBytecode(bytes calldata _bytecode) internal view returns (bytes32 hashedEVMBytecode) {
-        if (_bytecode.length > MAX_EVM_BYTECODE_LENGTH) {
+    function hashEVMBytecode(
+        uint256 evmBytecodeLen,
+        bytes calldata _bytecode
+    ) internal view returns (bytes32 hashedEVMBytecode) {
+        if (evmBytecodeLen > MAX_EVM_BYTECODE_LENGTH) {
             revert MalformedBytecode(BytecodeError.EvmBytecodeLength);
+        }
+
+        if (evmBytecodeLen > _bytecode.length) {
+            revert MalformedBytecode(BytecodeError.Length);
         }
 
         hashedEVMBytecode =
@@ -153,7 +160,7 @@ library Utils {
 
         // Setting the version of the hash
         hashedEVMBytecode = (hashedEVMBytecode | bytes32(uint256(EVM_BYTECODE_FLAG) << 248));
-        hashedEVMBytecode = hashedEVMBytecode | bytes32(_bytecode.length << 224);
+        hashedEVMBytecode = hashedEVMBytecode | bytes32(evmBytecodeLen << 224);
     }
 
     /// @notice Calculates the address of a deployed contract via create2 on the EVM

--- a/system-contracts/contracts/libraries/Utils.sol
+++ b/system-contracts/contracts/libraries/Utils.sol
@@ -141,23 +141,10 @@ library Utils {
     /// @param _bytecode The EVM bytecode to hash.
     /// @return hashedEVMBytecode The 32-byte hash of the EVM bytecode.
     /// Note: The function reverts the execution if the bytecode has non expected format:
-    /// - Bytecode bytes length is not a multiple of 32
     /// - Bytecode bytes length is greater than 2^16 - 1 bytes
-    /// - Bytecode words length is not odd
     function hashEVMBytecode(bytes calldata _bytecode) internal view returns (bytes32 hashedEVMBytecode) {
-        // Note that the length of the bytecode must be provided in 32-byte words.
-        if (_bytecode.length % 32 != 0) {
-            revert MalformedBytecode(BytecodeError.Length);
-        }
-
         if (_bytecode.length > MAX_EVM_BYTECODE_LENGTH) {
             revert MalformedBytecode(BytecodeError.EvmBytecodeLength);
-        }
-
-        uint256 lengthInWords = _bytecode.length / 32;
-        // bytecode length in words must be odd
-        if (lengthInWords % 2 == 0) {
-            revert MalformedBytecode(BytecodeError.WordsMustBeOdd);
         }
 
         hashedEVMBytecode =

--- a/system-contracts/evm-emulator/EvmEmulator.template.yul
+++ b/system-contracts/evm-emulator/EvmEmulator.template.yul
@@ -21,27 +21,6 @@ object "EvmEmulator" {
             copyActivePtrData(BYTECODE_OFFSET(), 0, size)
         }
 
-        function padBytecode(offset, len) -> blobOffset, blobLen {
-            blobOffset := sub(offset, 32)
-            let trueLastByte := add(offset, len)
-
-            mstore(blobOffset, len)
-            // clearing out additional bytes
-            mstore(trueLastByte, 0)
-            mstore(add(trueLastByte, 32), 0)
-
-            blobLen := add(len, 32)
-
-            if iszero(eq(mod(blobLen, 32), 0)) {
-                blobLen := add(blobLen, sub(32, mod(blobLen, 32)))
-            }
-
-            // Now it is divisible by 32, but we must make sure that the number of 32 byte words is odd
-            if iszero(eq(mod(blobLen, 64), 32)) {
-                blobLen := add(blobLen, 32)
-            }
-        }
-
         function validateBytecodeAndChargeGas(offset, deployedCodeLen, gasToReturn) -> returnGas {
             if deployedCodeLen {
                 // EIP-3860
@@ -97,8 +76,6 @@ object "EvmEmulator" {
         let offset, len, gasToReturn := simulate(isCallerEVM, evmGasLeft, false)
 
         gasToReturn := validateBytecodeAndChargeGas(offset, len, gasToReturn)
-
-        offset, len := padBytecode(offset, len)
 
         mstore(add(offset, len), gasToReturn)
 

--- a/system-contracts/evm-emulator/EvmEmulatorFunctions.template.yul
+++ b/system-contracts/evm-emulator/EvmEmulatorFunctions.template.yul
@@ -382,28 +382,6 @@ function fetchDeployedCode(addr, dstOffset, srcOffset, len) -> copiedLen {
     } 
 }
 
-// Returns the length of the EVM bytecode.
-function fetchDeployedEvmCodeLen(addr) -> codeLen {
-    let codeHash := getRawCodeHash(addr)
-    mstore(0, codeHash)
-
-    let success := staticcall(gas(), CODE_ORACLE_SYSTEM_CONTRACT(), 0, 32, 0, 0)
-
-    switch iszero(success)
-    case 1 {
-        // The code oracle call can only fail in the case where the contract
-        // we are querying is the current one executing and it has not yet been
-        // deployed, i.e., if someone calls codesize (or extcodesize(address()))
-        // inside the constructor. In that case, code length is zero.
-        codeLen := 0
-    }
-    default {
-        // The first word is the true length of the bytecode
-        returndatacopy(0, 0, 32)
-        codeLen := mload(0)
-    }
-}
-
 function getMax(a, b) -> max {
     max := b
     if gt(a, b) {

--- a/system-contracts/evm-emulator/EvmEmulatorLoop.template.yul
+++ b/system-contracts/evm-emulator/EvmEmulatorLoop.template.yul
@@ -468,7 +468,17 @@ for { } true { } {
             evmGasLeft := chargeGas(evmGasLeft, 2500)
         }
 
-        stackHead := extcodesize(addr)
+        let rawCodeHash := getRawCodeHash(addr)
+        switch shr(248, rawCodeHash)
+        case 1 {
+            stackHead := extcodesize(addr)
+        }
+        case 2 {
+            stackHead := and(shr(224, rawCodeHash), 0xffff)
+        }
+        default {
+            stackHead := 0
+        }
 
         ip := add(ip, 1)
     }

--- a/system-contracts/evm-emulator/EvmEmulatorLoop.template.yul
+++ b/system-contracts/evm-emulator/EvmEmulatorLoop.template.yul
@@ -468,9 +468,7 @@ for { } true { } {
             evmGasLeft := chargeGas(evmGasLeft, 2500)
         }
 
-        switch isEvmContract(addr) 
-            case 0  { stackHead := extcodesize(addr) }
-            default { stackHead := fetchDeployedEvmCodeLen(addr) }
+        stackHead := extcodesize(addr)
 
         ip := add(ip, 1)
     }

--- a/system-contracts/test/KnownCodesStorage.spec.ts
+++ b/system-contracts/test/KnownCodesStorage.spec.ts
@@ -6,6 +6,7 @@ import { KnownCodesStorageFactory } from "../typechain";
 import {
   TEST_BOOTLOADER_FORMAL_ADDRESS,
   TEST_COMPRESSOR_CONTRACT_ADDRESS,
+  TEST_DEPLOYER_SYSTEM_CONTRACT_ADDRESS,
   TEST_KNOWN_CODE_STORAGE_CONTRACT_ADDRESS,
 } from "./shared/constants";
 import { encodeCalldata, getMock, prepareEnvironment } from "./shared/mocks";
@@ -85,10 +86,32 @@ describe("KnownCodesStorage tests", function () {
   });
 
   describe("publishEVMBytecode", function () {
+    let deployerAccount: ethers.Signer;
+
+    const InvalidBytecode =
+      "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+
+    beforeEach(async () => {
+      deployerAccount = await ethers.getImpersonatedSigner(TEST_DEPLOYER_SYSTEM_CONTRACT_ADDRESS);
+    });
+
     it("non-deployer failed to call", async () => {
-      await expect(knownCodesStorage.publishEVMBytecode(32, "0x00")).to.be.revertedWithCustomError(
+      await expect(knownCodesStorage.publishEVMBytecode(1, "0x00")).to.be.revertedWithCustomError(
         knownCodesStorage,
         "Unauthorized"
+      );
+    });
+
+    it("bytecode with even length failed to publish", async () => {
+      await expect(
+        knownCodesStorage.connect(deployerAccount).publishEVMBytecode(64, InvalidBytecode)
+      ).to.be.revertedWithCustomError(knownCodesStorage, "MalformedBytecode");
+    });
+
+    it("invalid length bytecode failed to call", async () => {
+      await expect(knownCodesStorage.connect(deployerAccount).publishEVMBytecode(1, "0x00")).to.be.revertedWithCustomError(
+        knownCodesStorage,
+        "MalformedBytecode"
       );
     });
   });

--- a/system-contracts/test/KnownCodesStorage.spec.ts
+++ b/system-contracts/test/KnownCodesStorage.spec.ts
@@ -6,7 +6,6 @@ import { KnownCodesStorageFactory } from "../typechain";
 import {
   TEST_BOOTLOADER_FORMAL_ADDRESS,
   TEST_COMPRESSOR_CONTRACT_ADDRESS,
-  TEST_DEPLOYER_SYSTEM_CONTRACT_ADDRESS,
   TEST_KNOWN_CODE_STORAGE_CONTRACT_ADDRESS,
 } from "./shared/constants";
 import { encodeCalldata, getMock, prepareEnvironment } from "./shared/mocks";
@@ -86,32 +85,10 @@ describe("KnownCodesStorage tests", function () {
   });
 
   describe("publishEVMBytecode", function () {
-    let deployerAccount: ethers.Signer;
-
-    const InvalidBytecode =
-      "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
-
-    beforeEach(async () => {
-      deployerAccount = await ethers.getImpersonatedSigner(TEST_DEPLOYER_SYSTEM_CONTRACT_ADDRESS);
-    });
-
     it("non-deployer failed to call", async () => {
       await expect(knownCodesStorage.publishEVMBytecode("0x00")).to.be.revertedWithCustomError(
         knownCodesStorage,
         "Unauthorized"
-      );
-    });
-
-    it("bytecode with even length failed to publish", async () => {
-      await expect(
-        knownCodesStorage.connect(deployerAccount).publishEVMBytecode(InvalidBytecode)
-      ).to.be.revertedWithCustomError(knownCodesStorage, "MalformedBytecode");
-    });
-
-    it("invalid length bytecode failed to call", async () => {
-      await expect(knownCodesStorage.connect(deployerAccount).publishEVMBytecode("0x00")).to.be.revertedWithCustomError(
-        knownCodesStorage,
-        "MalformedBytecode"
       );
     });
   });

--- a/system-contracts/test/KnownCodesStorage.spec.ts
+++ b/system-contracts/test/KnownCodesStorage.spec.ts
@@ -86,7 +86,7 @@ describe("KnownCodesStorage tests", function () {
 
   describe("publishEVMBytecode", function () {
     it("non-deployer failed to call", async () => {
-      await expect(knownCodesStorage.publishEVMBytecode("0x00")).to.be.revertedWithCustomError(
+      await expect(knownCodesStorage.publishEVMBytecode(32, "0x00")).to.be.revertedWithCustomError(
         knownCodesStorage,
         "Unauthorized"
       );

--- a/system-contracts/test/KnownCodesStorage.spec.ts
+++ b/system-contracts/test/KnownCodesStorage.spec.ts
@@ -109,10 +109,9 @@ describe("KnownCodesStorage tests", function () {
     });
 
     it("invalid length bytecode failed to call", async () => {
-      await expect(knownCodesStorage.connect(deployerAccount).publishEVMBytecode(1, "0x00")).to.be.revertedWithCustomError(
-        knownCodesStorage,
-        "MalformedBytecode"
-      );
+      await expect(
+        knownCodesStorage.connect(deployerAccount).publishEVMBytecode(1, "0x00")
+      ).to.be.revertedWithCustomError(knownCodesStorage, "MalformedBytecode");
     });
   });
 


### PR DESCRIPTION
# What ❔

The previously used versioned bytecode hash encoding is inefficient. For EVM contracts, we can store the length of the **original unpadded** EVM bytecode directly in the hash to simplify the logic of `EXTCODESIZE`.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
