### PR TITLE
Reduce the `depth` parameter for invariant tests in the L1 context

### DIFF
--- a/l1-contracts/foundry.toml
+++ b/l1-contracts/foundry.toml
@@ -74,7 +74,7 @@ optimizer = false
 suppressed_warnings = ["txorigin"]
 [profile.invariant_tests_l1context_ci.invariant]
 runs = 10
-depth = 100000
+depth = 10000
 
 [profile.invariant_tests_l2context_ci]
 test = "test"


### PR DESCRIPTION
# What ❔

This PR reduces the the `depth` parameter.

## Why ❔

GitHub enforces the [6 hour job run limit](https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration) so both scheduled and manual workflow runs have failed for the L1 context. Looks like [runs=10 and depth=100000](https://github.com/matter-labs/era-contracts/blob/4518328108a348c5e656b06018a37ef64018f497/l1-contracts/foundry.toml#L76-L77) is too much for the CI. Reducing the depth to 10000.

Failed workflows:

- https://github.com/matter-labs/era-contracts/actions/runs/13534543437
- https://github.com/matter-labs/era-contracts/actions/runs/13524069214

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
