### PR TITLE
Add invariant tests workflow and fix coverage job

### DIFF
--- a/.github/workflows/invariant-tests.yaml
+++ b/.github/workflows/invariant-tests.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         branch: ${{ fromJSON(needs.define-matrix.outputs.branches) }}
-        command: ['test:invariant:l1-context', 'test:invariant:l2-context']
+        command: ["test:invariant:l1-context", "test:invariant:l2-context"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/invariant-tests.yaml
+++ b/.github/workflows/invariant-tests.yaml
@@ -1,0 +1,68 @@
+name: Invariant Tests
+
+on:
+  schedule:
+    - cron: "00 01 * * *"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  define-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.branches.outputs.branches }}
+    steps:
+      - name: Define branches
+        id: branches
+        run: |
+          if [[ ${{ github.event_name }} == "schedule" ]]; then
+            echo 'branches=["main", "dev"]' >> "$GITHUB_OUTPUT"
+          else
+            echo "branches=[\"$GITHUB_REF\"]" >> "$GITHUB_OUTPUT"
+          fi
+
+  test:
+    needs: define-matrix
+    strategy:
+      matrix:
+        branch: ${{ fromJSON(needs.define-matrix.outputs.branches) }}
+        command: ['test:invariant:l1-context', 'test:invariant:l2-context']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          ref: ${{ matrix.branch }}
+
+      - name: Install foundry-zksync
+        uses: dutterbutter/foundry-zksync-toolchain@5b0459c3701903f1913b8b2558a22bf49138e495 # v1.0.0
+        with:
+          version: nightly-27360d4c8d12beddbb730dae07ad33a206b38f4b
+
+      - name: Show forge version
+        shell: bash
+        run: forge --version
+
+      - name: Cache yarn packages
+        uses: actions/setup-node@v4
+        with:
+          cache: yarn
+
+      - name: Install yarn packages
+        shell: bash
+        run: yarn
+
+      - name: Build artifacts
+        shell: bash
+        run: |
+          # creates JSON files needed for `yarn l1 test:zkfoundry`
+          yarn sc build:foundry
+          cd l1-contracts
+          # creates `l1-contracts/script-out/diamond-selectors.toml` which is needed for `l1-contracts/deploy-scripts/DeployUtils.s.sol`
+          yarn test:zkfoundry
+
+      - name: Run tests
+        run: |
+          cd l1-contracts
+          yarn ${{ matrix.command }}

--- a/.github/workflows/invariant-tests.yaml
+++ b/.github/workflows/invariant-tests.yaml
@@ -17,7 +17,7 @@ jobs:
         id: branches
         run: |
           if [[ ${{ github.event_name }} == "schedule" ]]; then
-            echo 'branches=["main", "dev"]' >> "$GITHUB_OUTPUT"
+            echo 'branches=["dev"]' >> "$GITHUB_OUTPUT"
           else
             echo "branches=[\"$GITHUB_REF\"]" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/l1-contracts-ci.yaml
+++ b/.github/workflows/l1-contracts-ci.yaml
@@ -207,6 +207,12 @@ jobs:
       - name: Run coverage
         run: FOUNDRY_PROFILE=default yarn test:foundry && FOUNDRY_PROFILE=default yarn coverage:foundry --report summary --report lcov
 
+      # Installing the specific version of `lcov` because of
+      # the `genhtml: ERROR: line ... of ... has branchcov but no linecov data` error.
+      # https://github.com/zgosalvez/github-actions-report-lcov/issues/282
+      - name: Install LCOV
+        run: sudo apt update && sudo apt install -y lcov=1.15-1
+
       # To ignore coverage for certain directories modify the paths in this step as needed. The
       # below default ignores coverage results for the test and script directories. Alternatively,
       # to include coverage in all directories, comment out this step. Note that because this
@@ -215,9 +221,7 @@ jobs:
       # The `--rc branch_coverage=1` part keeps branch info in the filtered report, since lcov
       # defaults to removing branch info.
       - name: Filter directories
-        run: |
-          sudo apt update && sudo apt install -y lcov
-          lcov --remove lcov.info 'test/*' 'contracts/dev-contracts/*' --output-file lcov.info --rc branch_coverage=1
+        run: lcov --remove lcov.info 'test/*' 'contracts/dev-contracts/*' --output-file lcov.info --rc branch_coverage=1
 
       # This step posts a detailed coverage report as a comment and deletes previous comments on
       # each push. The below step is used to fail coverage if the specified coverage threshold is

--- a/.github/workflows/l1-contracts-ci.yaml
+++ b/.github/workflows/l1-contracts-ci.yaml
@@ -211,7 +211,9 @@ jobs:
       # the `genhtml: ERROR: line ... of ... has branchcov but no linecov data` error.
       # https://github.com/zgosalvez/github-actions-report-lcov/issues/282
       - name: Install LCOV
-        run: sudo apt update && sudo apt install -y lcov=1.15-1
+        uses: hrishikesh-kadam/setup-lcov@6c1aa0cc9e1c02f9f58f01ac599f1064ccc83470 # v1.1.0
+        with:
+          ref: v1.16
 
       # To ignore coverage for certain directories modify the paths in this step as needed. The
       # below default ignores coverage results for the test and script directories. Alternatively,

--- a/.github/workflows/l1-contracts-ci.yaml
+++ b/.github/workflows/l1-contracts-ci.yaml
@@ -217,7 +217,7 @@ jobs:
       - name: Filter directories
         run: |
           sudo apt update && sudo apt install -y lcov
-          lcov --remove lcov.info 'lib/*' 'test/*' 'contracts/dev-contracts/*' --output-file lcov.info --rc lcov_branch_coverage=1
+          lcov --remove lcov.info 'test/*' 'contracts/dev-contracts/*' --output-file lcov.info --rc lcov_branch_coverage=1
 
       # This step posts a detailed coverage report as a comment and deletes previous comments on
       # each push. The below step is used to fail coverage if the specified coverage threshold is

--- a/.github/workflows/l1-contracts-ci.yaml
+++ b/.github/workflows/l1-contracts-ci.yaml
@@ -233,7 +233,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }} # Adds a coverage summary comment to the PR.
 
       - name: Verify minimum coverage
-        uses: zgosalvez/github-actions-report-lcov@v2
+        uses: zgosalvez/github-actions-report-lcov@df68834145a4a567247d6a3ea8565c4c39d1fd17 # v4.1.23
         with:
           coverage-files: ./l1-contracts/lcov.info
           working-directory: l1-contracts

--- a/.github/workflows/l1-contracts-ci.yaml
+++ b/.github/workflows/l1-contracts-ci.yaml
@@ -217,7 +217,7 @@ jobs:
       - name: Filter directories
         run: |
           sudo apt update && sudo apt install -y lcov
-          lcov --remove lcov.info 'test/*' 'contracts/dev-contracts/*' '../lib/murky/*' 'lib/*' '../lib/*' 'lib/' --output-file lcov.info --rc lcov_branch_coverage=1
+          lcov --remove lcov.info 'lib/*' 'test/*' 'contracts/dev-contracts/*' --output-file lcov.info --rc lcov_branch_coverage=1
 
       # This step posts a detailed coverage report as a comment and deletes previous comments on
       # each push. The below step is used to fail coverage if the specified coverage threshold is

--- a/.github/workflows/l1-contracts-ci.yaml
+++ b/.github/workflows/l1-contracts-ci.yaml
@@ -212,12 +212,12 @@ jobs:
       # to include coverage in all directories, comment out this step. Note that because this
       # filtering applies to the lcov file, the summary table generated in the previous step will
       # still include all files and directories.
-      # The `--rc lcov_branch_coverage=1` part keeps branch info in the filtered report, since lcov
+      # The `--rc branch_coverage=1` part keeps branch info in the filtered report, since lcov
       # defaults to removing branch info.
       - name: Filter directories
         run: |
           sudo apt update && sudo apt install -y lcov
-          lcov --remove lcov.info 'test/*' 'contracts/dev-contracts/*' --output-file lcov.info --rc lcov_branch_coverage=1
+          lcov --remove lcov.info 'test/*' 'contracts/dev-contracts/*' --output-file lcov.info --rc branch_coverage=1
 
       # This step posts a detailed coverage report as a comment and deletes previous comments on
       # each push. The below step is used to fail coverage if the specified coverage threshold is

--- a/.github/workflows/l1-contracts-ci.yaml
+++ b/.github/workflows/l1-contracts-ci.yaml
@@ -217,7 +217,7 @@ jobs:
       - name: Filter directories
         run: |
           sudo apt update && sudo apt install -y lcov
-          lcov --remove lcov.info 'test/*' 'contracts/dev-contracts/*' '../lib/forge-std/*' '../lib/murky/*' 'lib/*' '../lib/*' 'lib/' --output-file lcov.info --rc lcov_branch_coverage=1
+          lcov --remove lcov.info 'test/*' 'contracts/dev-contracts/*' '../lib/murky/*' 'lib/*' '../lib/*' 'lib/' --output-file lcov.info --rc lcov_branch_coverage=1
 
       # This step posts a detailed coverage report as a comment and deletes previous comments on
       # each push. The below step is used to fail coverage if the specified coverage threshold is


### PR DESCRIPTION
# What ❔

Introducing the invariant tests workflow.

## Why ❔

We want to run invariant tests on schedule. This is possible only if the workflow is on the default branch which is currently `main`. On the other hand, it doesn't make sense to merge  https://github.com/matter-labs/era-contracts/pull/1237. to `main` yet because the `main` doesn't have the target code to test (i.e. the `main` is far behind `dev`).

So in order for https://github.com/matter-labs/era-contracts/pull/1237 to work we need to merge this PR. Later `dev` will be merged to `main` adding the missing code.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
