### PR TITLE
feat: keyed nonces

### DIFF
--- a/system-contracts/contracts/ContractDeployer.sol
+++ b/system-contracts/contracts/ContractDeployer.sol
@@ -79,7 +79,7 @@ contract ContractDeployer is IContractDeployer, SystemContractBase {
 
         if (
             _nonceOrdering != AccountNonceOrdering.Arbitrary ||
-            currentInfo.nonceOrdering != AccountNonceOrdering.Sequential
+            currentInfo.nonceOrdering != AccountNonceOrdering.KeyedSequential
         ) {
             revert InvalidNonceOrderingChange();
         }
@@ -210,7 +210,7 @@ contract ContractDeployer is IContractDeployer, SystemContractBase {
         AccountInfo memory newAccountInfo;
         newAccountInfo.supportedAAVersion = AccountAbstractionVersion.None;
         // Accounts have sequential nonces by default.
-        newAccountInfo.nonceOrdering = AccountNonceOrdering.Sequential;
+        newAccountInfo.nonceOrdering = AccountNonceOrdering.KeyedSequential;
         _storeAccountInfo(_deployment.newAddress, newAccountInfo);
 
         _constructContract({
@@ -289,7 +289,7 @@ contract ContractDeployer is IContractDeployer, SystemContractBase {
         AccountInfo memory newAccountInfo;
         newAccountInfo.supportedAAVersion = _aaVersion;
         // Accounts have sequential nonces by default.
-        newAccountInfo.nonceOrdering = AccountNonceOrdering.Sequential;
+        newAccountInfo.nonceOrdering = AccountNonceOrdering.KeyedSequential;
         _storeAccountInfo(_newAddress, newAccountInfo);
 
         _constructContract({

--- a/system-contracts/contracts/SystemContractErrors.sol
+++ b/system-contracts/contracts/SystemContractErrors.sol
@@ -196,6 +196,9 @@ error TooMuchGas();
 // 0x8c13f15d
 error InvalidNewL2BlockNumber(uint256 l2BlockNumber);
 
+// TODO selector
+error NonZeroNonceKey(uint192 nonceKey);
+
 enum CodeHashReason {
     NotContractOnConstructor,
     NotConstructedContract

--- a/system-contracts/contracts/interfaces/IContractDeployer.sol
+++ b/system-contracts/contracts/interfaces/IContractDeployer.sol
@@ -28,14 +28,14 @@ interface IContractDeployer {
     }
 
     /// @notice Defines the nonce ordering used by the account
-    /// - `Sequential` means that it is expected that the nonces are monotonic and increment by 1
-    /// at a time (the same as EOAs).
+    /// - `KeyedSequential` means that it is expected that the nonces are monotonic and increment by 1
+    /// at a time for each key (nonces are split 192:64 bits into nonceKey:nonceValue parts, as proposed by EIP-4337).
     /// - `Arbitrary` means that the nonces for the accounts can be arbitrary. The operator
     /// should serve the transactions from such an account on a first-come-first-serve basis.
     /// @dev This ordering is more of a suggestion to the operator on how the AA expects its transactions
     /// to be processed and is not considered as a system invariant.
     enum AccountNonceOrdering {
-        Sequential,
+        KeyedSequential,
         Arbitrary
     }
 


### PR DESCRIPTION
# What ❔

Support for EIP-4337's [semi-abstracted nonces](https://eips.ethereum.org/EIPS/eip-4337#semi-abstracted-nonce-support)

## Why ❔

Requiring a single sequential nonce value is limiting the senders' ability to define their custom logic with regard to transaction ordering.

In particular, ZKsync SSO's session module requires the ability to send multiple transactions in parallel without any one of them overriding or canceling the other ones.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
