### PR TITLE
fix: correct reverts & internal errors from ecpairing

### DIFF
--- a/system-contracts/contracts/precompiles/EcAdd.yul
+++ b/system-contracts/contracts/precompiles/EcAdd.yul
@@ -74,7 +74,7 @@ object "EcAdd" {
 
             switch and(success, internalSuccess)
             case 0 {
-                return(0, 0)
+                revert(0, 0)
             }
             default {
                 return(32, 64)

--- a/system-contracts/contracts/precompiles/EcMul.yul
+++ b/system-contracts/contracts/precompiles/EcMul.yul
@@ -73,7 +73,7 @@ object "EcMul" {
 
             switch and(success, internalSuccess)
             case 0 {
-                return(0, 0)
+                revert(0, 0)
             }
             default {
                 return(32, 64)

--- a/system-contracts/contracts/precompiles/EcPairing.yul
+++ b/system-contracts/contracts/precompiles/EcPairing.yul
@@ -16,7 +16,7 @@ object "EcPairing" {
             }
 
             /// @dev The additional gas cost of processing ecpairing circuit precompile.
-            /// @dev Added per pair. 
+            /// @dev Added per pair.
             function ECPAIRING_PAIR_GAS_COST() -> ret {
                 ret := 80000
             }
@@ -90,18 +90,22 @@ object "EcPairing" {
                 0,              // input offset in words
                 mul(6, pairs),  // input length in words multiples of (p_x, p_x, q_x_a, q_x_b, q_y_a, q_y_b)
                 0,              // output offset in words
-                1,              // output length in words (pairing check boolean)
+                2,              // output length in words with success (pairing check boolean)
                 pairs           // number of pairs
             )
             let gasToPay := ecpairingGasCost(pairs)
 
             let success := precompileCall(precompileParams, gasToPay)
-            if iszero(success) {
-                return(0, 0)
+            let internalSuccess := mload(0)
+
+            switch and(success, internalSuccess)
+            case 0 {
+                revert(0, 0)
+            }
+            default {
+                return(32, 64)
             }
 
-            return(0, 64)
-            
         }
     }
 }

--- a/system-contracts/contracts/precompiles/Modexp.yul
+++ b/system-contracts/contracts/precompiles/Modexp.yul
@@ -112,7 +112,7 @@ object "Modexp" {
             let gasToPay := MODEXP_GAS_COST() // TODO (?): make dynamic gas calculation
             let success := precompileCall(precompileParams, gasToPay)
             if iszero(success) {
-                return(0, 0)
+                revert(0, 0)
             }
 
             // To achieve homogeneity of the circuit, we always return the max supported bytes of the modulus (e.g. 256).


### PR DESCRIPTION
# What ❔

* ECPairing to handle the internal error correctly
* Proper reverts (instead of returns) for other precompiles too