### PR TITLE
feat: Use EfficientCall for keccak in pubdata chunk publisher

### DIFF
--- a/system-contracts/contracts/PubdataChunkPublisher.sol
+++ b/system-contracts/contracts/PubdataChunkPublisher.sol
@@ -28,9 +28,10 @@ contract PubdataChunkPublisher is IPubdataChunkPublisher {
         uint256 ptr;
         for (uint256 i = 0; i < blobCount; ++i) {
             if (ptr + BLOB_SIZE_BYTES <= _pubdata.length) {
+                // Pass chunk by pointer since we don't need to pad it
                 blobLinearHashes[i] = EfficientCall.keccak(_pubdata[ptr:ptr + BLOB_SIZE_BYTES]);
             } else {
-                // Pad with zeroes
+                // Copy to memory to pad with zeroes
                 bytes memory blob = new bytes(BLOB_SIZE_BYTES);
                 assembly {
                     calldatacopy(add(0x20, blob), add(_pubdata.offset, ptr), BLOB_SIZE_BYTES)

--- a/system-contracts/contracts/PubdataChunkPublisher.sol
+++ b/system-contracts/contracts/PubdataChunkPublisher.sol
@@ -26,12 +26,8 @@ contract PubdataChunkPublisher is IPubdataChunkPublisher {
         blobLinearHashes = new bytes32[](blobCount);
 
         uint256 ptr;
-        assembly {
-            ptr := _pubdata.offset
-        }
-
         for (uint256 i = 0; i < blobCount; ++i) {
-            blobLinearHashes[i] = EfficientCall.keccak(_pubdata[ptr: ptr + BLOB_SIZE_BYTES]);
+            blobLinearHashes[i] = EfficientCall.keccak(_pubdata[ptr:ptr + BLOB_SIZE_BYTES]);
             ptr = ptr + BLOB_SIZE_BYTES;
         }
     }

--- a/system-contracts/contracts/PubdataChunkPublisher.sol
+++ b/system-contracts/contracts/PubdataChunkPublisher.sol
@@ -34,7 +34,7 @@ contract PubdataChunkPublisher is IPubdataChunkPublisher {
                 // Copy to memory to pad with zeroes
                 bytes memory blob = new bytes(BLOB_SIZE_BYTES);
                 assembly {
-                    calldatacopy(add(0x20, blob), add(_pubdata.offset, ptr), BLOB_SIZE_BYTES)
+                    calldatacopy(add(0x20, blob), add(_pubdata.offset, ptr), sub(_pubdata.length, ptr))
                 }
                 blobLinearHashes[i] = keccak256(blob);
             }

--- a/system-contracts/contracts/PubdataChunkPublisher.sol
+++ b/system-contracts/contracts/PubdataChunkPublisher.sol
@@ -27,7 +27,17 @@ contract PubdataChunkPublisher is IPubdataChunkPublisher {
 
         uint256 ptr;
         for (uint256 i = 0; i < blobCount; ++i) {
-            blobLinearHashes[i] = EfficientCall.keccak(_pubdata[ptr:ptr + BLOB_SIZE_BYTES]);
+            if (ptr + BLOB_SIZE_BYTES <= _pubdata.length) {
+                blobLinearHashes[i] = EfficientCall.keccak(_pubdata[ptr:ptr + BLOB_SIZE_BYTES]);
+            } else {
+                // Pad with zeroes
+                bytes memory blob = new bytes(BLOB_SIZE_BYTES);
+                assembly {
+                    calldatacopy(add(0x20, blob), add(_pubdata.offset, ptr), BLOB_SIZE_BYTES)
+                }
+                blobLinearHashes[i] = keccak256(blob);
+            }
+
             ptr = ptr + BLOB_SIZE_BYTES;
         }
     }

--- a/system-contracts/contracts/PubdataChunkPublisher.sol
+++ b/system-contracts/contracts/PubdataChunkPublisher.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.28;
 import {IPubdataChunkPublisher} from "./interfaces/IPubdataChunkPublisher.sol";
 import {BLOB_SIZE_BYTES, MAX_NUMBER_OF_BLOBS} from "./Constants.sol";
 import {TooMuchPubdata} from "./SystemContractErrors.sol";
+import {EfficientCall} from "./libraries/EfficientCall.sol";
 
 /**
  * @author Matter Labs
@@ -14,7 +15,7 @@ contract PubdataChunkPublisher is IPubdataChunkPublisher {
     /// @notice Chunks pubdata into pieces that can fit into blobs.
     /// @param _pubdata The total l2 to l1 pubdata that will be sent via L1 blobs.
     /// @dev Note: This is an early implementation, in the future we plan to support up to 16 blobs per l1 batch.
-    function chunkPubdataToBlobs(bytes calldata _pubdata) external pure returns (bytes32[] memory blobLinearHashes) {
+    function chunkPubdataToBlobs(bytes calldata _pubdata) external view returns (bytes32[] memory blobLinearHashes) {
         if (_pubdata.length > BLOB_SIZE_BYTES * MAX_NUMBER_OF_BLOBS) {
             revert TooMuchPubdata(BLOB_SIZE_BYTES * MAX_NUMBER_OF_BLOBS, _pubdata.length);
         }
@@ -24,27 +25,14 @@ contract PubdataChunkPublisher is IPubdataChunkPublisher {
 
         blobLinearHashes = new bytes32[](blobCount);
 
-        // We allocate to the full size of blobCount * BLOB_SIZE_BYTES because we need to pad
-        // the data on the right with 0s if it doesn't take up the full blob
-        bytes memory totalBlobs = new bytes(BLOB_SIZE_BYTES * blobCount);
-
+        uint256 ptr;
         assembly {
-            // The pointer to the allocated memory above. We skip 32 bytes to avoid overwriting the length.
-            let ptr := add(totalBlobs, 0x20)
-            calldatacopy(ptr, _pubdata.offset, _pubdata.length)
+            ptr := _pubdata.offset
         }
 
         for (uint256 i = 0; i < blobCount; ++i) {
-            uint256 start = BLOB_SIZE_BYTES * i;
-
-            bytes32 blobHash;
-            assembly {
-                // The pointer to the allocated memory above skipping the length.
-                let ptr := add(totalBlobs, 0x20)
-                blobHash := keccak256(add(ptr, start), BLOB_SIZE_BYTES)
-            }
-
-            blobLinearHashes[i] = blobHash;
+            blobLinearHashes[i] = EfficientCall.keccak(_pubdata[ptr: ptr + BLOB_SIZE_BYTES]);
+            ptr = ptr + BLOB_SIZE_BYTES;
         }
     }
 }

--- a/system-contracts/contracts/interfaces/IPubdataChunkPublisher.sol
+++ b/system-contracts/contracts/interfaces/IPubdataChunkPublisher.sol
@@ -11,5 +11,5 @@ interface IPubdataChunkPublisher {
     /// @notice Chunks pubdata into pieces that can fit into blobs.
     /// @param _pubdata The total l2 to l1 pubdata that will be sent via L1 blobs.
     /// @dev Note: This is an early implementation, in the future we plan to support up to 16 blobs per l1 batch.
-    function chunkPubdataToBlobs(bytes calldata _pubdata) external pure returns (bytes32[] memory blobLinearHashes);
+    function chunkPubdataToBlobs(bytes calldata _pubdata) external view returns (bytes32[] memory blobLinearHashes);
 }

--- a/system-contracts/test/PubdataChunkPublisher.spec.ts
+++ b/system-contracts/test/PubdataChunkPublisher.spec.ts
@@ -47,7 +47,7 @@ describe("PubdataChunkPublisher tests", () => {
     });
   });
 
-  describe.only("chunkPubdataToBlobs", () => {
+  describe("chunkPubdataToBlobs", () => {
     it("Too Much Pubdata", async () => {
       const pubdata = genRandHex(blobSizeInBytes * maxNumberBlobs + 1);
       await expect(
@@ -57,19 +57,25 @@ describe("PubdataChunkPublisher tests", () => {
 
     it("Publish 1 Blob", async () => {
       const pubdata = genRandHex(blobSizeInBytes);
-      let result = await pubdataChunkPublisher.connect(l1MessengerAccount).chunkPubdataToBlobs(pubdata);
+      const result = await pubdataChunkPublisher.connect(l1MessengerAccount).chunkPubdataToBlobs(pubdata);
       expect(result).to.be.deep.eq(chunkData(pubdata));
     });
 
     it("Publish max Blobs", async () => {
       const pubdata = genRandHex(blobSizeInBytes * maxNumberBlobs);
-      let result = await pubdataChunkPublisher.connect(l1MessengerAccount).chunkPubdataToBlobs(pubdata);
+      const result = await pubdataChunkPublisher.connect(l1MessengerAccount).chunkPubdataToBlobs(pubdata);
       expect(result).to.be.deep.eq(chunkData(pubdata));
     });
 
-    it.only("Publish 1 padded blob", async () => {
+    it("Publish 1 padded blob", async () => {
       const pubdata = genRandHex(blobSizeInBytes / 2);
-      let result = await pubdataChunkPublisher.connect(l1MessengerAccount).chunkPubdataToBlobs(pubdata);
+      const result = await pubdataChunkPublisher.connect(l1MessengerAccount).chunkPubdataToBlobs(pubdata);
+      expect(result).to.be.deep.eq(chunkData(pubdata));
+    });
+
+    it("Publish 1 full and 1 padded blob", async () => {
+      const pubdata = genRandHex(blobSizeInBytes + blobSizeInBytes / 2);
+      const result = await pubdataChunkPublisher.connect(l1MessengerAccount).chunkPubdataToBlobs(pubdata);
       expect(result).to.be.deep.eq(chunkData(pubdata));
     });
   });

--- a/system-contracts/test/PubdataChunkPublisher.spec.ts
+++ b/system-contracts/test/PubdataChunkPublisher.spec.ts
@@ -24,7 +24,7 @@ describe("PubdataChunkPublisher tests", () => {
     const hexChunkLen = blobSizeInBytes * 2; // two symbols per byte
 
     for (let i = 0; i < strippedHex.length; i += hexChunkLen) {
-      chunks.push(strippedHex.slice(i, i + hexChunkLen));
+      chunks.push(strippedHex.slice(i, i + hexChunkLen).padEnd(hexChunkLen, "0"));
     }
 
     return chunks.map((x) => ethers.utils.keccak256("0x" + x));
@@ -61,8 +61,14 @@ describe("PubdataChunkPublisher tests", () => {
       expect(result).to.be.deep.eq(chunkData(pubdata));
     });
 
-    it("Publish 2 Blobs", async () => {
+    it("Publish max Blobs", async () => {
       const pubdata = genRandHex(blobSizeInBytes * maxNumberBlobs);
+      let result = await pubdataChunkPublisher.connect(l1MessengerAccount).chunkPubdataToBlobs(pubdata);
+      expect(result).to.be.deep.eq(chunkData(pubdata));
+    });
+
+    it.only("Publish 1 padded blob", async () => {
+      const pubdata = genRandHex(blobSizeInBytes / 2);
       let result = await pubdataChunkPublisher.connect(l1MessengerAccount).chunkPubdataToBlobs(pubdata);
       expect(result).to.be.deep.eq(chunkData(pubdata));
     });


### PR DESCRIPTION
# What ❔

We can pass most of chunks to keccak by pointer, without copying them to memory.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [X] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
