### PR TITLE
Add setUpgradeTimestamp and protocol version verification in ServerNotifier.

### DIFF
--- a/AllContractsHashes.json
+++ b/AllContractsHashes.json
@@ -985,11 +985,11 @@
   },
   {
     "contractName": "l1-contracts/GatewayCTMDeployer",
-    "zkBytecodeHash": "0x010003bf3cdc412828f67cb6cfa032e398c07429d9a524db0e1ec44de75a7301",
+    "zkBytecodeHash": "0x010003bf255eae2e8df6954978f1e55c54bda432b461550b4e4cf1b2a8565b00",
     "zkBytecodePath": "/l1-contracts/zkout/GatewayCTMDeployer.sol/GatewayCTMDeployer.json",
-    "evmBytecodeHash": "0xba92824b7788fbe5a715844d87737bd5e299313ce330c0f3cf2fd2021278929f",
+    "evmBytecodeHash": "0x0685c0e165718599bce64ef514b3af1e45850ef76f6f6ca245c4c91fe8cc14d4",
     "evmBytecodePath": "/l1-contracts/out/GatewayCTMDeployer.sol/GatewayCTMDeployer.json",
-    "evmDeployedBytecodeHash": "0x4650c36ad1fc30cfd760836d3397db8de4e172bf165eae295ea6d57790746f10"
+    "evmDeployedBytecodeHash": "0x92a9b667010fcf8515a52e778e3ac07531271a393c4a1ef2eb162d4ba36b8dc1"
   },
   {
     "contractName": "l1-contracts/GatewayTransactionFilterer",
@@ -1321,11 +1321,11 @@
   },
   {
     "contractName": "l1-contracts/ServerNotifier",
-    "zkBytecodeHash": "0x010000b964c383988287a72c8aec2b62336450392de49c28a3d41bf6e1a98ba8",
+    "zkBytecodeHash": "0x010000e7a21386bb420dd2291364b60d98d61615546c04ccd752c931c6aba38e",
     "zkBytecodePath": "/l1-contracts/zkout/ServerNotifier.sol/ServerNotifier.json",
-    "evmBytecodeHash": "0x02b4766fb8eeae314178ef9600f126ed6cd4116a8bbcd72b83d5852cc5a66c1d",
+    "evmBytecodeHash": "0x83875c0bd5dd77ad0c47d4bb270ed8ffe6002cf1215d99b3ebb7fd0e0383a261",
     "evmBytecodePath": "/l1-contracts/out/ServerNotifier.sol/ServerNotifier.json",
-    "evmDeployedBytecodeHash": "0x81aed7981c4bac998d37e0f47a59317dba5a3a501c83b21ea6f6eaab3cdaac45"
+    "evmDeployedBytecodeHash": "0xe161ec1e28549d02a11c0791f929b14df208e3a899a8c21f3bdb007f98ddf873"
   },
   {
     "contractName": "l1-contracts/SignedMath",

--- a/AllContractsHashes.json
+++ b/AllContractsHashes.json
@@ -985,11 +985,11 @@
   },
   {
     "contractName": "l1-contracts/GatewayCTMDeployer",
-    "zkBytecodeHash": "0x010003bf255eae2e8df6954978f1e55c54bda432b461550b4e4cf1b2a8565b00",
+    "zkBytecodeHash": "0x010003bfc2e171a8f070963f586452756895eb52889bf93406ecb29316fa19c7",
     "zkBytecodePath": "/l1-contracts/zkout/GatewayCTMDeployer.sol/GatewayCTMDeployer.json",
-    "evmBytecodeHash": "0x0685c0e165718599bce64ef514b3af1e45850ef76f6f6ca245c4c91fe8cc14d4",
+    "evmBytecodeHash": "0xb1469d70a3559d2408b8f47eac017c1dc36f00170a5bf0731044db205a7519ff",
     "evmBytecodePath": "/l1-contracts/out/GatewayCTMDeployer.sol/GatewayCTMDeployer.json",
-    "evmDeployedBytecodeHash": "0x92a9b667010fcf8515a52e778e3ac07531271a393c4a1ef2eb162d4ba36b8dc1"
+    "evmDeployedBytecodeHash": "0x6efd150d49f24d92bda8d7421bdc4f2a35284780f56523555207d961a12acc2b"
   },
   {
     "contractName": "l1-contracts/GatewayTransactionFilterer",
@@ -1321,11 +1321,11 @@
   },
   {
     "contractName": "l1-contracts/ServerNotifier",
-    "zkBytecodeHash": "0x010000e7a21386bb420dd2291364b60d98d61615546c04ccd752c931c6aba38e",
+    "zkBytecodeHash": "0x010000ff57f5e4bd11b7df94b4ce1636fae774427d9ae387484177a3e145db5a",
     "zkBytecodePath": "/l1-contracts/zkout/ServerNotifier.sol/ServerNotifier.json",
-    "evmBytecodeHash": "0x83875c0bd5dd77ad0c47d4bb270ed8ffe6002cf1215d99b3ebb7fd0e0383a261",
+    "evmBytecodeHash": "0x9638c0ac891a1f85bf20642e53028b0db9aab52dd09b56742b2210b41f1b5ee3",
     "evmBytecodePath": "/l1-contracts/out/ServerNotifier.sol/ServerNotifier.json",
-    "evmDeployedBytecodeHash": "0xe161ec1e28549d02a11c0791f929b14df208e3a899a8c21f3bdb007f98ddf873"
+    "evmDeployedBytecodeHash": "0xae02215e3ec804d4d1d6f491fccbf6a94fd1b38fee956be080c4e832f7e28b26"
   },
   {
     "contractName": "l1-contracts/SignedMath",

--- a/l1-contracts/contracts/governance/ServerNotifier.sol
+++ b/l1-contracts/contracts/governance/ServerNotifier.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import {Ownable2Step} from "@openzeppelin/contracts-v4/access/Ownable2Step.sol";
 import {Initializable} from "@openzeppelin/contracts-v4/proxy/utils/Initializable.sol";
-import {ZeroAddress, Unauthorized} from "../common/L1ContractErrors.sol";
+import {InvalidProtocolVersion, ZeroAddress, Unauthorized} from "../common/L1ContractErrors.sol";
 import {ReentrancyGuard} from "../common/ReentrancyGuard.sol";
 import {IChainTypeManager} from "../state-transition/IChainTypeManager.sol";
 
@@ -87,6 +87,7 @@ contract ServerNotifier is Ownable2Step, ReentrancyGuard, Initializable {
         uint256 _protocolVersion,
         uint256 _upgradeTimestamp
     ) external onlyChainAdmin(_chainId) {
+        require(chainTypeManager.protocolVersionIsActive(_protocolVersion), InvalidProtocolVersion());
         protocolVersionToUpgradeTimestamp[_chainId][_protocolVersion] = _upgradeTimestamp;
         emit UpgradeTimestampUpdated(_chainId, _protocolVersion, _upgradeTimestamp);
     }

--- a/l1-contracts/contracts/governance/ServerNotifier.sol
+++ b/l1-contracts/contracts/governance/ServerNotifier.sol
@@ -7,11 +7,31 @@ import {ZeroAddress, Unauthorized} from "../common/L1ContractErrors.sol";
 import {ReentrancyGuard} from "../common/ReentrancyGuard.sol";
 import {IChainTypeManager} from "../state-transition/IChainTypeManager.sol";
 
+/// @title ServerNotifier contract
+/// @author Matter Labs
+/// @custom:security-contact security@matterlabs.dev
+/// @notice The contract is designed to notify the server about migrations and protocol upgrade schedules.
 contract ServerNotifier is Ownable2Step, ReentrancyGuard, Initializable {
+    /// @dev Address of the ChainTypeManager smart contract.
     IChainTypeManager public chainTypeManager;
 
+    /// @notice Emitted when a chain is migrated into the gateway.
+    /// @param chainId The ID of the chain being migrated.
     event MigrateToGateway(uint256 indexed chainId);
+
+    /// @notice Emitted when a chain is migrated out of the gateway.
+    /// @param chainId The ID of the chain being migrated.
     event MigrateFromGateway(uint256 indexed chainId);
+
+    /// @notice Emitted whenever an upgrade timestamp is set.
+    /// @param chainId The ID of the chain.
+    /// @param protocolVersion The protocol version being scheduled.
+    /// @param upgradeTimestamp UNIX timestamp when the upgrade is expected.
+    event UpgradeTimestampUpdated(uint256 indexed chainId, uint256 indexed protocolVersion, uint256 upgradeTimestamp);
+
+    /// @notice Maps each chainId => protocolVersion => expected upgrade timestamp.
+    mapping(uint256 chainId => mapping(uint256 protocolVersion => uint256 upgradeTimestamp))
+        public protocolVersionToUpgradeTimestamp;
 
     /// @notice Checks if the caller is the admin of the chain.
     modifier onlyChainAdmin(uint256 _chainId) {
@@ -27,7 +47,9 @@ contract ServerNotifier is Ownable2Step, ReentrancyGuard, Initializable {
         }
     }
 
-    function initialize(address _admin) public reentrancyGuardInitializer {
+    /// @notice Used to initialize the contract
+    /// @param _admin The owner of the contract
+    function initialize(address _admin) external reentrancyGuardInitializer {
         if (_admin == address(0)) {
             revert ZeroAddress();
         }
@@ -35,6 +57,8 @@ contract ServerNotifier is Ownable2Step, ReentrancyGuard, Initializable {
         _transferOwnership(_admin);
     }
 
+    /// @notice Sets a new chain type manager.
+    /// @param _chainTypeManager The address of new chain type manager.
     function setChainTypeManager(IChainTypeManager _chainTypeManager) external onlyOwner {
         if (address(_chainTypeManager) == address(0)) {
             revert ZeroAddress();
@@ -42,11 +66,28 @@ contract ServerNotifier is Ownable2Step, ReentrancyGuard, Initializable {
         chainTypeManager = IChainTypeManager(_chainTypeManager);
     }
 
+    /// @notice Used to notify server of a chain migation to Gateway.
+    /// @param _chainId The chainId of the ZKsync chain that is getting migrated.
     function migrateToGateway(uint256 _chainId) external onlyChainAdmin(_chainId) {
         emit MigrateToGateway(_chainId);
     }
 
+    /// @notice Used to notify server of a chain migation from Gateway.
+    /// @param _chainId The chainId of the ZKsync chain that is getting migrated.
     function migrateFromGateway(uint256 _chainId) external onlyChainAdmin(_chainId) {
         emit MigrateFromGateway(_chainId);
+    }
+
+    /// @notice Set the expected upgrade timestamp for a specific protocol version. Only allowed to be called by ChainAdmin.
+    /// @param _chainId The chainId of the ZKsync chain for which the upgrade timestamp is being set.
+    /// @param _protocolVersion The ZKsync chain protocol version.
+    /// @param _upgradeTimestamp The timestamp at which the chain node should expect the upgrade to happen.
+    function setUpgradeTimestamp(
+        uint256 _chainId,
+        uint256 _protocolVersion,
+        uint256 _upgradeTimestamp
+    ) external onlyChainAdmin(_chainId) {
+        protocolVersionToUpgradeTimestamp[_chainId][_protocolVersion] = _upgradeTimestamp;
+        emit UpgradeTimestampUpdated(_chainId, _protocolVersion, _upgradeTimestamp);
     }
 }


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
- Add setUpgradeTimestamp with protocolVersionIsActive check to ServerNotifier

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
- Prevent invalid protocol‑version configurations, makes it easier to debug the mistake in scripts/configurations by explicitly throwing an error.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
