### PR TITLE
feat(eigenda): implement eigenDA client remaining features

### DIFF
--- a/da-contracts/contracts/da-layers/eigenda/EigenDAL1Validator.sol
+++ b/da-contracts/contracts/da-layers/eigenda/EigenDAL1Validator.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+import {IL1DAValidator, L1DAValidatorOutput} from "../../IL1DAValidator.sol";
+import {ValL1DAWrongInputLength} from "../../DAContractsErrors.sol";
+contract EigenDAL1Validator is IL1DAValidator {
+    function checkDA(
+        uint256, // _chainId
+        uint256, // _batchNumber
+        bytes32, // _l2DAValidatorOutputHash
+        bytes calldata _operatorDAInput,
+        uint256 maxBlobsSupported
+    ) external override returns (L1DAValidatorOutput memory output) {
+        // TODO: Implement real validation logic for M1.
+        // For Validiums, we expect the operator to just provide the data for us.
+        // We don't need to do any checks with regard to the l2DAValidatorOutputHash.
+        if (_operatorDAInput.length < 32) {
+            revert ValL1DAWrongInputLength(_operatorDAInput.length, 32);
+        }
+        bytes32 stateDiffHash = abi.decode(_operatorDAInput[:32], (bytes32));
+        output.stateDiffHash = stateDiffHash;
+        output.blobsLinearHashes = new bytes32[](maxBlobsSupported);
+        output.blobsOpeningCommitments = new bytes32[](maxBlobsSupported);
+    }
+}

--- a/l1-contracts/deploy-scripts/DeployL1.s.sol
+++ b/l1-contracts/deploy-scripts/DeployL1.s.sol
@@ -176,6 +176,15 @@ contract DeployL1Script is Script, DeployUtils {
             );
     }
 
+    function getEigenDAL2ValidatorAddress() internal returns (address) {
+        return
+            Utils.getL2AddressViaCreate2Factory(
+                bytes32(0),
+                L2ContractHelper.hashL2Bytecode(L2ContractsBytecodesLib.readEigenDAL2ValidatorBytecode()),
+                hex""
+            );
+    }
+
     function deployDAValidators() internal {
         vm.broadcast(msg.sender);
         address rollupDAManager = address(new RollupDAManager());
@@ -200,6 +209,13 @@ contract DeployL1Script is Script, DeployUtils {
             console.log("AvailL1DAValidator deployed at:", addresses.daAddresses.availL1DAValidator);
         } else {
             addresses.daAddresses.availL1DAValidator = config.contracts.availL1DAValidator;
+        }
+
+        if (config.contracts.eigenDAL1Validator == address(0)) {
+            addresses.daAddresses.eigenDAL1Validator = deployViaCreate2(Utils.readEigenDAL1ValidatorBytecode(), "");
+            console.log("EigenDAL1Validator deployed at:", addresses.daAddresses.eigenDAL1Validator);
+        } else {
+            addresses.daAddresses.eigenDAL1Validator = config.contracts.eigenDAL1Validator;
         }
 
         vm.startBroadcast(msg.sender);
@@ -703,6 +719,11 @@ contract DeployL1Script is Script, DeployUtils {
             "avail_l1_da_validator_addr",
             addresses.daAddresses.availL1DAValidator
         );
+        vm.serializeAddress(
+            "deployed_addresses",
+            "eigenda_l1_validator_addr",
+            addresses.daAddresses.eigenDAL1Validator
+        );
 
         string memory deployedAddresses = vm.serializeAddress(
             "deployed_addresses",
@@ -721,6 +742,7 @@ contract DeployL1Script is Script, DeployUtils {
         vm.serializeAddress("root", "expected_rollup_l2_da_validator_addr", getRollupL2ValidatorAddress());
         vm.serializeAddress("root", "expected_no_da_validium_l2_validator_addr", getNoDAValidiumL2ValidatorAddress());
         vm.serializeAddress("root", "expected_avail_l2_da_validator_addr", getAvailL2ValidatorAddress());
+        vm.serializeAddress("root", "expected_eigenda_l2_validator_addr", getEigenDAL2ValidatorAddress());
         string memory toml = vm.serializeAddress("root", "owner_address", config.ownerAddress);
 
         vm.writeToml(toml, outputPath);

--- a/l1-contracts/deploy-scripts/DeployL2Contracts.sol
+++ b/l1-contracts/deploy-scripts/DeployL2Contracts.sol
@@ -23,7 +23,8 @@ contract DeployL2Script is Script {
     enum DAValidatorType {
         Rollup,
         NoDA,
-        Avail
+        Avail,
+        EigenDA
     }
 
     // solhint-disable-next-line gas-struct-packing
@@ -136,7 +137,7 @@ contract DeployL2Script is Script {
         config.eraChainId = toml.readUint("$.era_chain_id");
 
         uint256 validatorTypeUint = toml.readUint("$.da_validator_type");
-        require(validatorTypeUint < 3, "Invalid DA validator type");
+        require(validatorTypeUint < 4, "Invalid DA validator type");
         config.validatorType = DAValidatorType(validatorTypeUint);
     }
 
@@ -161,6 +162,8 @@ contract DeployL2Script is Script {
             bytecode = L2ContractsBytecodesLib.readNoDAL2DAValidatorBytecode();
         } else if (config.validatorType == DAValidatorType.Avail) {
             bytecode = L2ContractsBytecodesLib.readAvailL2DAValidatorBytecode();
+        } else if (config.validatorType == DAValidatorType.EigenDA) {
+            bytecode = L2ContractsBytecodesLib.readEigenDAL2ValidatorBytecode();
         } else {
             revert("Invalid DA validator type");
         }

--- a/l1-contracts/deploy-scripts/DeployUtils.s.sol
+++ b/l1-contracts/deploy-scripts/DeployUtils.s.sol
@@ -103,6 +103,7 @@ struct DataAvailabilityDeployedAddresses {
     address l1RollupDAValidator;
     address noDAValidiumL1DAValidator;
     address availL1DAValidator;
+    address eigenDAL1Validator;
 }
 
 // solhint-disable-next-line gas-struct-packing
@@ -166,6 +167,7 @@ struct ContractsConfig {
     bytes32 bootloaderHash;
     bytes32 defaultAAHash;
     address availL1DAValidator;
+    address eigenDAL1Validator;
 }
 
 struct TokensConfig {
@@ -239,6 +241,9 @@ contract DeployUtils is Script {
 
         if (vm.keyExistsToml(toml, "$.contracts.avail_l1_da_validator")) {
             config.contracts.availL1DAValidator = toml.readAddress("$.contracts.avail_l1_da_validator");
+        }
+        if (vm.keyExistsToml(toml, "$.contracts.eigenda_l1_validator")) {
+            config.contracts.eigenDAL1Validator = toml.readAddress("$.contracts.eigenda_l1_validator");
         }
 
         config.tokens.tokenWethAddress = toml.readAddress("$.tokens.token_weth_address");

--- a/l1-contracts/deploy-scripts/L2ContractsBytecodesLib.sol
+++ b/l1-contracts/deploy-scripts/L2ContractsBytecodesLib.sol
@@ -82,6 +82,12 @@ library L2ContractsBytecodesLib {
         return Utils.readZKFoundryBytecodeL2("AvailL2DAValidator.sol", "AvailL2DAValidator");
     }
 
+    /// @notice Reads the bytecode of the ValidiumL2DAValidator contract for EigenDA.
+    /// @return The bytecode of the ValidiumL2DAValidator contract.
+    function readEigenDAL2ValidatorBytecode() internal view returns (bytes memory) {
+        return Utils.readZKFoundryBytecodeL2("EigenDAL2Validator.sol", "EigenDAL2Validator");
+    }
+
     /// @notice Reads the bytecode of the ValidiumL2DAValidator contract for NoDA validium.
     /// @return The bytecode of the ValidiumL2DAValidator contract.
     function readNoDAL2DAValidatorBytecode() internal view returns (bytes memory) {

--- a/l1-contracts/deploy-scripts/Utils.sol
+++ b/l1-contracts/deploy-scripts/Utils.sol
@@ -1122,6 +1122,10 @@ library Utils {
         bytecode = readFoundryBytecode("/../da-contracts/out/DummyAvailBridge.sol/DummyAvailBridge.json");
     }
 
+    function readEigenDAL1ValidatorBytecode() internal view returns (bytes memory bytecode) {
+        bytecode = readFoundryBytecode("/../da-contracts/out/EigenDAL1Validator.sol/EigenDAL1Validator.json");
+    }
+
     // add this to be excluded from coverage report
     function test() internal {}
 }

--- a/l2-contracts/contracts/data-availability/EigenDAL2Validator.sol
+++ b/l2-contracts/contracts/data-availability/EigenDAL2Validator.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+import {IL2DAValidator} from "../interfaces/IL2DAValidator.sol";
+/// Rollup DA validator. It will publish data that would allow to use either calldata or blobs.
+contract EigenDAL2Validator is IL2DAValidator {
+    function validatePubdata(
+        // The rolling hash of the user L2->L1 logs.
+        bytes32,
+        // The root hash of the user L2->L1 logs.
+        bytes32,
+        // The chained hash of the L2->L1 messages
+        bytes32,
+        // The chained hash of uncompressed bytecodes sent to L1
+        bytes32,
+        // Operator data, that is related to the DA itself
+        bytes calldata
+    ) external returns (bytes32 outputHash) {
+        // Since we do not need to publish anything to L1, we can just return 0.
+        // Note, that Rollup validator sends the hash of uncompressed state diffs, since the
+        // correctness of the publish pubdata depends on it. However Validium doesn't sent anything,
+        // so we don't need to publish even that.
+        // TODO: Implement real validation logic.
+        outputHash = bytes32(0);
+    }
+}


### PR DESCRIPTION
This PR includes the necessary changes for eigenda integration to work with the new changes from sync-layer-stable.
This is a dummy implementation, real M1 implementation will be done later.

The changes made are:

- A new L1 contract EigenDAL1Validator.sol which performs exactly as the one for NoDA, but with the operatorDAInput length check changed so that it can be greater than 32.

- A new L2 contract EigenDAL2Validator.sol which performs exactly as the one for NoDA.

- Changes needed for deployment of this two contracts.

Related to: [matter-labs/zksync-era#3243](https://github.com/matter-labs/zksync-era/pull/3243)