### PR TITLE
fix: allow createEVM/create2EVM system calls

### DIFF
--- a/AllContractsHashes.json
+++ b/AllContractsHashes.json
@@ -1706,7 +1706,7 @@
   {
     "contractName": "Bootloader",
     "zkBytecodePath": "/system-contracts/zkout/bootloader_test.yul/Bootloader.json",
-    "zkBytecodeHash": "0x0100040fa519d96bb7cdc15ad15b09e618f9a1bb48dfe9b29893bb7ee8873f81",
+    "zkBytecodeHash": "0x010004133522d1933f2161a6dab347ea5afbfa19068a84c95ee5b1637fd863a2",
     "evmBytecodePath": null,
     "evmBytecodeHash": null,
     "evmDeployedBytecodeHash": null
@@ -1722,7 +1722,7 @@
   {
     "contractName": "Bootloader",
     "zkBytecodePath": "/system-contracts/zkout/fee_estimate.yul/Bootloader.json",
-    "zkBytecodeHash": "0x010008e388ee6d97ca3f6ae5ed0237ace060dc42ee92c4783b3972516e976243",
+    "zkBytecodeHash": "0x010008e7307e11ead68f2cc251202724991514d0339105270d42ad6810c4bb3b",
     "evmBytecodePath": null,
     "evmBytecodeHash": null,
     "evmDeployedBytecodeHash": null
@@ -1730,7 +1730,7 @@
   {
     "contractName": "Bootloader",
     "zkBytecodePath": "/system-contracts/zkout/gas_test.yul/Bootloader.json",
-    "zkBytecodeHash": "0x0100084f4c5856f10ed02250013013ba186c399c68b43f436cc796871d31eaec",
+    "zkBytecodeHash": "0x01000853ac39b8cd30fe3487716d8bfbd4194bfada28ada2409970b9aa850ba7",
     "evmBytecodePath": null,
     "evmBytecodeHash": null,
     "evmDeployedBytecodeHash": null
@@ -1738,7 +1738,7 @@
   {
     "contractName": "Bootloader",
     "zkBytecodePath": "/system-contracts/zkout/playground_batch.yul/Bootloader.json",
-    "zkBytecodeHash": "0x010008e791b10831b7f31015a750adf937e80ed1b60dd62bb487e88925b52161",
+    "zkBytecodeHash": "0x010008ed7bb367c8f28cc76217487a848c18d07090428d45467eb89bfc55b28b",
     "evmBytecodePath": null,
     "evmBytecodeHash": null,
     "evmDeployedBytecodeHash": null
@@ -1746,7 +1746,7 @@
   {
     "contractName": "Bootloader",
     "zkBytecodePath": "/system-contracts/zkout/proved_batch.yul/Bootloader.json",
-    "zkBytecodeHash": "0x0100085f9382a7928dd83bfc529121827b5f29f18b9aa10d18aa68e1be7ddc35",
+    "zkBytecodeHash": "0x0100086360ea7c87d9f20a2d94ed2dc1027570540308bfb1ba023e089cdd76f3",
     "evmBytecodePath": null,
     "evmBytecodeHash": null,
     "evmDeployedBytecodeHash": null

--- a/system-contracts/bootloader/bootloader.yul
+++ b/system-contracts/bootloader/bootloader.yul
@@ -2000,11 +2000,13 @@ object "Bootloader" {
                     eq(selector, {{CREATE2_SELECTOR}}),
                     eq(selector, {{CREATE2_ACCOUNT_SELECTOR}})
                 )
+                let isSelectorCreateEVM := eq(selector, {{CREATE_EVM_SELECTOR}})
+                let isSelectorCreate2EVM := eq(selector, {{CREATE2_EVM_SELECTOR}})
 
                 // Firstly, ensure that the selector is a valid deployment function
                 ret := or(
-                    isSelectorCreate,
-                    isSelectorCreate2
+                    or(isSelectorCreate, isSelectorCreate2),
+                    or(isSelectorCreateEVM, isSelectorCreate2EVM)
                 )
                 // Secondly, ensure that the callee is ContractDeployer
                 ret := and(ret, eq(to, CONTRACT_DEPLOYER_ADDR()))

--- a/system-contracts/scripts/preprocess-bootloader.ts
+++ b/system-contracts/scripts/preprocess-bootloader.ts
@@ -90,6 +90,8 @@ const params = {
   GET_TX_HASHES_SELECTOR: getSelector("BootloaderUtilities", "getTransactionHashes"),
   CREATE_SELECTOR: getSelector("ContractDeployer", "create"),
   CREATE2_SELECTOR: getSelector("ContractDeployer", "create2"),
+  CREATE_EVM_SELECTOR: getSelector("ContractDeployer", "createEVM"),
+  CREATE2_EVM_SELECTOR: getSelector("ContractDeployer", "create2EVM"),
   CREATE_ACCOUNT_SELECTOR: getSelector("ContractDeployer", "createAccount"),
   CREATE2_ACCOUNT_SELECTOR: getSelector("ContractDeployer", "create2Account"),
   PADDED_TRANSFER_FROM_TO_SELECTOR: getPaddedSelector("L2BaseToken", "transferFromTo"),


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
Fix for an issue that disallowed `createEVM`/`create2EVM` calls to `ContractDeployer`.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
Currently, calls to `createEVM`/`create2EVM` will always fail, because the system call flag isn't applied on a call to those functions.
This PR is intended to gain the ability to call them.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
