### PR TITLE
fix(EVM): Check bytecodehash version in create functions of ContractDeployer

### DIFF
--- a/system-contracts/contracts/ContractDeployer.sol
+++ b/system-contracts/contracts/ContractDeployer.sol
@@ -10,7 +10,7 @@ import {Utils} from "./libraries/Utils.sol";
 import {EfficientCall} from "./libraries/EfficientCall.sol";
 import {SystemContractHelper} from "./libraries/SystemContractHelper.sol";
 import {SystemContractBase} from "./abstract/SystemContractBase.sol";
-import {Unauthorized, InvalidNonceOrderingChange, ValueMismatch, EmptyBytes32, EVMEmulationNotSupported, NotAllowedToDeployInKernelSpace, HashIsNonZero, NonEmptyAccount, UnknownCodeHash, NonEmptyMsgValue} from "./SystemContractErrors.sol";
+import {Unauthorized, InvalidNonceOrderingChange, ValueMismatch, EmptyBytes32, EVMBytecodeHash, EVMEmulationNotSupported, NotAllowedToDeployInKernelSpace, HashIsNonZero, NonEmptyAccount, UnknownCodeHash, NonEmptyMsgValue} from "./SystemContractErrors.sol";
 
 /**
  * @author Matter Labs
@@ -397,6 +397,9 @@ contract ContractDeployer is IContractDeployer, SystemContractBase {
     ) internal {
         if (_bytecodeHash == bytes32(0x0)) {
             revert EmptyBytes32();
+        }
+        if (Utils.isCodeHashEVM(_bytecodeHash)) {
+            revert EVMBytecodeHash();
         }
         if (uint160(_newAddress) <= MAX_SYSTEM_CONTRACT_ADDRESS) {
             revert NotAllowedToDeployInKernelSpace();

--- a/system-contracts/contracts/SystemContractErrors.sol
+++ b/system-contracts/contracts/SystemContractErrors.sol
@@ -34,6 +34,8 @@ error EmptyVirtualBlocks();
 error EncodedAndRealBytecodeChunkNotEqual(uint64 expected, uint64 provided);
 // 0x2bfbfc11
 error EncodedLengthNotFourTimesSmallerThanOriginal();
+// 0x39bae0e6
+error EVMBytecodeHash();
 // 0xb9e6e31f
 error EVMEmulationNotSupported();
 // 0xe95a1fbe


### PR DESCRIPTION
We should not allow to use EVM versioned bytecode hash in  `Create`/`Create2` functions of ContractDeployer

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
