### PR TITLE
fix(EVM): Make DELEGATECALL behavior closer to EVM

### DIFF
--- a/system-contracts/contracts/EvmEmulator.yul
+++ b/system-contracts/contracts/EvmEmulator.yul
@@ -396,8 +396,7 @@ object "EvmEmulator" {
             isEVM := fetchFromSystemContract(ACCOUNT_CODE_STORAGE_SYSTEM_CONTRACT(), 36)
         }
         
-        function isConstructedEvmContract(addr) -> isConstructedEVM {
-            let rawCodeHash := getRawCodeHash(addr)
+        function isHashOfConstructedEvmContract(rawCodeHash) -> isConstructedEVM {
             let version := shr(248, rawCodeHash)
             let isConstructedFlag := xor(shr(240, rawCodeHash), 1)
             isConstructedEVM := and(eq(version, 2), isConstructedFlag)
@@ -758,23 +757,35 @@ object "EvmEmulator" {
         
             newGasLeft := sub(newGasLeft, gasToPass)
         
-            let success := 1 // delegatecall to empty contract succeds
+            let success
             let frameGasLeft := gasToPass
         
-            switch shr(248, getRawCodeHash(addr)) // check version of called bytecode
-            case 1 {
+            let rawCodeHash := getRawCodeHash(addr)
+            switch isHashOfConstructedEvmContract(rawCodeHash)
+            case 0 {
+                // Not a constructed EVM contract
                 let precompileCost := getGasForPrecompiles(addr, argsOffset, argsSize)
                 switch precompileCost
                 case 0 {
-                    // We forbid delegatecalls to EraVM native contracts
-                    success := 0
+                    // Not a precompile
+                    switch eq(1, shr(248, rawCodeHash))
+                    case 0 {
+                        // Empty contract or EVM contract being constructed
+                        success := delegatecall(gas(), addr, add(MEM_OFFSET(), argsOffset), argsSize, 0, 0)
+                        _saveReturndataAfterZkEVMCall()
+                    }
+                    default {
+                        // We forbid delegatecalls to EraVM native contracts
+                        _eraseReturndataPointer()
+                    }
                 } 
                 default {
-                    // precompile
+                    // Precompile. Simlate using staticcall, since EraVM behavior differs here
                     success, frameGasLeft := callPrecompile(addr, precompileCost, gasToPass, 0, argsOffset, argsSize, retOffset, retSize, true)
                 }
             }
-            case 2 {
+            default {
+                // Constructed EVM contract
                 pushEvmFrame(gasToPass, isStatic)
                 // pass all remaining native gas
                 success := delegatecall(gas(), addr, add(MEM_OFFSET(), argsOffset), argsSize, 0, 0)
@@ -805,7 +816,7 @@ object "EvmEmulator" {
         }
         
         function _genericCall(addr, gasToPass, value, argsOffset, argsSize, retOffset, retSize, isStatic) -> success, frameGasLeft {
-            switch isConstructedEvmContract(addr)
+            switch isHashOfConstructedEvmContract(getRawCodeHash(addr))
             case 0 {
                 // zkEVM native call
                 let precompileCost := getGasForPrecompiles(addr, argsOffset, argsSize)
@@ -3445,8 +3456,7 @@ object "EvmEmulator" {
                 isEVM := fetchFromSystemContract(ACCOUNT_CODE_STORAGE_SYSTEM_CONTRACT(), 36)
             }
             
-            function isConstructedEvmContract(addr) -> isConstructedEVM {
-                let rawCodeHash := getRawCodeHash(addr)
+            function isHashOfConstructedEvmContract(rawCodeHash) -> isConstructedEVM {
                 let version := shr(248, rawCodeHash)
                 let isConstructedFlag := xor(shr(240, rawCodeHash), 1)
                 isConstructedEVM := and(eq(version, 2), isConstructedFlag)
@@ -3807,23 +3817,35 @@ object "EvmEmulator" {
             
                 newGasLeft := sub(newGasLeft, gasToPass)
             
-                let success := 1 // delegatecall to empty contract succeds
+                let success
                 let frameGasLeft := gasToPass
             
-                switch shr(248, getRawCodeHash(addr)) // check version of called bytecode
-                case 1 {
+                let rawCodeHash := getRawCodeHash(addr)
+                switch isHashOfConstructedEvmContract(rawCodeHash)
+                case 0 {
+                    // Not a constructed EVM contract
                     let precompileCost := getGasForPrecompiles(addr, argsOffset, argsSize)
                     switch precompileCost
                     case 0 {
-                        // We forbid delegatecalls to EraVM native contracts
-                        success := 0
+                        // Not a precompile
+                        switch eq(1, shr(248, rawCodeHash))
+                        case 0 {
+                            // Empty contract or EVM contract being constructed
+                            success := delegatecall(gas(), addr, add(MEM_OFFSET(), argsOffset), argsSize, 0, 0)
+                            _saveReturndataAfterZkEVMCall()
+                        }
+                        default {
+                            // We forbid delegatecalls to EraVM native contracts
+                            _eraseReturndataPointer()
+                        }
                     } 
                     default {
-                        // precompile
+                        // Precompile. Simlate using staticcall, since EraVM behavior differs here
                         success, frameGasLeft := callPrecompile(addr, precompileCost, gasToPass, 0, argsOffset, argsSize, retOffset, retSize, true)
                     }
                 }
-                case 2 {
+                default {
+                    // Constructed EVM contract
                     pushEvmFrame(gasToPass, isStatic)
                     // pass all remaining native gas
                     success := delegatecall(gas(), addr, add(MEM_OFFSET(), argsOffset), argsSize, 0, 0)
@@ -3854,7 +3876,7 @@ object "EvmEmulator" {
             }
             
             function _genericCall(addr, gasToPass, value, argsOffset, argsSize, retOffset, retSize, isStatic) -> success, frameGasLeft {
-                switch isConstructedEvmContract(addr)
+                switch isHashOfConstructedEvmContract(getRawCodeHash(addr))
                 case 0 {
                     // zkEVM native call
                     let precompileCost := getGasForPrecompiles(addr, argsOffset, argsSize)

--- a/system-contracts/evm-emulator/EvmEmulatorFunctions.template.yul
+++ b/system-contracts/evm-emulator/EvmEmulatorFunctions.template.yul
@@ -724,33 +724,32 @@ function performDelegateCall(oldSp, evmGasLeft, isStatic, oldStackHead) -> newGa
     // memory_expansion_cost
     gasUsed := add(gasUsed, expandMemory2(retOffset, retSize, argsOffset, argsSize))
 
-    evmGasLeft := chargeGas(evmGasLeft, gasUsed)
+    newGasLeft := chargeGas(evmGasLeft, gasUsed)
 
     // it is also not possible to delegatecall precompiles
-    if iszero(isEvmContract(addr)) {
-        revertWithGas(evmGasLeft)
+    if isEvmContract(addr) {
+        gasToPass := capGasForCall(newGasLeft, gasToPass)
+        newGasLeft := sub(newGasLeft, gasToPass)
+
+        pushEvmFrame(gasToPass, isStatic)
+        let success := delegatecall(
+            gas(), // pass all remaining native gas
+            addr,
+            add(MEM_OFFSET(), argsOffset),
+            argsSize,
+            0,
+            0
+        )
+
+        let frameGasLeft := _saveReturndataAfterEVMCall(add(MEM_OFFSET(), retOffset), retSize)
+        if iszero(success) {
+            resetEvmFrame()
+        }
+
+        newGasLeft := add(evmGasLeft, frameGasLeft)
+
+        stackHead := success
     }
-
-    gasToPass := capGasForCall(evmGasLeft, gasToPass)
-    evmGasLeft := sub(evmGasLeft, gasToPass)
-
-    pushEvmFrame(gasToPass, isStatic)
-    let success := delegatecall(
-        gas(), // pass all remaining native gas
-        addr,
-        add(MEM_OFFSET(), argsOffset),
-        argsSize,
-        0,
-        0
-    )
-
-    let frameGasLeft := _saveReturndataAfterEVMCall(add(MEM_OFFSET(), retOffset), retSize)
-    if iszero(success) {
-        resetEvmFrame()
-    }
-
-    newGasLeft := add(evmGasLeft, frameGasLeft)
-    stackHead := success
 }
 
 function _genericCall(addr, gasToPass, value, argsOffset, argsSize, retOffset, retSize, isStatic) -> success, frameGasLeft {

--- a/system-contracts/evm-emulator/EvmEmulatorFunctions.template.yul
+++ b/system-contracts/evm-emulator/EvmEmulatorFunctions.template.yul
@@ -593,20 +593,15 @@ function resetEvmFrame() {
 ////////////////////////////////////////////////////////////////
 
 function performCall(oldSp, evmGasLeft, oldStackHead, isStatic) -> newGasLeft, sp, stackHead {
-    let gasToPass, addr, value, argsOffset, argsSize, retOffset, retSize
+    let gasToPass, rawAddr, value, argsOffset, argsSize, retOffset, retSize
 
     popStackCheck(oldSp, 7)
     gasToPass, sp, stackHead := popStackItemWithoutCheck(oldSp, oldStackHead)
-    addr, sp, stackHead := popStackItemWithoutCheck(sp, stackHead)
+    rawAddr, sp, stackHead := popStackItemWithoutCheck(sp, stackHead)
     value, sp, stackHead := popStackItemWithoutCheck(sp, stackHead)
     argsOffset, sp, stackHead := popStackItemWithoutCheck(sp, stackHead)
     argsSize, sp, stackHead := popStackItemWithoutCheck(sp, stackHead)
     retOffset, sp, retSize := popStackItemWithoutCheck(sp, stackHead)
-
-    addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
-
-    checkMemIsAccessible(argsOffset, argsSize)
-    checkMemIsAccessible(retOffset, retSize)
 
     // static_gas = 0
     // dynamic_gas = memory_expansion_cost + code_execution_cost + address_access_cost + positive_value_cost + value_to_empty_account_cost
@@ -615,13 +610,7 @@ function performCall(oldSp, evmGasLeft, oldStackHead, isStatic) -> newGasLeft, s
     // If value is not 0, then positive_value_cost is 9000. In this case there is also a call stipend that is given to make sure that a basic fallback function can be called.
     // If value is not 0 and the address given points to an empty account, then value_to_empty_account_cost is 25000. An account is empty if its balance is 0, its nonce is 0 and it has no code.
 
-    let gasUsed := 100 // warm address access cost
-    if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
-        gasUsed := 2600 // cold address access cost
-    }
-
-    // memory_expansion_cost
-    gasUsed := add(gasUsed, expandMemory2(retOffset, retSize, argsOffset, argsSize))
+    let addr, gasUsed := _genericPrecallLogic(rawAddr, argsOffset, argsSize, retOffset, retSize)
 
     if gt(value, 0) {
         if isStatic {
@@ -659,27 +648,16 @@ function performCall(oldSp, evmGasLeft, oldStackHead, isStatic) -> newGasLeft, s
 }
 
 function performStaticCall(oldSp, evmGasLeft, oldStackHead) -> newGasLeft, sp, stackHead {
-    let gasToPass,addr, argsOffset, argsSize, retOffset, retSize
+    let gasToPass, rawAddr, argsOffset, argsSize, retOffset, retSize
 
     popStackCheck(oldSp, 6)
     gasToPass, sp, stackHead := popStackItemWithoutCheck(oldSp, oldStackHead)
-    addr, sp, stackHead  := popStackItemWithoutCheck(sp, stackHead)
+    rawAddr, sp, stackHead  := popStackItemWithoutCheck(sp, stackHead)
     argsOffset, sp, stackHead := popStackItemWithoutCheck(sp, stackHead)
     argsSize, sp, stackHead := popStackItemWithoutCheck(sp, stackHead)
     retOffset, sp, retSize := popStackItemWithoutCheck(sp, stackHead)
 
-    addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
-
-    checkMemIsAccessible(argsOffset, argsSize)
-    checkMemIsAccessible(retOffset, retSize)
-
-    let gasUsed := 100 // warm address access cost
-    if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
-        gasUsed := 2600 // cold address access cost
-    }
-
-    // memory_expansion_cost
-    gasUsed := add(gasUsed, expandMemory2(retOffset, retSize, argsOffset, argsSize))
+    let addr, gasUsed := _genericPrecallLogic(rawAddr, argsOffset, argsSize, retOffset, retSize)
 
     evmGasLeft := chargeGas(evmGasLeft, gasUsed)
     gasToPass := capGasForCall(evmGasLeft, gasToPass)
@@ -702,54 +680,66 @@ function performStaticCall(oldSp, evmGasLeft, oldStackHead) -> newGasLeft, sp, s
 
 
 function performDelegateCall(oldSp, evmGasLeft, isStatic, oldStackHead) -> newGasLeft, sp, stackHead {
-    let addr, gasToPass, argsOffset, argsSize, retOffset, retSize
+    let gasToPass, rawAddr, argsOffset, argsSize, retOffset, retSize
 
     popStackCheck(oldSp, 6)
     gasToPass, sp, stackHead := popStackItemWithoutCheck(oldSp, oldStackHead)
-    addr, sp, stackHead := popStackItemWithoutCheck(sp, stackHead)
+    rawAddr, sp, stackHead := popStackItemWithoutCheck(sp, stackHead)
     argsOffset, sp, stackHead := popStackItemWithoutCheck(sp, stackHead)
     argsSize, sp, stackHead := popStackItemWithoutCheck(sp, stackHead)
     retOffset, sp, retSize := popStackItemWithoutCheck(sp, stackHead)
 
-    addr := and(addr, 0xffffffffffffffffffffffffffffffffffffffff)
+    let addr, gasUsed := _genericPrecallLogic(rawAddr, argsOffset, argsSize, retOffset, retSize)
+
+    newGasLeft := chargeGas(evmGasLeft, gasUsed)
+    gasToPass := capGasForCall(newGasLeft, gasToPass)
+
+    newGasLeft := sub(newGasLeft, gasToPass)
+
+    let success := 1 // delegatecall to empty contract succeds
+    let frameGasLeft := gasToPass
+
+    switch shr(248, getRawCodeHash(addr)) // check version of called bytecode
+    case 1 {
+        let precompileCost := getGasForPrecompiles(addr, argsOffset, argsSize)
+        switch precompileCost
+        case 0 {
+            // We forbid delegatecalls to EraVM native contracts
+            success := 0
+        } 
+        default {
+            // precompile
+            success, frameGasLeft := callPrecompile(addr, precompileCost, gasToPass, 0, argsOffset, argsSize, retOffset, retSize, true)
+        }
+    }
+    case 2 {
+        pushEvmFrame(gasToPass, isStatic)
+        // pass all remaining native gas
+        success := delegatecall(gas(), addr, add(MEM_OFFSET(), argsOffset), argsSize, 0, 0)
+
+        frameGasLeft := _saveReturndataAfterEVMCall(add(MEM_OFFSET(), retOffset), retSize)
+        if iszero(success) {
+            resetEvmFrame()
+        }
+    }
+
+    newGasLeft := add(newGasLeft, frameGasLeft)
+    stackHead := success
+}
+
+function _genericPrecallLogic(rawAddr, argsOffset, argsSize, retOffset, retSize) -> addr, gasUsed {
+    addr := and(rawAddr, 0xffffffffffffffffffffffffffffffffffffffff)
 
     checkMemIsAccessible(argsOffset, argsSize)
     checkMemIsAccessible(retOffset, retSize)
 
-    let gasUsed := 100 // warm address access cost
+    gasUsed := 100 // warm address access cost
     if iszero($llvm_AlwaysInline_llvm$_warmAddress(addr)) {
         gasUsed := 2600 // cold address access cost
     }
 
     // memory_expansion_cost
     gasUsed := add(gasUsed, expandMemory2(retOffset, retSize, argsOffset, argsSize))
-
-    newGasLeft := chargeGas(evmGasLeft, gasUsed)
-
-    // it is also not possible to delegatecall precompiles
-    if isEvmContract(addr) {
-        gasToPass := capGasForCall(newGasLeft, gasToPass)
-        newGasLeft := sub(newGasLeft, gasToPass)
-
-        pushEvmFrame(gasToPass, isStatic)
-        let success := delegatecall(
-            gas(), // pass all remaining native gas
-            addr,
-            add(MEM_OFFSET(), argsOffset),
-            argsSize,
-            0,
-            0
-        )
-
-        let frameGasLeft := _saveReturndataAfterEVMCall(add(MEM_OFFSET(), retOffset), retSize)
-        if iszero(success) {
-            resetEvmFrame()
-        }
-
-        newGasLeft := add(evmGasLeft, frameGasLeft)
-
-        stackHead := success
-    }
 }
 
 function _genericCall(addr, gasToPass, value, argsOffset, argsSize, retOffset, retSize, isStatic) -> success, frameGasLeft {


### PR DESCRIPTION
# What ❔

We should:
- Not revert caller frame on DELEGATECALL to EraVM contracts
- Get the same result from precompiles as using CALL
- Allow delegatecalls to empty contracts

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
