### PR TITLE
fix(EVM): Change caching fixed context values

### DIFF
--- a/system-contracts/contracts/EvmEmulator.yul
+++ b/system-contracts/contracts/EvmEmulator.yul
@@ -86,44 +86,8 @@ object "EvmEmulator" {
             addr :=  0x0000000000000000000000000000000000008009
         }
         
-        function ORIGIN_CACHE_OFFSET() -> offset {
-            offset := mul(23, 32)
-        }
-        
-        function GASPRICE_CACHE_OFFSET() -> offset {
-            offset := mul(24, 32)
-        }
-        
-        function COINBASE_CACHE_OFFSET() -> offset {
-            offset := mul(25, 32)
-        }
-        
-        function BLOCKTIMESTAMP_CACHE_OFFSET() -> offset {
-            offset := mul(26, 32)
-        }
-        
-        function BLOCKNUMBER_CACHE_OFFSET() -> offset {
-            offset := mul(27, 32)
-        }
-        
-        function PREVRANDAO_CACHE_OFFSET() -> offset {
-            offset := mul(28, 32)
-        }
-        
-        function GASLIMIT_CACHE_OFFSET() -> offset {
-            offset := mul(29, 32)
-        }
-        
-        function CHAINID_CACHE_OFFSET() -> offset {
-            offset := mul(30, 32)
-        }
-        
-        function BASEFEE_CACHE_OFFSET() -> offset {
-            offset := mul(31, 32)
-        }
-        
         function LAST_RETURNDATA_SIZE_OFFSET() -> offset {
-            offset := add(BASEFEE_CACHE_OFFSET(), 32)
+            offset := mul(32, 32)
         }
         
         function STACK_OFFSET() -> offset {
@@ -216,11 +180,6 @@ object "EvmEmulator" {
         function panic() { // revert consuming all EVM gas
             mstore(0, 0)
             revert(0, 32)
-        }
-        
-        function cached(cacheIndex, value) -> _value {
-            _value := value
-            mstore(cacheIndex, _value)
         }
         
         function chargeGas(prevGas, toCharge) -> gasRemaining {
@@ -1337,7 +1296,17 @@ object "EvmEmulator" {
             let ip := BYTECODE_OFFSET()
             let stackHead
             
-            let bytecodeEndOffset := add(BYTECODE_OFFSET(), mload(BYTECODE_LEN_OFFSET()))
+            let bytecodeLen := mload(BYTECODE_LEN_OFFSET())
+            let bytecodeEndOffset := add(BYTECODE_OFFSET(), bytecodeLen)
+            let originVal := 0
+            let gaspriceVal := 0
+            let coinbaseVal := 0
+            let timestampVal := 0
+            let numberVal := 0
+            let prevrandaoVal := 0
+            let gaslimitVal := 0
+            let chainidVal := 0
+            let basefeeVal := 0
             
             for { } true { } {
                 let opcode := readIP(ip, bytecodeEndOffset)
@@ -1655,11 +1624,10 @@ object "EvmEmulator" {
                 }
                 case 0x32 { // OP_ORIGIN
                     evmGasLeft := chargeGas(evmGasLeft, 2)
-                    let _origin := mload(ORIGIN_CACHE_OFFSET())
-                    if iszero(_origin) {
-                        _origin := cached(ORIGIN_CACHE_OFFSET(), origin())
+                    if iszero(originVal) {
+                        originVal := origin()
                     }
-                    sp, stackHead := pushStackItem(sp, _origin, stackHead)
+                    sp, stackHead := pushStackItem(sp, originVal, stackHead)
                     ip := add(ip, 1)
                 }
                 case 0x33 { // OP_CALLER
@@ -1730,7 +1698,6 @@ object "EvmEmulator" {
                 case 0x38 { // OP_CODESIZE
                     evmGasLeft := chargeGas(evmGasLeft, 2)
             
-                    let bytecodeLen := mload(BYTECODE_LEN_OFFSET())
                     sp, stackHead := pushStackItem(sp, bytecodeLen, stackHead)
                     ip := add(ip, 1)
                 }
@@ -1778,11 +1745,10 @@ object "EvmEmulator" {
                 }
                 case 0x3A { // OP_GASPRICE
                     evmGasLeft := chargeGas(evmGasLeft, 2)
-                    let _gasprice := mload(GASPRICE_CACHE_OFFSET())
-                    if iszero(_gasprice) {
-                        _gasprice := cached(GASPRICE_CACHE_OFFSET(), gasprice())
+                    if iszero(gaspriceVal) {
+                        gaspriceVal := gasprice()
                     }
-                    sp, stackHead := pushStackItem(sp, _gasprice, stackHead)
+                    sp, stackHead := pushStackItem(sp, gaspriceVal, stackHead)
                     ip := add(ip, 1)
                 }
                 case 0x3B { // OP_EXTCODESIZE
@@ -1939,56 +1905,50 @@ object "EvmEmulator" {
                 }
                 case 0x41 { // OP_COINBASE
                     evmGasLeft := chargeGas(evmGasLeft, 2)
-                    let _coinbase := mload(COINBASE_CACHE_OFFSET())
-                    if iszero(_coinbase) {
-                        _coinbase := cached(COINBASE_CACHE_OFFSET(), coinbase())
+                    if iszero(coinbaseVal) {
+                        coinbaseVal := coinbase()
                     }
-                    sp, stackHead := pushStackItem(sp, _coinbase, stackHead)
+                    sp, stackHead := pushStackItem(sp, coinbaseVal, stackHead)
                     ip := add(ip, 1)
                 }
                 case 0x42 { // OP_TIMESTAMP
                     evmGasLeft := chargeGas(evmGasLeft, 2)
-                    let _blocktimestamp := mload(BLOCKTIMESTAMP_CACHE_OFFSET())
-                    if iszero(_blocktimestamp) {
-                        _blocktimestamp := cached(BLOCKTIMESTAMP_CACHE_OFFSET(), timestamp())
+                    if iszero(timestampVal) {
+                        timestampVal := timestamp()
                     }
-                    sp, stackHead := pushStackItem(sp, _blocktimestamp, stackHead)
+                    sp, stackHead := pushStackItem(sp, timestampVal, stackHead)
                     ip := add(ip, 1)
                 }
                 case 0x43 { // OP_NUMBER
                     evmGasLeft := chargeGas(evmGasLeft, 2)
-                    let _blocknumber := mload(BLOCKNUMBER_CACHE_OFFSET())
-                    if iszero(_blocknumber) {
-                        _blocknumber := cached(BLOCKNUMBER_CACHE_OFFSET(), number())
+                    if iszero(numberVal) {
+                        numberVal := number()
                     }
-                    sp, stackHead := pushStackItem(sp, _blocknumber, stackHead)
+                    sp, stackHead := pushStackItem(sp, numberVal, stackHead)
                     ip := add(ip, 1)
                 }
                 case 0x44 { // OP_PREVRANDAO
                     evmGasLeft := chargeGas(evmGasLeft, 2)
-                    let _prevrandao := mload(PREVRANDAO_CACHE_OFFSET())
-                    if iszero(_prevrandao) {
-                        _prevrandao := cached(PREVRANDAO_CACHE_OFFSET(), prevrandao())
+                    if iszero(prevrandaoVal) {
+                        prevrandaoVal := prevrandao()
                     }
-                    sp, stackHead := pushStackItem(sp, _prevrandao, stackHead)
+                    sp, stackHead := pushStackItem(sp, prevrandaoVal, stackHead)
                     ip := add(ip, 1)
                 }
                 case 0x45 { // OP_GASLIMIT
                     evmGasLeft := chargeGas(evmGasLeft, 2)
-                    let _gasLimit := mload(GASLIMIT_CACHE_OFFSET())
-                    if iszero(_gasLimit) {
-                        _gasLimit := cached(GASLIMIT_CACHE_OFFSET(), gaslimit())
+                    if iszero(gaslimitVal) {
+                        gaslimitVal := gaslimit()
                     }
-                    sp, stackHead := pushStackItem(sp, _gasLimit, stackHead)
+                    sp, stackHead := pushStackItem(sp, gaslimitVal, stackHead)
                     ip := add(ip, 1)
                 }
                 case 0x46 { // OP_CHAINID
                     evmGasLeft := chargeGas(evmGasLeft, 2)
-                    let _chainId := mload(CHAINID_CACHE_OFFSET())
-                    if iszero(_chainId) {
-                        _chainId := cached(CHAINID_CACHE_OFFSET(), chainid())
+                    if iszero(chainidVal) {
+                        chainidVal := chainid()
                     }
-                    sp, stackHead := pushStackItem(sp, _chainId, stackHead)
+                    sp, stackHead := pushStackItem(sp, chainidVal, stackHead)
                     ip := add(ip, 1)
                 }
                 case 0x47 { // OP_SELFBALANCE
@@ -1998,11 +1958,10 @@ object "EvmEmulator" {
                 }
                 case 0x48 { // OP_BASEFEE
                     evmGasLeft := chargeGas(evmGasLeft, 2)
-                    let _baseFee := mload(BASEFEE_CACHE_OFFSET())
-                    if iszero(_baseFee) {
-                        _baseFee := cached(BASEFEE_CACHE_OFFSET(), basefee())
+                    if iszero(basefeeVal) {
+                        basefeeVal := basefee()
                     }
-                    sp, stackHead := pushStackItem(sp, _baseFee, stackHead)
+                    sp, stackHead := pushStackItem(sp, basefeeVal, stackHead)
                     ip := add(ip, 1)
                 }
                 case 0x50 { // OP_POP
@@ -3232,44 +3191,8 @@ object "EvmEmulator" {
                 addr :=  0x0000000000000000000000000000000000008009
             }
             
-            function ORIGIN_CACHE_OFFSET() -> offset {
-                offset := mul(23, 32)
-            }
-            
-            function GASPRICE_CACHE_OFFSET() -> offset {
-                offset := mul(24, 32)
-            }
-            
-            function COINBASE_CACHE_OFFSET() -> offset {
-                offset := mul(25, 32)
-            }
-            
-            function BLOCKTIMESTAMP_CACHE_OFFSET() -> offset {
-                offset := mul(26, 32)
-            }
-            
-            function BLOCKNUMBER_CACHE_OFFSET() -> offset {
-                offset := mul(27, 32)
-            }
-            
-            function PREVRANDAO_CACHE_OFFSET() -> offset {
-                offset := mul(28, 32)
-            }
-            
-            function GASLIMIT_CACHE_OFFSET() -> offset {
-                offset := mul(29, 32)
-            }
-            
-            function CHAINID_CACHE_OFFSET() -> offset {
-                offset := mul(30, 32)
-            }
-            
-            function BASEFEE_CACHE_OFFSET() -> offset {
-                offset := mul(31, 32)
-            }
-            
             function LAST_RETURNDATA_SIZE_OFFSET() -> offset {
-                offset := add(BASEFEE_CACHE_OFFSET(), 32)
+                offset := mul(32, 32)
             }
             
             function STACK_OFFSET() -> offset {
@@ -3362,11 +3285,6 @@ object "EvmEmulator" {
             function panic() { // revert consuming all EVM gas
                 mstore(0, 0)
                 revert(0, 32)
-            }
-            
-            function cached(cacheIndex, value) -> _value {
-                _value := value
-                mstore(cacheIndex, _value)
             }
             
             function chargeGas(prevGas, toCharge) -> gasRemaining {
@@ -4471,7 +4389,17 @@ object "EvmEmulator" {
                 let ip := BYTECODE_OFFSET()
                 let stackHead
                 
-                let bytecodeEndOffset := add(BYTECODE_OFFSET(), mload(BYTECODE_LEN_OFFSET()))
+                let bytecodeLen := mload(BYTECODE_LEN_OFFSET())
+                let bytecodeEndOffset := add(BYTECODE_OFFSET(), bytecodeLen)
+                let originVal := 0
+                let gaspriceVal := 0
+                let coinbaseVal := 0
+                let timestampVal := 0
+                let numberVal := 0
+                let prevrandaoVal := 0
+                let gaslimitVal := 0
+                let chainidVal := 0
+                let basefeeVal := 0
                 
                 for { } true { } {
                     let opcode := readIP(ip, bytecodeEndOffset)
@@ -4789,11 +4717,10 @@ object "EvmEmulator" {
                     }
                     case 0x32 { // OP_ORIGIN
                         evmGasLeft := chargeGas(evmGasLeft, 2)
-                        let _origin := mload(ORIGIN_CACHE_OFFSET())
-                        if iszero(_origin) {
-                            _origin := cached(ORIGIN_CACHE_OFFSET(), origin())
+                        if iszero(originVal) {
+                            originVal := origin()
                         }
-                        sp, stackHead := pushStackItem(sp, _origin, stackHead)
+                        sp, stackHead := pushStackItem(sp, originVal, stackHead)
                         ip := add(ip, 1)
                     }
                     case 0x33 { // OP_CALLER
@@ -4864,7 +4791,6 @@ object "EvmEmulator" {
                     case 0x38 { // OP_CODESIZE
                         evmGasLeft := chargeGas(evmGasLeft, 2)
                 
-                        let bytecodeLen := mload(BYTECODE_LEN_OFFSET())
                         sp, stackHead := pushStackItem(sp, bytecodeLen, stackHead)
                         ip := add(ip, 1)
                     }
@@ -4912,11 +4838,10 @@ object "EvmEmulator" {
                     }
                     case 0x3A { // OP_GASPRICE
                         evmGasLeft := chargeGas(evmGasLeft, 2)
-                        let _gasprice := mload(GASPRICE_CACHE_OFFSET())
-                        if iszero(_gasprice) {
-                            _gasprice := cached(GASPRICE_CACHE_OFFSET(), gasprice())
+                        if iszero(gaspriceVal) {
+                            gaspriceVal := gasprice()
                         }
-                        sp, stackHead := pushStackItem(sp, _gasprice, stackHead)
+                        sp, stackHead := pushStackItem(sp, gaspriceVal, stackHead)
                         ip := add(ip, 1)
                     }
                     case 0x3B { // OP_EXTCODESIZE
@@ -5073,56 +4998,50 @@ object "EvmEmulator" {
                     }
                     case 0x41 { // OP_COINBASE
                         evmGasLeft := chargeGas(evmGasLeft, 2)
-                        let _coinbase := mload(COINBASE_CACHE_OFFSET())
-                        if iszero(_coinbase) {
-                            _coinbase := cached(COINBASE_CACHE_OFFSET(), coinbase())
+                        if iszero(coinbaseVal) {
+                            coinbaseVal := coinbase()
                         }
-                        sp, stackHead := pushStackItem(sp, _coinbase, stackHead)
+                        sp, stackHead := pushStackItem(sp, coinbaseVal, stackHead)
                         ip := add(ip, 1)
                     }
                     case 0x42 { // OP_TIMESTAMP
                         evmGasLeft := chargeGas(evmGasLeft, 2)
-                        let _blocktimestamp := mload(BLOCKTIMESTAMP_CACHE_OFFSET())
-                        if iszero(_blocktimestamp) {
-                            _blocktimestamp := cached(BLOCKTIMESTAMP_CACHE_OFFSET(), timestamp())
+                        if iszero(timestampVal) {
+                            timestampVal := timestamp()
                         }
-                        sp, stackHead := pushStackItem(sp, _blocktimestamp, stackHead)
+                        sp, stackHead := pushStackItem(sp, timestampVal, stackHead)
                         ip := add(ip, 1)
                     }
                     case 0x43 { // OP_NUMBER
                         evmGasLeft := chargeGas(evmGasLeft, 2)
-                        let _blocknumber := mload(BLOCKNUMBER_CACHE_OFFSET())
-                        if iszero(_blocknumber) {
-                            _blocknumber := cached(BLOCKNUMBER_CACHE_OFFSET(), number())
+                        if iszero(numberVal) {
+                            numberVal := number()
                         }
-                        sp, stackHead := pushStackItem(sp, _blocknumber, stackHead)
+                        sp, stackHead := pushStackItem(sp, numberVal, stackHead)
                         ip := add(ip, 1)
                     }
                     case 0x44 { // OP_PREVRANDAO
                         evmGasLeft := chargeGas(evmGasLeft, 2)
-                        let _prevrandao := mload(PREVRANDAO_CACHE_OFFSET())
-                        if iszero(_prevrandao) {
-                            _prevrandao := cached(PREVRANDAO_CACHE_OFFSET(), prevrandao())
+                        if iszero(prevrandaoVal) {
+                            prevrandaoVal := prevrandao()
                         }
-                        sp, stackHead := pushStackItem(sp, _prevrandao, stackHead)
+                        sp, stackHead := pushStackItem(sp, prevrandaoVal, stackHead)
                         ip := add(ip, 1)
                     }
                     case 0x45 { // OP_GASLIMIT
                         evmGasLeft := chargeGas(evmGasLeft, 2)
-                        let _gasLimit := mload(GASLIMIT_CACHE_OFFSET())
-                        if iszero(_gasLimit) {
-                            _gasLimit := cached(GASLIMIT_CACHE_OFFSET(), gaslimit())
+                        if iszero(gaslimitVal) {
+                            gaslimitVal := gaslimit()
                         }
-                        sp, stackHead := pushStackItem(sp, _gasLimit, stackHead)
+                        sp, stackHead := pushStackItem(sp, gaslimitVal, stackHead)
                         ip := add(ip, 1)
                     }
                     case 0x46 { // OP_CHAINID
                         evmGasLeft := chargeGas(evmGasLeft, 2)
-                        let _chainId := mload(CHAINID_CACHE_OFFSET())
-                        if iszero(_chainId) {
-                            _chainId := cached(CHAINID_CACHE_OFFSET(), chainid())
+                        if iszero(chainidVal) {
+                            chainidVal := chainid()
                         }
-                        sp, stackHead := pushStackItem(sp, _chainId, stackHead)
+                        sp, stackHead := pushStackItem(sp, chainidVal, stackHead)
                         ip := add(ip, 1)
                     }
                     case 0x47 { // OP_SELFBALANCE
@@ -5132,11 +5051,10 @@ object "EvmEmulator" {
                     }
                     case 0x48 { // OP_BASEFEE
                         evmGasLeft := chargeGas(evmGasLeft, 2)
-                        let _baseFee := mload(BASEFEE_CACHE_OFFSET())
-                        if iszero(_baseFee) {
-                            _baseFee := cached(BASEFEE_CACHE_OFFSET(), basefee())
+                        if iszero(basefeeVal) {
+                            basefeeVal := basefee()
                         }
-                        sp, stackHead := pushStackItem(sp, _baseFee, stackHead)
+                        sp, stackHead := pushStackItem(sp, basefeeVal, stackHead)
                         ip := add(ip, 1)
                     }
                     case 0x50 { // OP_POP

--- a/system-contracts/evm-emulator/EvmEmulatorFunctions.template.yul
+++ b/system-contracts/evm-emulator/EvmEmulatorFunctions.template.yul
@@ -26,44 +26,8 @@ function MSG_VALUE_SYSTEM_CONTRACT() -> addr {
     addr :=  0x0000000000000000000000000000000000008009
 }
 
-function ORIGIN_CACHE_OFFSET() -> offset {
-    offset := mul(23, 32)
-}
-
-function GASPRICE_CACHE_OFFSET() -> offset {
-    offset := mul(24, 32)
-}
-
-function COINBASE_CACHE_OFFSET() -> offset {
-    offset := mul(25, 32)
-}
-
-function BLOCKTIMESTAMP_CACHE_OFFSET() -> offset {
-    offset := mul(26, 32)
-}
-
-function BLOCKNUMBER_CACHE_OFFSET() -> offset {
-    offset := mul(27, 32)
-}
-
-function PREVRANDAO_CACHE_OFFSET() -> offset {
-    offset := mul(28, 32)
-}
-
-function GASLIMIT_CACHE_OFFSET() -> offset {
-    offset := mul(29, 32)
-}
-
-function CHAINID_CACHE_OFFSET() -> offset {
-    offset := mul(30, 32)
-}
-
-function BASEFEE_CACHE_OFFSET() -> offset {
-    offset := mul(31, 32)
-}
-
 function LAST_RETURNDATA_SIZE_OFFSET() -> offset {
-    offset := add(BASEFEE_CACHE_OFFSET(), 32)
+    offset := mul(32, 32)
 }
 
 function STACK_OFFSET() -> offset {
@@ -156,11 +120,6 @@ function revertWithGas(evmGasLeft) {
 function panic() { // revert consuming all EVM gas
     mstore(0, 0)
     revert(0, 32)
-}
-
-function cached(cacheIndex, value) -> _value {
-    _value := value
-    mstore(cacheIndex, _value)
 }
 
 function chargeGas(prevGas, toCharge) -> gasRemaining {

--- a/system-contracts/evm-emulator/EvmEmulatorLoop.template.yul
+++ b/system-contracts/evm-emulator/EvmEmulatorLoop.template.yul
@@ -5,7 +5,17 @@ let sp := sub(STACK_OFFSET(), 32)
 let ip := BYTECODE_OFFSET()
 let stackHead
 
-let bytecodeEndOffset := add(BYTECODE_OFFSET(), mload(BYTECODE_LEN_OFFSET()))
+let bytecodeLen := mload(BYTECODE_LEN_OFFSET())
+let bytecodeEndOffset := add(BYTECODE_OFFSET(), bytecodeLen)
+let originVal := 0
+let gaspriceVal := 0
+let coinbaseVal := 0
+let timestampVal := 0
+let numberVal := 0
+let prevrandaoVal := 0
+let gaslimitVal := 0
+let chainidVal := 0
+let basefeeVal := 0
 
 for { } true { } {
     let opcode := readIP(ip, bytecodeEndOffset)
@@ -323,11 +333,10 @@ for { } true { } {
     }
     case 0x32 { // OP_ORIGIN
         evmGasLeft := chargeGas(evmGasLeft, 2)
-        let _origin := mload(ORIGIN_CACHE_OFFSET())
-        if iszero(_origin) {
-            _origin := cached(ORIGIN_CACHE_OFFSET(), origin())
+        if iszero(originVal) {
+            originVal := origin()
         }
-        sp, stackHead := pushStackItem(sp, _origin, stackHead)
+        sp, stackHead := pushStackItem(sp, originVal, stackHead)
         ip := add(ip, 1)
     }
     case 0x33 { // OP_CALLER
@@ -398,7 +407,6 @@ for { } true { } {
     case 0x38 { // OP_CODESIZE
         evmGasLeft := chargeGas(evmGasLeft, 2)
 
-        let bytecodeLen := mload(BYTECODE_LEN_OFFSET())
         sp, stackHead := pushStackItem(sp, bytecodeLen, stackHead)
         ip := add(ip, 1)
     }
@@ -446,11 +454,10 @@ for { } true { } {
     }
     case 0x3A { // OP_GASPRICE
         evmGasLeft := chargeGas(evmGasLeft, 2)
-        let _gasprice := mload(GASPRICE_CACHE_OFFSET())
-        if iszero(_gasprice) {
-            _gasprice := cached(GASPRICE_CACHE_OFFSET(), gasprice())
+        if iszero(gaspriceVal) {
+            gaspriceVal := gasprice()
         }
-        sp, stackHead := pushStackItem(sp, _gasprice, stackHead)
+        sp, stackHead := pushStackItem(sp, gaspriceVal, stackHead)
         ip := add(ip, 1)
     }
     case 0x3B { // OP_EXTCODESIZE
@@ -607,56 +614,50 @@ for { } true { } {
     }
     case 0x41 { // OP_COINBASE
         evmGasLeft := chargeGas(evmGasLeft, 2)
-        let _coinbase := mload(COINBASE_CACHE_OFFSET())
-        if iszero(_coinbase) {
-            _coinbase := cached(COINBASE_CACHE_OFFSET(), coinbase())
+        if iszero(coinbaseVal) {
+            coinbaseVal := coinbase()
         }
-        sp, stackHead := pushStackItem(sp, _coinbase, stackHead)
+        sp, stackHead := pushStackItem(sp, coinbaseVal, stackHead)
         ip := add(ip, 1)
     }
     case 0x42 { // OP_TIMESTAMP
         evmGasLeft := chargeGas(evmGasLeft, 2)
-        let _blocktimestamp := mload(BLOCKTIMESTAMP_CACHE_OFFSET())
-        if iszero(_blocktimestamp) {
-            _blocktimestamp := cached(BLOCKTIMESTAMP_CACHE_OFFSET(), timestamp())
+        if iszero(timestampVal) {
+            timestampVal := timestamp()
         }
-        sp, stackHead := pushStackItem(sp, _blocktimestamp, stackHead)
+        sp, stackHead := pushStackItem(sp, timestampVal, stackHead)
         ip := add(ip, 1)
     }
     case 0x43 { // OP_NUMBER
         evmGasLeft := chargeGas(evmGasLeft, 2)
-        let _blocknumber := mload(BLOCKNUMBER_CACHE_OFFSET())
-        if iszero(_blocknumber) {
-            _blocknumber := cached(BLOCKNUMBER_CACHE_OFFSET(), number())
+        if iszero(numberVal) {
+            numberVal := number()
         }
-        sp, stackHead := pushStackItem(sp, _blocknumber, stackHead)
+        sp, stackHead := pushStackItem(sp, numberVal, stackHead)
         ip := add(ip, 1)
     }
     case 0x44 { // OP_PREVRANDAO
         evmGasLeft := chargeGas(evmGasLeft, 2)
-        let _prevrandao := mload(PREVRANDAO_CACHE_OFFSET())
-        if iszero(_prevrandao) {
-            _prevrandao := cached(PREVRANDAO_CACHE_OFFSET(), prevrandao())
+        if iszero(prevrandaoVal) {
+            prevrandaoVal := prevrandao()
         }
-        sp, stackHead := pushStackItem(sp, _prevrandao, stackHead)
+        sp, stackHead := pushStackItem(sp, prevrandaoVal, stackHead)
         ip := add(ip, 1)
     }
     case 0x45 { // OP_GASLIMIT
         evmGasLeft := chargeGas(evmGasLeft, 2)
-        let _gasLimit := mload(GASLIMIT_CACHE_OFFSET())
-        if iszero(_gasLimit) {
-            _gasLimit := cached(GASLIMIT_CACHE_OFFSET(), gaslimit())
+        if iszero(gaslimitVal) {
+            gaslimitVal := gaslimit()
         }
-        sp, stackHead := pushStackItem(sp, _gasLimit, stackHead)
+        sp, stackHead := pushStackItem(sp, gaslimitVal, stackHead)
         ip := add(ip, 1)
     }
     case 0x46 { // OP_CHAINID
         evmGasLeft := chargeGas(evmGasLeft, 2)
-        let _chainId := mload(CHAINID_CACHE_OFFSET())
-        if iszero(_chainId) {
-            _chainId := cached(CHAINID_CACHE_OFFSET(), chainid())
+        if iszero(chainidVal) {
+            chainidVal := chainid()
         }
-        sp, stackHead := pushStackItem(sp, _chainId, stackHead)
+        sp, stackHead := pushStackItem(sp, chainidVal, stackHead)
         ip := add(ip, 1)
     }
     case 0x47 { // OP_SELFBALANCE
@@ -666,11 +667,10 @@ for { } true { } {
     }
     case 0x48 { // OP_BASEFEE
         evmGasLeft := chargeGas(evmGasLeft, 2)
-        let _baseFee := mload(BASEFEE_CACHE_OFFSET())
-        if iszero(_baseFee) {
-            _baseFee := cached(BASEFEE_CACHE_OFFSET(), basefee())
+        if iszero(basefeeVal) {
+            basefeeVal := basefee()
         }
-        sp, stackHead := pushStackItem(sp, _baseFee, stackHead)
+        sp, stackHead := pushStackItem(sp, basefeeVal, stackHead)
         ip := add(ip, 1)
     }
     case 0x50 { // OP_POP


### PR DESCRIPTION
# What ❔
Instead of caching these values in memory, cache them in local variables that are defined before the main loop.
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔
By doing this, one load will be removed and store will be changed to add that spills variable onto the stack:
```
before:
	ldm.h	768, r1
	sub!	r1, r0, r0
...
	stm.h	768, r1

after:
	sub!	stack-[12], r0, r0
...
	add	r1, r0, stack-[12]              ; 32-byte Folded Spill
```
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
