### PR TITLE
Restore coverage CI by unstacking fflonk verifier

### DIFF
--- a/.github/workflows/l1-contracts-ci.yaml
+++ b/.github/workflows/l1-contracts-ci.yaml
@@ -280,7 +280,6 @@ jobs:
         run: diff tools/data/VerifierFflonk.sol l1-contracts/contracts/state-transition/verifiers/L2VerifierFflonk.sol
 
   coverage:
-    if: false # FIXME: coverage disabled due to stack-too-deep in VerifierFflonk.sol
     defaults:
       run:
         working-directory: l1-contracts

--- a/AllContractsHashes.json
+++ b/AllContractsHashes.json
@@ -985,11 +985,11 @@
   },
   {
     "contractName": "l1-contracts/GatewayCTMDeployer",
-    "zkBytecodeHash": "0x010003c15cf8aef29a3cdbc94551fb00fdc550b4d2a813de4295d5ca956b0604",
+    "zkBytecodeHash": "0x010003c1c71364afb1fccde1da33e3f0c24651aa82edc5e8662e27138d33440a",
     "zkBytecodePath": "/l1-contracts/zkout/GatewayCTMDeployer.sol/GatewayCTMDeployer.json",
-    "evmBytecodeHash": "0x41f01d0d77fb969686ac1eb1dfad1fac6452b6187d539bcf710e9e5506176a3d",
+    "evmBytecodeHash": "0xcdff25237dc00e0b5d044ba58873f52acc245dd42563a00bd0c4776cf9cc661c",
     "evmBytecodePath": "/l1-contracts/out/GatewayCTMDeployer.sol/GatewayCTMDeployer.json",
-    "evmDeployedBytecodeHash": "0xc9ee71ec09976f43c8f6a985f14eb3080465c09fa527416ad408e483c72e65ec"
+    "evmDeployedBytecodeHash": "0x841c9570a028c1ce658e1c73002f21f6bf6564ad3dfe9172df02a9e64f2b5d9a"
   },
   {
     "contractName": "l1-contracts/GatewayTransactionFilterer",
@@ -1073,11 +1073,11 @@
   },
   {
     "contractName": "l1-contracts/L1VerifierFflonk",
-    "zkBytecodeHash": "0x010009bbfce1714c0c85442924a45feed6b698d8d056de9de31401360a3c42a8",
+    "zkBytecodeHash": "0x010009bf4152475a22610aa1eade7ba8cb0b9f457ab4914059c491834e7e3c94",
     "zkBytecodePath": "/l1-contracts/zkout/L1VerifierFflonk.sol/L1VerifierFflonk.json",
-    "evmBytecodeHash": "0xcf2d7a5aaec89054c45e187efcbf1712cdd1186097eb07bae026d944afa54b90",
+    "evmBytecodeHash": "0xf073db14e4fa177aa7369058acb7d04bb342ee5bfa49604d7620d3d1ca6b1284",
     "evmBytecodePath": "/l1-contracts/out/L1VerifierFflonk.sol/L1VerifierFflonk.json",
-    "evmDeployedBytecodeHash": "0x228c777fb8272b5ff58ea0da50f89ba9aee07416a23e1b82aaf85aef78b4fc2f"
+    "evmDeployedBytecodeHash": "0x7656656012fae90e18762893b5ca00cf0f44f307df5dbe2171397e1b1f9567fb"
   },
   {
     "contractName": "l1-contracts/L1VerifierPlonk",
@@ -1137,11 +1137,11 @@
   },
   {
     "contractName": "l1-contracts/L2VerifierFflonk",
-    "zkBytecodeHash": "0x010009e754bf8e05cea25368b4b705fc9cdd9a6ee8290ba785880a73986e7b96",
+    "zkBytecodeHash": "0x010009ed476067e2488218de48f0c31033003a65c10a890470f78d68232f040a",
     "zkBytecodePath": "/l1-contracts/zkout/L2VerifierFflonk.sol/L2VerifierFflonk.json",
-    "evmBytecodeHash": "0xc8f407ec06b60a823532d869f1dad282c9249bae7b7aff889ead18acd1b982f4",
+    "evmBytecodeHash": "0x257fffd4dd762d018fd168d0d7476f160e262199e2041b87253a3b96296cdfa9",
     "evmBytecodePath": "/l1-contracts/out/L2VerifierFflonk.sol/L2VerifierFflonk.json",
-    "evmDeployedBytecodeHash": "0x169b2aee511df3d19b5552c135ecf2c7e4d1b0929326d431093b51eb3e58c9b3"
+    "evmDeployedBytecodeHash": "0xa523d100ef72792bbce3426ca711741599b08c8a32f7ad491c0c6e9764edb986"
   },
   {
     "contractName": "l1-contracts/L2VerifierPlonk",

--- a/l1-contracts/contracts/state-transition/verifiers/L1VerifierFflonk.sol
+++ b/l1-contracts/contracts/state-transition/verifiers/L1VerifierFflonk.sol
@@ -114,8 +114,8 @@ contract L1VerifierFflonk is IVerifierV2 {
     uint256 internal constant PROOF_EVALUATIONS_LENGTH = 15;
     uint256 internal constant TOTAL_LAGRANGE_BASIS_INVERSES_LENGTH = 18;
 
-    /// @inheritdoc IVerifierV2
-    function verificationKeyHash() external pure returns (bytes32 vkHash) {
+        /// @inheritdoc IVerifierV2
+    function verificationKeyHash() external pure returns (bytes32) {
         return
             keccak256(
                 // solhint-disable-next-line func-named-parameters
@@ -125,15 +125,25 @@ contract L1VerifierFflonk is IVerifierV2 {
                     VK_C0_G1_Y,
                     VK_NON_RESIDUES_0,
                     VK_NON_RESIDUES_1,
-                    VK_G2_ELEMENT_0_X1,
-                    VK_G2_ELEMENT_0_X2,
-                    VK_G2_ELEMENT_0_Y1,
-                    VK_G2_ELEMENT_0_Y2,
-                    VK_G2_ELEMENT_1_X1,
-                    VK_G2_ELEMENT_1_X2,
-                    VK_G2_ELEMENT_1_Y1,
-                    VK_G2_ELEMENT_1_Y2
+                    _getG2Elements()
                 )
+            );
+    }
+
+    /// @dev This breakdown is done to avoid stack-too-deep error
+    /// @return bytes memory The G2 elements
+    function _getG2Elements() internal pure returns (bytes memory) {
+        return
+            // solhint-disable-next-line func-named-parameters
+            abi.encodePacked(
+                VK_G2_ELEMENT_0_X1,
+                VK_G2_ELEMENT_0_X2,
+                VK_G2_ELEMENT_0_Y1,
+                VK_G2_ELEMENT_0_Y2,
+                VK_G2_ELEMENT_1_X1,
+                VK_G2_ELEMENT_1_X2,
+                VK_G2_ELEMENT_1_Y1,
+                VK_G2_ELEMENT_1_Y2
             );
     }
 
@@ -525,33 +535,9 @@ contract L1VerifierFflonk is IVerifierV2 {
             }
 
             /**
-             * @dev Computes partial lagrange basis evaluations Li(y)_numerator = {i = [start..(start+num_polys))} & Li(y)_numerator {i = [(start+num_polys)..(start+(2*num_polys)))} using montgomery lagrange basis inverses sent with proof.
-             * For Li(y)_numerator{i = [start..(start+num_polys))}:
-             * Li(y)_numerator = w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys})))
-             * Li(y)_denominator = (num_polys * (h^{(2*num_polys)-1}-(h^{num_polys-1} * h_s^{num_polys})) * (y-(h*w_i)))
-             * Li(y) = Li(y)_numerator / Li(y)_denominator =  (w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys})))) / (num_polys * (h^{(2*num_polys)-1}-(h^{num_polys-1} * h_s^{num_polys})) * (y-(h*w_i)))
-             *
-             * For Li(y)_numerator{i = [(start+num_polys)..(start+(2*num_polys)))}
-             * Li(y)_numerator = w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys})))
-             * Li(y)_denominator = (num_polys * (h_s^{(2*num_polys)-1}-(h_s^{num_polys-1} * h^{num_polys})) * (y-(h_s*w_i)))
-             * Li(y) = Li(y)_numerator / Li(y)_denominator =  (w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys}))) ) / (num_polys * (h_s^{(2*num_polys)-1}-(h_s^{num_polys-1} * h^{num_polys})) * (y-(h_s*w_i)))
-             *
-             * Also calculates the products of the denominators of the lagrange basis evaluations:
-             * Li(y)_denominators_product = Li(y)_previous_denominators_product * (∏(Li(y)_denominator {i = [start..(start+num_polys))})) * (∏(Li(y)_denominator {i = [(start+num_polys)..(start+(2*num_polys)))}))
+             * sma: TODO add description
              */
-
-            function precompute_partial_lagrange_basis_evaluations_for_union_set(
-                start,
-                num_polys,
-                y,
-                omega,
-                h,
-                h_shifted,
-                product
-            ) -> final_product {
-                if gt(add(start, mul(2, num_polys)), TOTAL_LAGRANGE_BASIS_INVERSES_LENGTH) {
-                    revertWithMessage(32, "Precompute Eval. Error [PLBEIU1]")
-                }
+            function temp_name_inner_function(num_polys, h, h_shifted) -> constant_parts_0, constant_parts_1, t_0, t_1 {
                 let h_pows_0 := h
                 let h_pows_1 := h_shifted
                 let loop_length := sub(num_polys, 2)
@@ -564,8 +550,8 @@ contract L1VerifierFflonk is IVerifierV2 {
                     h_pows_0 := mulmod(h_pows_0, h, R_MOD)
                     h_pows_1 := mulmod(h_pows_1, h_shifted, R_MOD)
                 }
-                let constant_parts_0 := h_pows_0
-                let constant_parts_1 := h_pows_1
+                constant_parts_0 := h_pows_0
+                constant_parts_1 := h_pows_1
                 // h^{num_polys}
                 h_pows_0 := mulmod(h_pows_0, h, R_MOD)
                 // h_s^{num_polys}
@@ -583,9 +569,9 @@ contract L1VerifierFflonk is IVerifierV2 {
                 // y^{num_polys}
                 let t_2 := mload(add(OPS_Y_POWS, mul(num_polys, 0x20)))
                 // h^{num_polys} * h_s^{num_polys}
-                let t_1 := mulmod(h_pows_0, h_pows_1, R_MOD)
+                t_1 := mulmod(h_pows_0, h_pows_1, R_MOD)
                 // h^{num_polys} + h_s^{num_polys}
-                let t_0 := addmod(h_pows_0, h_pows_1, R_MOD)
+                t_0 := addmod(h_pows_0, h_pows_1, R_MOD)
                 // y^{num_polys} * (h^{num_polys} + h_s^{num_polys})
                 t_0 := mulmod(t_0, t_2, R_MOD)
                 // - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys}))
@@ -614,9 +600,40 @@ contract L1VerifierFflonk is IVerifierV2 {
                 constant_parts_1 := addmod(constant_parts_1, h_pows_1, R_MOD)
                 // num_polys * (h_s^{(2*num_polys)-1}-(h_s^{num_polys-1} * h^{num_polys}))
                 constant_parts_1 := mulmod(constant_parts_1, num_polys, R_MOD)
+            }
+
+            /**
+             * @dev Computes partial lagrange basis evaluations Li(y)_numerator = {i = [start..(start+num_polys))} & Li(y)_numerator {i = [(start+num_polys)..(start+(2*num_polys)))} using montgomery lagrange basis inverses sent with proof.
+             * For Li(y)_numerator{i = [start..(start+num_polys))}:
+             * Li(y)_numerator = w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys})))
+             * Li(y)_denominator = (num_polys * (h^{(2*num_polys)-1}-(h^{num_polys-1} * h_s^{num_polys})) * (y-(h*w_i)))
+             * Li(y) = Li(y)_numerator / Li(y)_denominator =  (w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys})))) / (num_polys * (h^{(2*num_polys)-1}-(h^{num_polys-1} * h_s^{num_polys})) * (y-(h*w_i)))
+             *
+             * For Li(y)_numerator{i = [(start+num_polys)..(start+(2*num_polys)))}
+             * Li(y)_numerator = w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys})))
+             * Li(y)_denominator = (num_polys * (h_s^{(2*num_polys)-1}-(h_s^{num_polys-1} * h^{num_polys})) * (y-(h_s*w_i)))
+             * Li(y) = Li(y)_numerator / Li(y)_denominator =  (w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys}))) ) / (num_polys * (h_s^{(2*num_polys)-1}-(h_s^{num_polys-1} * h^{num_polys})) * (y-(h_s*w_i)))
+             *
+             * Also calculates the products of the denominators of the lagrange basis evaluations:
+             * Li(y)_denominators_product = Li(y)_previous_denominators_product * (∏(Li(y)_denominator {i = [start..(start+num_polys))})) * (∏(Li(y)_denominator {i = [(start+num_polys)..(start+(2*num_polys)))}))
+             */
+
+            function precompute_partial_lagrange_basis_evaluations_for_union_set(
+                start,
+                num_polys,
+                y,
+                omega,
+                h,
+                h_shifted,
+                interim_product
+            ) -> final_product {
+                if gt(add(start, mul(2, num_polys)), TOTAL_LAGRANGE_BASIS_INVERSES_LENGTH) {
+                    revertWithMessage(32, "Precompute Eval. Error [PLBEIU1]")
+                }
+
+                let constant_parts_0, constant_parts_1, t_0, t_1 := temp_name_inner_function(num_polys, h, h_shifted)
 
                 let current_omega := 1
-                let interim_product := product
                 for {
                     let i := 0
                 } lt(i, num_polys) {

--- a/l1-contracts/contracts/state-transition/verifiers/L1VerifierFflonk.sol
+++ b/l1-contracts/contracts/state-transition/verifiers/L1VerifierFflonk.sol
@@ -114,7 +114,7 @@ contract L1VerifierFflonk is IVerifierV2 {
     uint256 internal constant PROOF_EVALUATIONS_LENGTH = 15;
     uint256 internal constant TOTAL_LAGRANGE_BASIS_INVERSES_LENGTH = 18;
 
-        /// @inheritdoc IVerifierV2
+    /// @inheritdoc IVerifierV2
     function verificationKeyHash() external pure returns (bytes32) {
         return
             keccak256(

--- a/l1-contracts/contracts/state-transition/verifiers/L2VerifierFflonk.sol
+++ b/l1-contracts/contracts/state-transition/verifiers/L2VerifierFflonk.sol
@@ -114,8 +114,8 @@ contract L2VerifierFflonk is IVerifierV2 {
     uint256 internal constant PROOF_EVALUATIONS_LENGTH = 15;
     uint256 internal constant TOTAL_LAGRANGE_BASIS_INVERSES_LENGTH = 18;
 
-    /// @inheritdoc IVerifierV2
-    function verificationKeyHash() external pure returns (bytes32 vkHash) {
+        /// @inheritdoc IVerifierV2
+    function verificationKeyHash() external pure returns (bytes32) {
         return
             keccak256(
                 // solhint-disable-next-line func-named-parameters
@@ -125,15 +125,25 @@ contract L2VerifierFflonk is IVerifierV2 {
                     VK_C0_G1_Y,
                     VK_NON_RESIDUES_0,
                     VK_NON_RESIDUES_1,
-                    VK_G2_ELEMENT_0_X1,
-                    VK_G2_ELEMENT_0_X2,
-                    VK_G2_ELEMENT_0_Y1,
-                    VK_G2_ELEMENT_0_Y2,
-                    VK_G2_ELEMENT_1_X1,
-                    VK_G2_ELEMENT_1_X2,
-                    VK_G2_ELEMENT_1_Y1,
-                    VK_G2_ELEMENT_1_Y2
+                    _getG2Elements()
                 )
+            );
+    }
+
+    /// @dev This breakdown is done to avoid stack-too-deep error
+    /// @return bytes memory The G2 elements
+    function _getG2Elements() internal pure returns (bytes memory) {
+        return
+            // solhint-disable-next-line func-named-parameters
+            abi.encodePacked(
+                VK_G2_ELEMENT_0_X1,
+                VK_G2_ELEMENT_0_X2,
+                VK_G2_ELEMENT_0_Y1,
+                VK_G2_ELEMENT_0_Y2,
+                VK_G2_ELEMENT_1_X1,
+                VK_G2_ELEMENT_1_X2,
+                VK_G2_ELEMENT_1_Y1,
+                VK_G2_ELEMENT_1_Y2
             );
     }
 
@@ -525,33 +535,9 @@ contract L2VerifierFflonk is IVerifierV2 {
             }
 
             /**
-             * @dev Computes partial lagrange basis evaluations Li(y)_numerator = {i = [start..(start+num_polys))} & Li(y)_numerator {i = [(start+num_polys)..(start+(2*num_polys)))} using montgomery lagrange basis inverses sent with proof.
-             * For Li(y)_numerator{i = [start..(start+num_polys))}:
-             * Li(y)_numerator = w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys})))
-             * Li(y)_denominator = (num_polys * (h^{(2*num_polys)-1}-(h^{num_polys-1} * h_s^{num_polys})) * (y-(h*w_i)))
-             * Li(y) = Li(y)_numerator / Li(y)_denominator =  (w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys})))) / (num_polys * (h^{(2*num_polys)-1}-(h^{num_polys-1} * h_s^{num_polys})) * (y-(h*w_i)))
-             *
-             * For Li(y)_numerator{i = [(start+num_polys)..(start+(2*num_polys)))}
-             * Li(y)_numerator = w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys})))
-             * Li(y)_denominator = (num_polys * (h_s^{(2*num_polys)-1}-(h_s^{num_polys-1} * h^{num_polys})) * (y-(h_s*w_i)))
-             * Li(y) = Li(y)_numerator / Li(y)_denominator =  (w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys}))) ) / (num_polys * (h_s^{(2*num_polys)-1}-(h_s^{num_polys-1} * h^{num_polys})) * (y-(h_s*w_i)))
-             *
-             * Also calculates the products of the denominators of the lagrange basis evaluations:
-             * Li(y)_denominators_product = Li(y)_previous_denominators_product * (∏(Li(y)_denominator {i = [start..(start+num_polys))})) * (∏(Li(y)_denominator {i = [(start+num_polys)..(start+(2*num_polys)))}))
+             * sma: TODO add description
              */
-
-            function precompute_partial_lagrange_basis_evaluations_for_union_set(
-                start,
-                num_polys,
-                y,
-                omega,
-                h,
-                h_shifted,
-                product
-            ) -> final_product {
-                if gt(add(start, mul(2, num_polys)), TOTAL_LAGRANGE_BASIS_INVERSES_LENGTH) {
-                    revertWithMessage(32, "Precompute Eval. Error [PLBEIU1]")
-                }
+            function temp_name_inner_function(num_polys, h, h_shifted) -> constant_parts_0, constant_parts_1, t_0, t_1 {
                 let h_pows_0 := h
                 let h_pows_1 := h_shifted
                 let loop_length := sub(num_polys, 2)
@@ -564,8 +550,8 @@ contract L2VerifierFflonk is IVerifierV2 {
                     h_pows_0 := mulmod(h_pows_0, h, R_MOD)
                     h_pows_1 := mulmod(h_pows_1, h_shifted, R_MOD)
                 }
-                let constant_parts_0 := h_pows_0
-                let constant_parts_1 := h_pows_1
+                constant_parts_0 := h_pows_0
+                constant_parts_1 := h_pows_1
                 // h^{num_polys}
                 h_pows_0 := mulmod(h_pows_0, h, R_MOD)
                 // h_s^{num_polys}
@@ -583,9 +569,9 @@ contract L2VerifierFflonk is IVerifierV2 {
                 // y^{num_polys}
                 let t_2 := mload(add(OPS_Y_POWS, mul(num_polys, 0x20)))
                 // h^{num_polys} * h_s^{num_polys}
-                let t_1 := mulmod(h_pows_0, h_pows_1, R_MOD)
+                t_1 := mulmod(h_pows_0, h_pows_1, R_MOD)
                 // h^{num_polys} + h_s^{num_polys}
-                let t_0 := addmod(h_pows_0, h_pows_1, R_MOD)
+                t_0 := addmod(h_pows_0, h_pows_1, R_MOD)
                 // y^{num_polys} * (h^{num_polys} + h_s^{num_polys})
                 t_0 := mulmod(t_0, t_2, R_MOD)
                 // - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys}))
@@ -614,9 +600,40 @@ contract L2VerifierFflonk is IVerifierV2 {
                 constant_parts_1 := addmod(constant_parts_1, h_pows_1, R_MOD)
                 // num_polys * (h_s^{(2*num_polys)-1}-(h_s^{num_polys-1} * h^{num_polys}))
                 constant_parts_1 := mulmod(constant_parts_1, num_polys, R_MOD)
+            }
+
+            /**
+             * @dev Computes partial lagrange basis evaluations Li(y)_numerator = {i = [start..(start+num_polys))} & Li(y)_numerator {i = [(start+num_polys)..(start+(2*num_polys)))} using montgomery lagrange basis inverses sent with proof.
+             * For Li(y)_numerator{i = [start..(start+num_polys))}:
+             * Li(y)_numerator = w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys})))
+             * Li(y)_denominator = (num_polys * (h^{(2*num_polys)-1}-(h^{num_polys-1} * h_s^{num_polys})) * (y-(h*w_i)))
+             * Li(y) = Li(y)_numerator / Li(y)_denominator =  (w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys})))) / (num_polys * (h^{(2*num_polys)-1}-(h^{num_polys-1} * h_s^{num_polys})) * (y-(h*w_i)))
+             *
+             * For Li(y)_numerator{i = [(start+num_polys)..(start+(2*num_polys)))}
+             * Li(y)_numerator = w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys})))
+             * Li(y)_denominator = (num_polys * (h_s^{(2*num_polys)-1}-(h_s^{num_polys-1} * h^{num_polys})) * (y-(h_s*w_i)))
+             * Li(y) = Li(y)_numerator / Li(y)_denominator =  (w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys}))) ) / (num_polys * (h_s^{(2*num_polys)-1}-(h_s^{num_polys-1} * h^{num_polys})) * (y-(h_s*w_i)))
+             *
+             * Also calculates the products of the denominators of the lagrange basis evaluations:
+             * Li(y)_denominators_product = Li(y)_previous_denominators_product * (∏(Li(y)_denominator {i = [start..(start+num_polys))})) * (∏(Li(y)_denominator {i = [(start+num_polys)..(start+(2*num_polys)))}))
+             */
+
+            function precompute_partial_lagrange_basis_evaluations_for_union_set(
+                start,
+                num_polys,
+                y,
+                omega,
+                h,
+                h_shifted,
+                interim_product
+            ) -> final_product {
+                if gt(add(start, mul(2, num_polys)), TOTAL_LAGRANGE_BASIS_INVERSES_LENGTH) {
+                    revertWithMessage(32, "Precompute Eval. Error [PLBEIU1]")
+                }
+
+                let constant_parts_0, constant_parts_1, t_0, t_1 := temp_name_inner_function(num_polys, h, h_shifted)
 
                 let current_omega := 1
-                let interim_product := product
                 for {
                     let i := 0
                 } lt(i, num_polys) {

--- a/l1-contracts/contracts/state-transition/verifiers/L2VerifierFflonk.sol
+++ b/l1-contracts/contracts/state-transition/verifiers/L2VerifierFflonk.sol
@@ -114,7 +114,7 @@ contract L2VerifierFflonk is IVerifierV2 {
     uint256 internal constant PROOF_EVALUATIONS_LENGTH = 15;
     uint256 internal constant TOTAL_LAGRANGE_BASIS_INVERSES_LENGTH = 18;
 
-        /// @inheritdoc IVerifierV2
+    /// @inheritdoc IVerifierV2
     function verificationKeyHash() external pure returns (bytes32) {
         return
             keccak256(

--- a/l1-contracts/package.json
+++ b/l1-contracts/package.json
@@ -67,7 +67,7 @@
     "test:fork": "TEST_CONTRACTS_FORK=1 yarn run hardhat test test/unit_tests/*.fork.ts --network hardhat",
     "test:invariant:l1-context": "WHERE=L1 scripts/run-invariant-tests",
     "test:invariant:l2-context": "WHERE=L2 scripts/run-invariant-tests",
-    "coverage:foundry": "forge coverage --ffi --match-path 'test/foundry/l1/*' --no-match-coverage 'contracts/(bridge/.*L2.*\\.sol|governance/L2AdminFactory\\.sol)' --no-match-test test_MainnetFork",
+    "coverage:foundry": "forge coverage --ffi --match-path 'test/foundry/l1/*' --no-match-coverage 'contracts/(bridge/.*L2.*\\.sol|governance/L2AdminFactory\\.sol|state-transition/L2TestnetVerifier\\.sol|state-transition/L2Verifier\\.sol)' --no-match-test 'test_StageProofsForkScriptBased|test_StageProofsForkFileBased|test_MainnetFork'",
     "deploy-no-build": "ts-node scripts/deploy.ts",
     "register-zk-chain": "ts-node scripts/register-zk-chain.ts",
     "deploy-weth-bridges": "ts-node scripts/deploy-weth-bridges.ts",

--- a/l1-contracts/package.json
+++ b/l1-contracts/package.json
@@ -67,7 +67,7 @@
     "test:fork": "TEST_CONTRACTS_FORK=1 yarn run hardhat test test/unit_tests/*.fork.ts --network hardhat",
     "test:invariant:l1-context": "WHERE=L1 scripts/run-invariant-tests",
     "test:invariant:l2-context": "WHERE=L2 scripts/run-invariant-tests",
-    "coverage:foundry": "forge coverage --ffi --match-path 'test/foundry/l1/*' --no-match-coverage 'contracts/(bridge/.*L2.*\\.sol|governance/L2AdminFactory\\.sol|state-transition/L2TestnetVerifier\\.sol|state-transition/L2Verifier\\.sol)' --no-match-test 'test_StageProofsForkScriptBased|test_StageProofsForkFileBased|test_MainnetFork'",
+    "coverage:foundry": "forge coverage --ffi --match-path 'test/foundry/l1/*' --no-match-coverage 'contracts/(bridge/.*L2.*\\.sol|governance/L2AdminFactory\\.sol|state-transition/L2TestnetVerifier\\.sol|state-transition/L2Verifier\\.sol|state-transition/verifiers/.*\\.sol)' --no-match-test 'test_StageProofsForkScriptBased|test_StageProofsForkFileBased|test_MainnetFork'",
     "deploy-no-build": "ts-node scripts/deploy.ts",
     "register-zk-chain": "ts-node scripts/register-zk-chain.ts",
     "deploy-weth-bridges": "ts-node scripts/deploy-weth-bridges.ts",

--- a/l1-contracts/package.json
+++ b/l1-contracts/package.json
@@ -67,7 +67,7 @@
     "test:fork": "TEST_CONTRACTS_FORK=1 yarn run hardhat test test/unit_tests/*.fork.ts --network hardhat",
     "test:invariant:l1-context": "WHERE=L1 scripts/run-invariant-tests",
     "test:invariant:l2-context": "WHERE=L2 scripts/run-invariant-tests",
-    "coverage:foundry": "forge coverage --ffi --match-path 'test/foundry/l1/*' --no-match-coverage 'contracts/(bridge/.*L2.*\\.sol|governance/L2AdminFactory\\.sol|state-transition/L2TestnetVerifier\\.sol|state-transition/L2Verifier\\.sol)' --no-match-test 'test_StageProofsForkScriptBased|test_StageProofsForkFileBased'",
+    "coverage:foundry": "forge coverage --ffi --match-path 'test/foundry/l1/*' --no-match-coverage 'contracts/(bridge/.*L2.*\\.sol|governance/L2AdminFactory\\.sol)' --no-match-test test_MainnetFork",
     "deploy-no-build": "ts-node scripts/deploy.ts",
     "register-zk-chain": "ts-node scripts/register-zk-chain.ts",
     "deploy-weth-bridges": "ts-node scripts/deploy-weth-bridges.ts",

--- a/tools/data/fflonk_verifier_contract_template.txt
+++ b/tools/data/fflonk_verifier_contract_template.txt
@@ -98,8 +98,8 @@ contract VerifierFflonk is IVerifierV2 {
     uint256 internal constant PROOF_EVALUATIONS_LENGTH = 15;
     uint256 internal constant TOTAL_LAGRANGE_BASIS_INVERSES_LENGTH = 18;
 
-    /// @inheritdoc IVerifierV2
-    function verificationKeyHash() external pure returns (bytes32 vkHash) {
+        /// @inheritdoc IVerifierV2
+    function verificationKeyHash() external pure returns (bytes32) {
         return
             keccak256(
                 // solhint-disable-next-line func-named-parameters
@@ -109,15 +109,25 @@ contract VerifierFflonk is IVerifierV2 {
                     VK_C0_G1_Y,
                     VK_NON_RESIDUES_0,
                     VK_NON_RESIDUES_1,
-                    VK_G2_ELEMENT_0_X1,
-                    VK_G2_ELEMENT_0_X2,
-                    VK_G2_ELEMENT_0_Y1,
-                    VK_G2_ELEMENT_0_Y2,
-                    VK_G2_ELEMENT_1_X1,
-                    VK_G2_ELEMENT_1_X2,
-                    VK_G2_ELEMENT_1_Y1,
-                    VK_G2_ELEMENT_1_Y2
+                    _getG2Elements()
                 )
+            );
+    }
+
+    /// @dev This breakdown is done to avoid stack-too-deep error
+    /// @return bytes memory The G2 elements
+    function _getG2Elements() internal pure returns (bytes memory) {
+        return
+            // solhint-disable-next-line func-named-parameters
+            abi.encodePacked(
+                VK_G2_ELEMENT_0_X1,
+                VK_G2_ELEMENT_0_X2,
+                VK_G2_ELEMENT_0_Y1,
+                VK_G2_ELEMENT_0_Y2,
+                VK_G2_ELEMENT_1_X1,
+                VK_G2_ELEMENT_1_X2,
+                VK_G2_ELEMENT_1_Y1,
+                VK_G2_ELEMENT_1_Y2
             );
     }
 
@@ -509,33 +519,9 @@ contract VerifierFflonk is IVerifierV2 {
             }
 
             /**
-             * @dev Computes partial lagrange basis evaluations Li(y)_numerator = {i = [start..(start+num_polys))} & Li(y)_numerator {i = [(start+num_polys)..(start+(2*num_polys)))} using montgomery lagrange basis inverses sent with proof.
-             * For Li(y)_numerator{i = [start..(start+num_polys))}:
-             * Li(y)_numerator = w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys})))
-             * Li(y)_denominator = (num_polys * (h^{(2*num_polys)-1}-(h^{num_polys-1} * h_s^{num_polys})) * (y-(h*w_i)))
-             * Li(y) = Li(y)_numerator / Li(y)_denominator =  (w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys})))) / (num_polys * (h^{(2*num_polys)-1}-(h^{num_polys-1} * h_s^{num_polys})) * (y-(h*w_i)))
-             *
-             * For Li(y)_numerator{i = [(start+num_polys)..(start+(2*num_polys)))}
-             * Li(y)_numerator = w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys})))
-             * Li(y)_denominator = (num_polys * (h_s^{(2*num_polys)-1}-(h_s^{num_polys-1} * h^{num_polys})) * (y-(h_s*w_i)))
-             * Li(y) = Li(y)_numerator / Li(y)_denominator =  (w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys}))) ) / (num_polys * (h_s^{(2*num_polys)-1}-(h_s^{num_polys-1} * h^{num_polys})) * (y-(h_s*w_i)))
-             *
-             * Also calculates the products of the denominators of the lagrange basis evaluations:
-             * Li(y)_denominators_product = Li(y)_previous_denominators_product * (∏(Li(y)_denominator {i = [start..(start+num_polys))})) * (∏(Li(y)_denominator {i = [(start+num_polys)..(start+(2*num_polys)))}))
+             * sma: TODO add description
              */
-
-            function precompute_partial_lagrange_basis_evaluations_for_union_set(
-                start,
-                num_polys,
-                y,
-                omega,
-                h,
-                h_shifted,
-                product
-            ) -> final_product {
-                if gt(add(start, mul(2, num_polys)), TOTAL_LAGRANGE_BASIS_INVERSES_LENGTH) {
-                    revertWithMessage(32, "Precompute Eval. Error [PLBEIU1]")
-                }
+            function temp_name_inner_function(num_polys, h, h_shifted) -> constant_parts_0, constant_parts_1, t_0, t_1 {
                 let h_pows_0 := h
                 let h_pows_1 := h_shifted
                 let loop_length := sub(num_polys, 2)
@@ -548,8 +534,8 @@ contract VerifierFflonk is IVerifierV2 {
                     h_pows_0 := mulmod(h_pows_0, h, R_MOD)
                     h_pows_1 := mulmod(h_pows_1, h_shifted, R_MOD)
                 }
-                let constant_parts_0 := h_pows_0
-                let constant_parts_1 := h_pows_1
+                constant_parts_0 := h_pows_0
+                constant_parts_1 := h_pows_1
                 // h^{num_polys}
                 h_pows_0 := mulmod(h_pows_0, h, R_MOD)
                 // h_s^{num_polys}
@@ -567,9 +553,9 @@ contract VerifierFflonk is IVerifierV2 {
                 // y^{num_polys}
                 let t_2 := mload(add(OPS_Y_POWS, mul(num_polys, 0x20)))
                 // h^{num_polys} * h_s^{num_polys}
-                let t_1 := mulmod(h_pows_0, h_pows_1, R_MOD)
+                t_1 := mulmod(h_pows_0, h_pows_1, R_MOD)
                 // h^{num_polys} + h_s^{num_polys}
-                let t_0 := addmod(h_pows_0, h_pows_1, R_MOD)
+                t_0 := addmod(h_pows_0, h_pows_1, R_MOD)
                 // y^{num_polys} * (h^{num_polys} + h_s^{num_polys})
                 t_0 := mulmod(t_0, t_2, R_MOD)
                 // - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys}))
@@ -598,9 +584,40 @@ contract VerifierFflonk is IVerifierV2 {
                 constant_parts_1 := addmod(constant_parts_1, h_pows_1, R_MOD)
                 // num_polys * (h_s^{(2*num_polys)-1}-(h_s^{num_polys-1} * h^{num_polys}))
                 constant_parts_1 := mulmod(constant_parts_1, num_polys, R_MOD)
+            }
+
+            /**
+             * @dev Computes partial lagrange basis evaluations Li(y)_numerator = {i = [start..(start+num_polys))} & Li(y)_numerator {i = [(start+num_polys)..(start+(2*num_polys)))} using montgomery lagrange basis inverses sent with proof.
+             * For Li(y)_numerator{i = [start..(start+num_polys))}:
+             * Li(y)_numerator = w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys})))
+             * Li(y)_denominator = (num_polys * (h^{(2*num_polys)-1}-(h^{num_polys-1} * h_s^{num_polys})) * (y-(h*w_i)))
+             * Li(y) = Li(y)_numerator / Li(y)_denominator =  (w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys})))) / (num_polys * (h^{(2*num_polys)-1}-(h^{num_polys-1} * h_s^{num_polys})) * (y-(h*w_i)))
+             *
+             * For Li(y)_numerator{i = [(start+num_polys)..(start+(2*num_polys)))}
+             * Li(y)_numerator = w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys})))
+             * Li(y)_denominator = (num_polys * (h_s^{(2*num_polys)-1}-(h_s^{num_polys-1} * h^{num_polys})) * (y-(h_s*w_i)))
+             * Li(y) = Li(y)_numerator / Li(y)_denominator =  (w_i * (y^{2*num_polys} + (h^{num_polys} * h_s^{num_polys}) - (y^{num_polys} * (h^{num_polys} + h_s^{num_polys}))) ) / (num_polys * (h_s^{(2*num_polys)-1}-(h_s^{num_polys-1} * h^{num_polys})) * (y-(h_s*w_i)))
+             *
+             * Also calculates the products of the denominators of the lagrange basis evaluations:
+             * Li(y)_denominators_product = Li(y)_previous_denominators_product * (∏(Li(y)_denominator {i = [start..(start+num_polys))})) * (∏(Li(y)_denominator {i = [(start+num_polys)..(start+(2*num_polys)))}))
+             */
+
+            function precompute_partial_lagrange_basis_evaluations_for_union_set(
+                start,
+                num_polys,
+                y,
+                omega,
+                h,
+                h_shifted,
+                interim_product
+            ) -> final_product {
+                if gt(add(start, mul(2, num_polys)), TOTAL_LAGRANGE_BASIS_INVERSES_LENGTH) {
+                    revertWithMessage(32, "Precompute Eval. Error [PLBEIU1]")
+                }
+
+                let constant_parts_0, constant_parts_1, t_0, t_1 := temp_name_inner_function(num_polys, h, h_shifted)
 
                 let current_omega := 1
-                let interim_product := product
                 for {
                     let i := 0
                 } lt(i, num_polys) {

--- a/tools/data/fflonk_verifier_contract_template.txt
+++ b/tools/data/fflonk_verifier_contract_template.txt
@@ -98,7 +98,7 @@ contract VerifierFflonk is IVerifierV2 {
     uint256 internal constant PROOF_EVALUATIONS_LENGTH = 15;
     uint256 internal constant TOTAL_LAGRANGE_BASIS_INVERSES_LENGTH = 18;
 
-        /// @inheritdoc IVerifierV2
+    /// @inheritdoc IVerifierV2
     function verificationKeyHash() external pure returns (bytes32) {
         return
             keccak256(


### PR DESCRIPTION
# What ❔

Un-stacked FFLONK (removed stack-too-deep issue when running coverage).

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Coverage CI is temporarily removed since v27.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
