### PR TITLE
M-01: Return Length of ‘EcPairing’ Does Not Match the Specifications

### DIFF
--- a/system-contracts/contracts/precompiles/EcPairing.yul
+++ b/system-contracts/contracts/precompiles/EcPairing.yul
@@ -119,7 +119,7 @@ object "EcPairing" {
                 revert(0, 0)
             }
             default {
-                return(32, 64)
+                return(32, 32)
             }
 
         }


### PR DESCRIPTION
## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
