### PR TITLE
[DO NOT MERGE]: EVM emulator optimization read bytecode by pointer

### DIFF
--- a/system-contracts/contracts/EvmEmulator.yul
+++ b/system-contracts/contracts/EvmEmulator.yul
@@ -317,7 +317,6 @@ object "EvmEmulator" {
             swapActivePointerWithBytecodePointer()
             opcode := shr(248, activePointerLoad(ip))
             swapActivePointerWithBytecodePointer()
-            // STOP else
         }
         
         // It is the responsibility of the caller to ensure that start and length is correct
@@ -343,7 +342,7 @@ object "EvmEmulator" {
         }
         
         function swapActivePointerWithBytecodePointer() {
-            verbatim_2i_0o("active_ptr_swap", 0, 4)
+            verbatim_2i_0o("active_ptr_swap", 0, 2)
         }
         
         function activePointerLoad(pos) -> res {
@@ -2124,7 +2123,7 @@ object "EvmEmulator" {
                     let counter
                     counter, sp, stackHead := popStackItem(sp, stackHead)
             
-                    // Counter certainly can't be bigger than uint64.
+                    // Counter certainly can't be bigger than uint32.
                     if gt(counter, MAX_UINT32()) {
                         panic()
                     } 
@@ -2154,7 +2153,7 @@ object "EvmEmulator" {
                         continue
                     }
             
-                    // Counter certainly can't be bigger than uint64.
+                    // Counter certainly can't be bigger than uint32.
                     if gt(counter, MAX_UINT32()) {
                         panic()
                     } 
@@ -3252,7 +3251,6 @@ object "EvmEmulator" {
                 swapActivePointerWithBytecodePointer()
                 opcode := shr(248, activePointerLoad(ip))
                 swapActivePointerWithBytecodePointer()
-                // STOP else
             }
             
             // It is the responsibility of the caller to ensure that start and length is correct
@@ -3278,7 +3276,7 @@ object "EvmEmulator" {
             }
             
             function swapActivePointerWithBytecodePointer() {
-                verbatim_2i_0o("active_ptr_swap", 0, 4)
+                verbatim_2i_0o("active_ptr_swap", 0, 2)
             }
             
             function activePointerLoad(pos) -> res {
@@ -5047,7 +5045,7 @@ object "EvmEmulator" {
                         let counter
                         counter, sp, stackHead := popStackItem(sp, stackHead)
                 
-                        // Counter certainly can't be bigger than uint64.
+                        // Counter certainly can't be bigger than uint32.
                         if gt(counter, MAX_UINT32()) {
                             panic()
                         } 
@@ -5077,7 +5075,7 @@ object "EvmEmulator" {
                             continue
                         }
                 
-                        // Counter certainly can't be bigger than uint64.
+                        // Counter certainly can't be bigger than uint32.
                         if gt(counter, MAX_UINT32()) {
                             panic()
                         } 

--- a/system-contracts/contracts/EvmEmulator.yul
+++ b/system-contracts/contracts/EvmEmulator.yul
@@ -179,7 +179,7 @@ object "EvmEmulator" {
         
         function MAX_UINT32() -> ret { ret := 4294967295 } // 2^32 - 1
         
-        function MAX_CALLDATA_OFFSET() -> ret { ret := sub(MAX_UINT32(), 32) } // EraVM will panic if offset + length overflows u32
+        function MAX_POINTER_READ_OFFSET() -> ret { ret := sub(MAX_UINT32(), 32) } // EraVM will panic if offset + length overflows u32
         
         function EMPTY_KECCAK() -> value {  // keccak("")
             value := 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
@@ -1725,14 +1725,14 @@ object "EvmEmulator" {
                     dstOffset := add(dstOffset, MEM_OFFSET())
             
                     // EraVM will revert if offset + length overflows uint32
-                    if gt(sourceOffset, MAX_CALLDATA_OFFSET()) {
-                        sourceOffset := MAX_CALLDATA_OFFSET()
+                    if gt(sourceOffset, MAX_POINTER_READ_OFFSET()) {
+                        sourceOffset := MAX_POINTER_READ_OFFSET()
                     }
             
                     // Check bytecode out-of-bounds access
                     let truncatedLen := len
-                    if gt(add(sourceOffset, len), MAX_CALLDATA_OFFSET()) { // in theory we could also copy MAX_CALLDATA_OFFSET slot, but it is unreachable
-                        truncatedLen := sub(MAX_CALLDATA_OFFSET(), sourceOffset) // truncate
+                    if gt(add(sourceOffset, len), MAX_POINTER_READ_OFFSET()) { // in theory we could also copy MAX_POINTER_READ_OFFSET slot, but it is unreachable
+                        truncatedLen := sub(MAX_POINTER_READ_OFFSET(), sourceOffset) // truncate
                         $llvm_AlwaysInline_llvm$_memsetToZero(add(dstOffset, truncatedLen), sub(len, truncatedLen)) // pad with zeroes any out-of-bounds
                     }
             
@@ -2126,8 +2126,8 @@ object "EvmEmulator" {
                     let counter
                     counter, sp, stackHead := popStackItem(sp, stackHead)
             
-                    // Counter certainly can't be bigger than uint32.
-                    if gt(counter, MAX_UINT32()) {
+                    // Counter certainly can't be bigger than uint32 - 32.
+                    if gt(counter, MAX_POINTER_READ_OFFSET()) {
                         panic()
                     } 
             
@@ -2156,8 +2156,8 @@ object "EvmEmulator" {
                         continue
                     }
             
-                    // Counter certainly can't be bigger than uint32.
-                    if gt(counter, MAX_UINT32()) {
+                    // Counter certainly can't be bigger than uint32 - 32.
+                    if gt(counter, MAX_POINTER_READ_OFFSET()) {
                         panic()
                     } 
             
@@ -3116,7 +3116,7 @@ object "EvmEmulator" {
             
             function MAX_UINT32() -> ret { ret := 4294967295 } // 2^32 - 1
             
-            function MAX_CALLDATA_OFFSET() -> ret { ret := sub(MAX_UINT32(), 32) } // EraVM will panic if offset + length overflows u32
+            function MAX_POINTER_READ_OFFSET() -> ret { ret := sub(MAX_UINT32(), 32) } // EraVM will panic if offset + length overflows u32
             
             function EMPTY_KECCAK() -> value {  // keccak("")
                 value := 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
@@ -4650,14 +4650,14 @@ object "EvmEmulator" {
                         dstOffset := add(dstOffset, MEM_OFFSET())
                 
                         // EraVM will revert if offset + length overflows uint32
-                        if gt(sourceOffset, MAX_CALLDATA_OFFSET()) {
-                            sourceOffset := MAX_CALLDATA_OFFSET()
+                        if gt(sourceOffset, MAX_POINTER_READ_OFFSET()) {
+                            sourceOffset := MAX_POINTER_READ_OFFSET()
                         }
                 
                         // Check bytecode out-of-bounds access
                         let truncatedLen := len
-                        if gt(add(sourceOffset, len), MAX_CALLDATA_OFFSET()) { // in theory we could also copy MAX_CALLDATA_OFFSET slot, but it is unreachable
-                            truncatedLen := sub(MAX_CALLDATA_OFFSET(), sourceOffset) // truncate
+                        if gt(add(sourceOffset, len), MAX_POINTER_READ_OFFSET()) { // in theory we could also copy MAX_POINTER_READ_OFFSET slot, but it is unreachable
+                            truncatedLen := sub(MAX_POINTER_READ_OFFSET(), sourceOffset) // truncate
                             $llvm_AlwaysInline_llvm$_memsetToZero(add(dstOffset, truncatedLen), sub(len, truncatedLen)) // pad with zeroes any out-of-bounds
                         }
                 
@@ -5051,8 +5051,8 @@ object "EvmEmulator" {
                         let counter
                         counter, sp, stackHead := popStackItem(sp, stackHead)
                 
-                        // Counter certainly can't be bigger than uint32.
-                        if gt(counter, MAX_UINT32()) {
+                        // Counter certainly can't be bigger than uint32 - 32.
+                        if gt(counter, MAX_POINTER_READ_OFFSET()) {
                             panic()
                         } 
                 
@@ -5081,8 +5081,8 @@ object "EvmEmulator" {
                             continue
                         }
                 
-                        // Counter certainly can't be bigger than uint32.
-                        if gt(counter, MAX_UINT32()) {
+                        // Counter certainly can't be bigger than uint32 - 32.
+                        if gt(counter, MAX_POINTER_READ_OFFSET()) {
                             panic()
                         } 
                 
@@ -5881,7 +5881,7 @@ object "EvmEmulator" {
                 
                 function $llvm_AlwaysInline_llvm$_calldataload(calldataOffset) -> res {
                     // EraVM will revert if offset + length overflows uint32
-                    if lt(calldataOffset, MAX_CALLDATA_OFFSET()) { // in theory we could also copy MAX_CALLDATA_OFFSET slot, but it is unreachable
+                    if lt(calldataOffset, MAX_POINTER_READ_OFFSET()) { // in theory we could also copy MAX_POINTER_READ_OFFSET slot, but it is unreachable
                         res := calldataload(calldataOffset)
                     }
                 }

--- a/system-contracts/contracts/EvmEmulator.yul.llvm.options
+++ b/system-contracts/contracts/EvmEmulator.yul.llvm.options
@@ -1,1 +1,1 @@
-'-eravm-jump-table-density-threshold=10 -tail-dup-size=6 -eravm-enable-split-loop-phi-live-ranges -tail-merge-only-bbs-without-succ -tail-dup-fallthrough-bbs'
+'-eravm-jump-table-density-threshold=10 -tail-dup-size=6 -eravm-enable-split-loop-phi-live-ranges -eravm-enable-load-sinking -join-globalcopies'

--- a/system-contracts/contracts/EvmGasManager.yul
+++ b/system-contracts/contracts/EvmGasManager.yul
@@ -50,6 +50,11 @@ object "EvmGasManager" {
                 value := sub(shl(88, 1), 1)
             }
 
+            function mloadFromReturndata(pos) -> res {
+                verbatim_0i_0o("return_data_ptr_to_active")
+                res := verbatim_1i_1o("active_ptr_data_load", pos)
+            }
+
             function $llvm_AlwaysInline_llvm$__getRawSenderCodeHash() -> hash {
                 // function getRawCodeHash(address _address)
                 mstore(0, 0x4DE2E46800000000000000000000000000000000000000000000000000000000)
@@ -62,8 +67,7 @@ object "EvmGasManager" {
                     revert(0, 0)
                 }
                 
-                returndatacopy(0, 0, 32)
-                hash := mload(0)
+                hash := mloadFromReturndata(0)
             }
 
             /// @dev Checks that the call is done by the EVM emulator in system mode.

--- a/system-contracts/evm-emulator/EvmEmulator.template.yul
+++ b/system-contracts/evm-emulator/EvmEmulator.template.yul
@@ -17,8 +17,8 @@ object "EvmEmulator" {
             }
 
             mstore(BYTECODE_LEN_OFFSET(), size)
-            mstore(EMPTY_CODE_OFFSET(), 0)
-            copyActivePtrData(BYTECODE_OFFSET(), 0, size)
+
+            swapActivePointerWithBytecodePointer()
         }
 
         function padBytecode(offset, len) -> blobLen {
@@ -112,19 +112,14 @@ object "EvmEmulator" {
             }
 
             function getDeployedBytecode() {
-                let codeLen := fetchDeployedCode(
-                    getCodeAddress(), 
-                    BYTECODE_OFFSET(), // destination offset
-                    0, // source offset
-                    add(MAX_POSSIBLE_DEPLOYED_BYTECODE_LEN(), 1) // so we can check that bytecode isn't too big
-                )
-
-                if gt(codeLen, MAX_POSSIBLE_DEPLOYED_BYTECODE_LEN()) {
-                    panic()
-                }
+                let success, rawCodeHash := fetchBytecode(getCodeAddress())
+                let codeLen := and(shr(224, rawCodeHash), 0xffff)
+                
+                loadReturndataIntoActivePtr()
             
-                mstore(EMPTY_CODE_OFFSET(), 0)
                 mstore(BYTECODE_LEN_OFFSET(), codeLen)
+
+                swapActivePointerWithBytecodePointer()
             }
 
             <!-- @include EvmEmulatorFunctions.template.yul -->

--- a/system-contracts/evm-emulator/EvmEmulatorFunctions.template.yul
+++ b/system-contracts/evm-emulator/EvmEmulatorFunctions.template.yul
@@ -121,7 +121,7 @@ function OVERHEAD() -> overhead { overhead := 2000 }
 
 function MAX_UINT32() -> ret { ret := 4294967295 } // 2^32 - 1
 
-function MAX_CALLDATA_OFFSET() -> ret { ret := sub(MAX_UINT32(), 32) } // EraVM will panic if offset + length overflows u32
+function MAX_POINTER_READ_OFFSET() -> ret { ret := sub(MAX_UINT32(), 32) } // EraVM will panic if offset + length overflows u32
 
 function EMPTY_KECCAK() -> value {  // keccak("")
     value := 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470

--- a/system-contracts/evm-emulator/EvmEmulatorFunctions.template.yul
+++ b/system-contracts/evm-emulator/EvmEmulatorFunctions.template.yul
@@ -283,6 +283,14 @@ function loadReturndataIntoActivePtr() {
     verbatim_0i_0o("return_data_ptr_to_active")
 }
 
+function swapActivePointer(index0, index1) {
+    verbatim_2i_0o("active_ptr_swap", index0, index1)
+}
+
+function activePointerLoad(pos) -> res {
+    res := verbatim_1i_1o("active_ptr_data_load", pos)
+}
+
 function loadCalldataIntoActivePtr() {
     verbatim_0i_0o("calldata_ptr_to_active")
 }
@@ -308,6 +316,13 @@ function getIsStaticFromCallFlags() -> isStatic {
     isStatic := iszero(iszero(and(isStatic, 0x04)))
 }
 
+function loadFromReturnDataPointer(pos) -> res {
+    swapActivePointer(0, 1)
+    loadReturndataIntoActivePtr()
+    res := activePointerLoad(pos)
+    swapActivePointer(0, 1)
+}
+
 function fetchFromSystemContract(to, argSize) -> res {
     let success := staticcall(gas(), to, 0, argSize, 0, 0)
 
@@ -316,8 +331,7 @@ function fetchFromSystemContract(to, argSize) -> res {
         abortEvmEnvironment()
     }
 
-    returndatacopy(0, 0, 32)
-    res := mload(0) 
+    res := loadFromReturnDataPointer(0)
 }
 
 function isAddrEmpty(addr) -> isEmpty {
@@ -579,8 +593,7 @@ function warmSlot(key, currentValue) -> isWarm, originalValue {
     originalValue := currentValue
     if returndatasize() {
         isWarm := true
-        returndatacopy(0, 0, 32)
-        originalValue := mload(0)
+        originalValue := loadFromReturnDataPointer(0)
     }
 }
 
@@ -605,8 +618,7 @@ function consumeEvmFrame() -> passGas, isStatic, callerEVM {
         callerEVM := true
         mstore(PANIC_RETURNDATASIZE_OFFSET(), 32) // we should return 0 gas after panics
 
-        returndatacopy(0, 0, 32)
-        passGas := mload(0)
+        passGas := loadFromReturnDataPointer(0)
         
         isStatic := gt(_returndatasize, 32)
     }
@@ -982,8 +994,7 @@ function _saveReturndataAfterEVMCall(_outputOffset, _outputLen) -> _gasLeft {
             abortEvmEnvironment()
         }
         default {
-            returndatacopy(0, 0, 32)
-            _gasLeft := mload(0)
+            _gasLeft := activePointerLoad(0)
 
             // We copy as much returndata as possible without going over the 
             // returndata size.
@@ -1085,8 +1096,7 @@ function _executeCreate(offset, size, value, evmGasLeftOld, isCreate2, salt) -> 
     let canBeDeployed := performSystemCallRevertable(DEPLOYER_SYSTEM_CONTRACT(), 68)
 
     if canBeDeployed {
-        returndatacopy(0, 0, 32)
-        addr := and(mload(0), ADDRESS_MASK())
+        addr := and(loadFromReturnDataPointer(0), ADDRESS_MASK())
         pop($llvm_AlwaysInline_llvm$_warmAddress(addr)) // will stay warm even if constructor reverts
         // so even if constructor reverts, nonce stays incremented and addr stays warm
 
@@ -1171,9 +1181,8 @@ function _saveConstructorReturnGas() -> gasLeft, addr {
     }
 
     // ContractDeployer returns (uint256 gasLeft, address createdContract)
-    returndatacopy(0, 0, 64)
-    gasLeft := mload(0)
-    addr := mload(32)
+    gasLeft := activePointerLoad(0)
+    addr := activePointerLoad(32)
 
     _eraseReturndataPointer()
 }

--- a/system-contracts/evm-emulator/EvmEmulatorLoop.template.yul
+++ b/system-contracts/evm-emulator/EvmEmulatorLoop.template.yul
@@ -774,7 +774,7 @@ for { } true { } {
         let counter
         counter, sp, stackHead := popStackItem(sp, stackHead)
 
-        // Counter certainly can't be bigger than uint64.
+        // Counter certainly can't be bigger than uint32.
         if gt(counter, MAX_UINT32()) {
             panic()
         } 
@@ -804,7 +804,7 @@ for { } true { } {
             continue
         }
 
-        // Counter certainly can't be bigger than uint64.
+        // Counter certainly can't be bigger than uint32.
         if gt(counter, MAX_UINT32()) {
             panic()
         } 

--- a/system-contracts/evm-emulator/EvmEmulatorLoop.template.yul
+++ b/system-contracts/evm-emulator/EvmEmulatorLoop.template.yul
@@ -373,14 +373,14 @@ for { } true { } {
         dstOffset := add(dstOffset, MEM_OFFSET())
 
         // EraVM will revert if offset + length overflows uint32
-        if gt(sourceOffset, MAX_CALLDATA_OFFSET()) {
-            sourceOffset := MAX_CALLDATA_OFFSET()
+        if gt(sourceOffset, MAX_POINTER_READ_OFFSET()) {
+            sourceOffset := MAX_POINTER_READ_OFFSET()
         }
 
         // Check bytecode out-of-bounds access
         let truncatedLen := len
-        if gt(add(sourceOffset, len), MAX_CALLDATA_OFFSET()) { // in theory we could also copy MAX_CALLDATA_OFFSET slot, but it is unreachable
-            truncatedLen := sub(MAX_CALLDATA_OFFSET(), sourceOffset) // truncate
+        if gt(add(sourceOffset, len), MAX_POINTER_READ_OFFSET()) { // in theory we could also copy MAX_POINTER_READ_OFFSET slot, but it is unreachable
+            truncatedLen := sub(MAX_POINTER_READ_OFFSET(), sourceOffset) // truncate
             $llvm_AlwaysInline_llvm$_memsetToZero(add(dstOffset, truncatedLen), sub(len, truncatedLen)) // pad with zeroes any out-of-bounds
         }
 
@@ -774,8 +774,8 @@ for { } true { } {
         let counter
         counter, sp, stackHead := popStackItem(sp, stackHead)
 
-        // Counter certainly can't be bigger than uint32.
-        if gt(counter, MAX_UINT32()) {
+        // Counter certainly can't be bigger than uint32 - 32.
+        if gt(counter, MAX_POINTER_READ_OFFSET()) {
             panic()
         } 
 
@@ -804,8 +804,8 @@ for { } true { } {
             continue
         }
 
-        // Counter certainly can't be bigger than uint32.
-        if gt(counter, MAX_UINT32()) {
+        // Counter certainly can't be bigger than uint32 - 32.
+        if gt(counter, MAX_POINTER_READ_OFFSET()) {
             panic()
         } 
 

--- a/system-contracts/evm-emulator/calldata-opcodes/RuntimeScope.template.yul
+++ b/system-contracts/evm-emulator/calldata-opcodes/RuntimeScope.template.yul
@@ -8,7 +8,7 @@ function $llvm_AlwaysInline_llvm$_calldatacopy(dstOffset, sourceOffset, truncate
 
 function $llvm_AlwaysInline_llvm$_calldataload(calldataOffset) -> res {
     // EraVM will revert if offset + length overflows uint32
-    if lt(calldataOffset, MAX_CALLDATA_OFFSET()) { // in theory we could also copy MAX_CALLDATA_OFFSET slot, but it is unreachable
+    if lt(calldataOffset, MAX_POINTER_READ_OFFSET()) { // in theory we could also copy MAX_POINTER_READ_OFFSET slot, but it is unreachable
         res := calldataload(calldataOffset)
     }
 }

--- a/system-contracts/foundry.toml
+++ b/system-contracts/foundry.toml
@@ -11,6 +11,6 @@ remappings = [
 ]
 
 [profile.default.zksync]
-zksolc = "1.5.7"
+zksolc = "1.5.11"
 enable_eravm_extensions = true
 suppressed_errors = ["sendtransfer"]

--- a/system-contracts/hardhat.config.ts
+++ b/system-contracts/hardhat.config.ts
@@ -7,7 +7,7 @@ import "hardhat-typechain";
 
 export default {
   zksolc: {
-    version: "1.5.7",
+    version: "1.5.11",
     compilerSource: "binary",
     settings: {
       enableEraVMExtensions: true,

--- a/system-contracts/scripts/compile-yul.ts
+++ b/system-contracts/scripts/compile-yul.ts
@@ -6,7 +6,7 @@ import * as fs from "fs";
 import { Command } from "commander";
 import * as _path from "path";
 
-const COMPILER_VERSION = "1.5.7";
+const COMPILER_VERSION = "1.5.11";
 const IS_COMPILER_PRE_RELEASE = false;
 const CONTRACTS_DIR = "contracts-preprocessed";
 const BOOTLOADER_DIR = "bootloader";

--- a/system-contracts/scripts/compile-zasm.ts
+++ b/system-contracts/scripts/compile-zasm.ts
@@ -3,7 +3,7 @@ import type { CompilerPaths } from "./utils";
 import { spawn, compilerLocation, prepareCompilerPaths } from "./utils";
 import * as fs from "fs";
 
-const COMPILER_VERSION = "1.5.7";
+const COMPILER_VERSION = "1.5.11";
 const IS_COMPILER_PRE_RELEASE = false;
 
 export async function compileZasm(paths: CompilerPaths, file: string) {

--- a/system-contracts/scripts/utils.ts
+++ b/system-contracts/scripts/utils.ts
@@ -40,7 +40,7 @@ export function readYulBytecode(description: YulContractDescription) {
 
 export function readZasmBytecode(description: ZasmContractDescription) {
   const contractName = description.codeName;
-  const path = `contracts-preprocessed/${description.path}/artifacts/${contractName}.zasm/${contractName}.zbin`;
+  const path = `contracts-preprocessed/${description.path}/artifacts/${contractName}.zasm/${contractName}.zasm.zbin`;
   return readBytecodeUtf8(path);
 }
 

--- a/system-contracts/scripts/utils.ts
+++ b/system-contracts/scripts/utils.ts
@@ -34,13 +34,13 @@ export interface DeployedDependency {
 
 export function readYulBytecode(description: YulContractDescription) {
   const contractName = description.codeName;
-  const path = `contracts-preprocessed/${description.path}/artifacts/${contractName}.yul/${contractName}.yul.zbin`;
+  const path = `contracts-preprocessed/${description.path}/artifacts/${contractName}.yul/${contractName}.zbin`;
   return readBytecodeUtf8(path);
 }
 
 export function readZasmBytecode(description: ZasmContractDescription) {
   const contractName = description.codeName;
-  const path = `contracts-preprocessed/${description.path}/artifacts/${contractName}.zasm/${contractName}.zasm.zbin`;
+  const path = `contracts-preprocessed/${description.path}/artifacts/${contractName}.zasm/${contractName}.zbin`;
   return readBytecodeUtf8(path);
 }
 


### PR DESCRIPTION
# What ❔

Changes way of reading bytecodes of EVM contracts: after this change Emulator doesn't copy EVM bytecodes during calls and just reads them by pointers. Also more actively uses pointers for optimization.

zksolc is bumped to `1.5.11` since this version includes some beneficial compiler optimizations.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
