### PR TITLE
N-03: Modexp Lacks an SPDX License Identifier

### DIFF
--- a/system-contracts/contracts/precompiles/Modexp.yul
+++ b/system-contracts/contracts/precompiles/Modexp.yul
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 object "Modexp" {
     code {
         return(0, 0)


### PR DESCRIPTION
## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
