### PR TITLE
fix(EVM): Handle calldata-related opcodes in constructor

### DIFF
--- a/system-contracts/contracts/EvmEmulator.yul
+++ b/system-contracts/contracts/EvmEmulator.yul
@@ -1309,6 +1309,18 @@ object "EvmEmulator" {
             }
         }
 
+        function $llvm_AlwaysInline_llvm$_calldatasize() -> size {
+            size := 0
+        }
+        
+        function $llvm_AlwaysInline_llvm$_calldatacopy(dstOffset, sourceOffset, truncatedLen) {
+            $llvm_AlwaysInline_llvm$_memsetToZero(dstOffset, truncatedLen)
+        }
+        
+        function $llvm_AlwaysInline_llvm$_calldataload(calldataOffset) -> res {
+            res := 0
+        }
+
         function simulate(
             isCallerEVM,
             evmGasLeft,
@@ -1667,18 +1679,14 @@ object "EvmEmulator" {
             
                     let calldataOffset := accessStackHead(sp, stackHead)
             
-                    stackHead := 0
-                    // EraVM will revert if offset + length overflows uint32
-                    if lt(calldataOffset, UINT32_MAX()) {
-                        stackHead := calldataload(calldataOffset)
-                    }
+                    stackHead := $llvm_AlwaysInline_llvm$_calldataload(calldataOffset)
             
                     ip := add(ip, 1)
                 }
                 case 0x36 { // OP_CALLDATASIZE
                     evmGasLeft := chargeGas(evmGasLeft, 2)
             
-                    sp, stackHead := pushStackItem(sp, calldatasize(), stackHead)
+                    sp, stackHead := pushStackItem(sp, $llvm_AlwaysInline_llvm$_calldatasize(), stackHead)
                     ip := add(ip, 1)
                 }
                 case 0x37 { // OP_CALLDATACOPY
@@ -1713,7 +1721,7 @@ object "EvmEmulator" {
                     }
             
                     if truncatedLen {
-                        calldatacopy(dstOffset, sourceOffset, truncatedLen)
+                        $llvm_AlwaysInline_llvm$_calldatacopy(dstOffset, sourceOffset, truncatedLen)
                     }
             
                     ip := add(ip, 1)
@@ -4805,18 +4813,14 @@ object "EvmEmulator" {
                 
                         let calldataOffset := accessStackHead(sp, stackHead)
                 
-                        stackHead := 0
-                        // EraVM will revert if offset + length overflows uint32
-                        if lt(calldataOffset, UINT32_MAX()) {
-                            stackHead := calldataload(calldataOffset)
-                        }
+                        stackHead := $llvm_AlwaysInline_llvm$_calldataload(calldataOffset)
                 
                         ip := add(ip, 1)
                     }
                     case 0x36 { // OP_CALLDATASIZE
                         evmGasLeft := chargeGas(evmGasLeft, 2)
                 
-                        sp, stackHead := pushStackItem(sp, calldatasize(), stackHead)
+                        sp, stackHead := pushStackItem(sp, $llvm_AlwaysInline_llvm$_calldatasize(), stackHead)
                         ip := add(ip, 1)
                     }
                     case 0x37 { // OP_CALLDATACOPY
@@ -4851,7 +4855,7 @@ object "EvmEmulator" {
                         }
                 
                         if truncatedLen {
-                            calldatacopy(dstOffset, sourceOffset, truncatedLen)
+                            $llvm_AlwaysInline_llvm$_calldatacopy(dstOffset, sourceOffset, truncatedLen)
                         }
                 
                         ip := add(ip, 1)
@@ -6283,6 +6287,21 @@ object "EvmEmulator" {
                     }
                 }
                 
+
+                function $llvm_AlwaysInline_llvm$_calldatasize() -> size {
+                    size := calldatasize()
+                }
+                
+                function $llvm_AlwaysInline_llvm$_calldatacopy(dstOffset, sourceOffset, truncatedLen) {
+                    calldatacopy(dstOffset, sourceOffset, truncatedLen)
+                }
+                
+                function $llvm_AlwaysInline_llvm$_calldataload(calldataOffset) -> res {
+                    // EraVM will revert if offset + length overflows uint32
+                    if lt(calldataOffset, UINT32_MAX()) {
+                        res := calldataload(calldataOffset)
+                    }
+                }
 
                 if eq(isCallerEVM, 1) {
                     // Includes gas

--- a/system-contracts/evm-emulator/EvmEmulator.template.yul
+++ b/system-contracts/evm-emulator/EvmEmulator.template.yul
@@ -60,6 +60,8 @@ object "EvmEmulator" {
 
         <!-- @include EvmEmulatorFunctions.template.yul -->
 
+        <!-- @include calldata-opcodes/ConstructorScope.template.yul -->
+
         function simulate(
             isCallerEVM,
             evmGasLeft,
@@ -133,6 +135,8 @@ object "EvmEmulator" {
                 returnLen := 0
 
                 <!-- @include EvmEmulatorLoop.template.yul -->
+
+                <!-- @include calldata-opcodes/RuntimeScope.template.yul -->
 
                 if eq(isCallerEVM, 1) {
                     // Includes gas

--- a/system-contracts/evm-emulator/EvmEmulatorLoop.template.yul
+++ b/system-contracts/evm-emulator/EvmEmulatorLoop.template.yul
@@ -347,18 +347,14 @@ for { } true { } {
 
         let calldataOffset := accessStackHead(sp, stackHead)
 
-        stackHead := 0
-        // EraVM will revert if offset + length overflows uint32
-        if lt(calldataOffset, UINT32_MAX()) {
-            stackHead := calldataload(calldataOffset)
-        }
+        stackHead := $llvm_AlwaysInline_llvm$_calldataload(calldataOffset)
 
         ip := add(ip, 1)
     }
     case 0x36 { // OP_CALLDATASIZE
         evmGasLeft := chargeGas(evmGasLeft, 2)
 
-        sp, stackHead := pushStackItem(sp, calldatasize(), stackHead)
+        sp, stackHead := pushStackItem(sp, $llvm_AlwaysInline_llvm$_calldatasize(), stackHead)
         ip := add(ip, 1)
     }
     case 0x37 { // OP_CALLDATACOPY
@@ -393,7 +389,7 @@ for { } true { } {
         }
 
         if truncatedLen {
-            calldatacopy(dstOffset, sourceOffset, truncatedLen)
+            $llvm_AlwaysInline_llvm$_calldatacopy(dstOffset, sourceOffset, truncatedLen)
         }
 
         ip := add(ip, 1)

--- a/system-contracts/evm-emulator/calldata-opcodes/ConstructorScope.template.yul
+++ b/system-contracts/evm-emulator/calldata-opcodes/ConstructorScope.template.yul
@@ -1,0 +1,11 @@
+function $llvm_AlwaysInline_llvm$_calldatasize() -> size {
+    size := 0
+}
+
+function $llvm_AlwaysInline_llvm$_calldatacopy(dstOffset, sourceOffset, truncatedLen) {
+    $llvm_AlwaysInline_llvm$_memsetToZero(dstOffset, truncatedLen)
+}
+
+function $llvm_AlwaysInline_llvm$_calldataload(calldataOffset) -> res {
+    res := 0
+}

--- a/system-contracts/evm-emulator/calldata-opcodes/RuntimeScope.template.yul
+++ b/system-contracts/evm-emulator/calldata-opcodes/RuntimeScope.template.yul
@@ -1,0 +1,14 @@
+function $llvm_AlwaysInline_llvm$_calldatasize() -> size {
+    size := calldatasize()
+}
+
+function $llvm_AlwaysInline_llvm$_calldatacopy(dstOffset, sourceOffset, truncatedLen) {
+    calldatacopy(dstOffset, sourceOffset, truncatedLen)
+}
+
+function $llvm_AlwaysInline_llvm$_calldataload(calldataOffset) -> res {
+    // EraVM will revert if offset + length overflows uint32
+    if lt(calldataOffset, UINT32_MAX()) {
+        res := calldataload(calldataOffset)
+    }
+}


### PR DESCRIPTION
# What ❔

Calldata should be empty in constructor.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
