### PR TITLE
feat: add verification of of protocolVersion in setUpgradeTimestamp

### DIFF
--- a/AllContractsHashes.json
+++ b/AllContractsHashes.json
@@ -817,11 +817,11 @@
   },
   {
     "contractName": "l1-contracts/ChainAdmin",
-    "zkBytecodeHash": "0x0100019b56a2222257811ea4417aacbce9359c507739843043458eafa100a06d",
+    "zkBytecodeHash": "0x010001b17e319b8d66255ba940c6f1833fc1b05e8862bebe7a254e706949e8fd",
     "zkBytecodePath": "/l1-contracts/zkout/ChainAdmin.sol/ChainAdmin.json",
-    "evmBytecodeHash": "0xafbe1a47500aa2431105e02da9c3e3d132110ef7850de9980d67cac8e4c903bb",
+    "evmBytecodeHash": "0x587c46f6e13429245ec3bc09a08a1888098ba322664c76ceb6004120a1c5168f",
     "evmBytecodePath": "/l1-contracts/out/ChainAdmin.sol/ChainAdmin.json",
-    "evmDeployedBytecodeHash": "0x2b9df716933087a432c54ee8af87762b4d1c231f9dda000168b3653e5bd19252"
+    "evmDeployedBytecodeHash": "0x8db736432f243d5b45667a154a5ecf910f31eac2ca750eebf5a3d5a4010ee898"
   },
   {
     "contractName": "l1-contracts/ChainAdminOwnable",
@@ -1089,11 +1089,11 @@
   },
   {
     "contractName": "l1-contracts/L2AdminFactory",
-    "zkBytecodeHash": "0x010000bbb7921ecf206d804c765cab8435b1196c3ed7960d342a571be361083c",
+    "zkBytecodeHash": "0x010000bb0cd7b22e93abc3ac6e7a3b87b960aa0e0afe7e3e40522ae61f4ef17d",
     "zkBytecodePath": "/l1-contracts/zkout/L2AdminFactory.sol/L2AdminFactory.json",
-    "evmBytecodeHash": "0x17dfce6e49a9a578caef09d472b1ed996e8c45a9a8fdb770d60726fddfdfdc04",
+    "evmBytecodeHash": "0xa0a7ce5f88b000cfa6ad6aae5284bc84c572cca59e320913d6cf0ee4f5d78d8e",
     "evmBytecodePath": "/l1-contracts/out/L2AdminFactory.sol/L2AdminFactory.json",
-    "evmDeployedBytecodeHash": "0x22e0b2bcd5301491c61e691e3e6e6ff868ad05ed74ff3abcd6b801a62418c4dd"
+    "evmDeployedBytecodeHash": "0x6fb20ba4e21f62880ab60d6d4d5cca5a7b78cab4d3669b5400dad1d2380749d1"
   },
   {
     "contractName": "l1-contracts/L2AssetRouter",

--- a/l1-contracts/contracts/dev-contracts/DummyChainTypeManager.sol
+++ b/l1-contracts/contracts/dev-contracts/DummyChainTypeManager.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.28;
+
+contract DummyChainTypeManager {
+    constructor() {}
+
+    mapping(uint256 _protocolVersion => uint256) public protocolVersionDeadline;
+
+    function setProtocolVersionDeadline(uint256 _protocolVersion, uint256 _timestamp) external {
+        protocolVersionDeadline[_protocolVersion] = _timestamp;
+    }
+
+    function protocolVersionIsActive(uint256 _protocolVersion) external view returns (bool) {
+        return block.timestamp <= protocolVersionDeadline[_protocolVersion];
+    }
+}

--- a/l1-contracts/contracts/governance/ChainAdmin.sol
+++ b/l1-contracts/contracts/governance/ChainAdmin.sol
@@ -4,11 +4,12 @@ pragma solidity 0.8.28;
 
 // solhint-disable gas-length-in-loops
 
-import {NoCallsProvided, OnlySelfAllowed, RestrictionWasNotPresent, RestrictionWasAlreadyPresent} from "../common/L1ContractErrors.sol";
+import {InvalidProtocolVersion, NoCallsProvided, OnlySelfAllowed, RestrictionWasNotPresent, RestrictionWasAlreadyPresent} from "../common/L1ContractErrors.sol";
 import {IChainAdmin} from "./IChainAdmin.sol";
 import {Restriction} from "./restriction/Restriction.sol";
 import {RestrictionValidator} from "./restriction/RestrictionValidator.sol";
 import {Call} from "./Common.sol";
+import {IChainTypeManager} from "../state-transition/IChainTypeManager.sol";
 
 import {EnumerableSet} from "@openzeppelin/contracts-v4/utils/structs/EnumerableSet.sol";
 import {ReentrancyGuard} from "../common/ReentrancyGuard.sol";
@@ -75,7 +76,15 @@ contract ChainAdmin is IChainAdmin, ReentrancyGuard {
     /// @notice Set the expected upgrade timestamp for a specific protocol version.
     /// @param _protocolVersion The ZKsync chain protocol version.
     /// @param _upgradeTimestamp The timestamp at which the chain node should expect the upgrade to happen.
-    function setUpgradeTimestamp(uint256 _protocolVersion, uint256 _upgradeTimestamp) external onlySelf {
+    /// @param _chainTypeManager ChainTypeManager address used to check if the protocol version is active. Included for the convenience of the Chain Admin.
+    function setUpgradeTimestamp(
+        uint256 _protocolVersion,
+        uint256 _upgradeTimestamp,
+        address _chainTypeManager
+    ) external onlySelf {
+        if (!IChainTypeManager(_chainTypeManager).protocolVersionIsActive(_protocolVersion)) {
+            revert InvalidProtocolVersion();
+        }
         protocolVersionToUpgradeTimestamp[_protocolVersion] = _upgradeTimestamp;
         emit UpdateUpgradeTimestamp(_protocolVersion, _upgradeTimestamp);
     }

--- a/l1-contracts/test/foundry/l1/unit/concrete/Governance/ChainAdmin.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/Governance/ChainAdmin.t.sol
@@ -12,12 +12,15 @@ import {Call} from "contracts/governance/Common.sol";
 import {DummyRestriction} from "contracts/dev-contracts/DummyRestriction.sol";
 import {NotARestriction, NoCallsProvided, RestrictionWasAlreadyPresent, RestrictionWasNotPresent, AccessToFallbackDenied, AccessToFunctionDenied} from "contracts/common/L1ContractErrors.sol";
 import {Utils} from "test/foundry/l1/unit/concrete/Utils/Utils.sol";
+import {DummyChainTypeManager} from "contracts/dev-contracts/DummyChainTypeManager.sol";
+import {Diamond} from "contracts/state-transition/libraries/Diamond.sol";
 
 contract ChainAdminTest is Test {
     ChainAdmin internal chainAdmin;
     AccessControlRestriction internal restriction;
     GettersFacet internal gettersFacet;
     DummyRestriction internal dummyRestriction;
+    DummyChainTypeManager internal dummyChainTypeManager;
 
     address internal owner;
     uint32 internal major;
@@ -36,6 +39,7 @@ contract ChainAdminTest is Test {
 
         gettersFacet = new GettersFacet();
         dummyRestriction = new DummyRestriction(true);
+        dummyChainTypeManager = new DummyChainTypeManager();
     }
 
     function test_getRestrictions() public {
@@ -120,11 +124,13 @@ contract ChainAdminTest is Test {
         (major, minor, patch) = gettersFacet.getSemverProtocolVersion();
         uint256 protocolVersion = packSemver(major, minor, patch + 1, semverMinorVersionMultiplier);
 
+        dummyChainTypeManager.setProtocolVersionDeadline(protocolVersion, block.timestamp + 42);
+
         vm.expectEmit(true, false, false, true);
         emit IChainAdmin.UpdateUpgradeTimestamp(protocolVersion, timestamp);
 
         vm.prank(address(chainAdmin));
-        chainAdmin.setUpgradeTimestamp(protocolVersion, timestamp, gettersFacet.getChainTypeManager());
+        chainAdmin.setUpgradeTimestamp(protocolVersion, timestamp, address(dummyChainTypeManager));
     }
 
     function test_multicallRevertNoCalls() public {

--- a/l1-contracts/test/foundry/l1/unit/concrete/Governance/ChainAdmin.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/Governance/ChainAdmin.t.sol
@@ -124,7 +124,7 @@ contract ChainAdminTest is Test {
         emit IChainAdmin.UpdateUpgradeTimestamp(protocolVersion, timestamp);
 
         vm.prank(address(chainAdmin));
-        chainAdmin.setUpgradeTimestamp(protocolVersion, timestamp);
+        chainAdmin.setUpgradeTimestamp(protocolVersion, timestamp, gettersFacet.getChainTypeManager());
     }
 
     function test_multicallRevertNoCalls() public {


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
`ChainTypeManager` address was added as a parameter to `setUpgradeTimestamp` function in `ChainAdmin` contract.
It's used to verify whether protocol version parameter in `setUpgradeTimestamp` is indeed active.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
It's being included as a quality-of-life improvement for chain admins, that verifies whether protocol version they specified is valid, and reverts with `InvalidProtocolVersion` error if not.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
