### PR TITLE
fix: Implement semaphore for configs

### DIFF
--- a/l1-contracts/package.json
+++ b/l1-contracts/package.json
@@ -61,7 +61,7 @@
     "clean": "hardhat clean && CONTRACTS_BASE_NETWORK_ZKSYNC=true hardhat clean",
     "clean:foundry": "forge clean",
     "test": "yarn workspace da-contracts build && hardhat test test/unit_tests/*.spec.ts --network hardhat",
-    "test:foundry": "forge script --sig 0x2dd0ebe3 DeployL1Script --ffi && forge test --ffi --match-path 'test/foundry/l1/*' --no-match-test 'test_MainnetFork'",
+    "test:foundry": "forge script --sig 0x2dd0ebe3 DeployL1Script --ffi && forge script --sig 'releaseConfigLock()' ConfigSemaphore && forge test --ffi --match-path 'test/foundry/l1/*' --no-match-test 'test_MainnetFork'",
     "test:zkfoundry": "forge script --sig 0x2dd0ebe3 DeployL1Script --ffi && forge test --zksync --match-path 'test/foundry/l2/*' --gas-limit 20000000000",
     "test:mainnet-upgrade-fork": "forge test --match-test test_MainnetFork --ffi --rpc-url $INFURA_MAINNET --gas-limit 2000000000",
     "test:fork": "TEST_CONTRACTS_FORK=1 yarn run hardhat test test/unit_tests/*.fork.ts --network hardhat",

--- a/l1-contracts/test/foundry/l1/integration/AssetRouterTest.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/AssetRouterTest.t.sol
@@ -35,8 +35,9 @@ import {BridgeHelper} from "contracts/bridge/BridgeHelper.sol";
 import {BridgedStandardERC20, NonSequentialVersion} from "contracts/bridge/BridgedStandardERC20.sol";
 import {IBridgedStandardToken} from "contracts/bridge/BridgedStandardERC20.sol";
 import {IERC20} from "@openzeppelin/contracts-v4/token/ERC20/IERC20.sol";
+import {ConfigSemaphore} from "./utils/_ConfigSemaphore.sol";
 
-contract AssetRouterIntegrationTest is L1ContractDeployer, ZKChainDeployer, TokenDeployer, L2TxMocker {
+contract AssetRouterIntegrationTest is L1ContractDeployer, ZKChainDeployer, TokenDeployer, L2TxMocker, ConfigSemaphore {
     uint256 constant TEST_USERS_COUNT = 10;
     address[] public users;
     address[] public l2ContractAddresses;
@@ -55,6 +56,8 @@ contract AssetRouterIntegrationTest is L1ContractDeployer, ZKChainDeployer, Toke
     function prepare() public {
         _generateUserAddresses();
 
+        takeConfigLock(); // Prevents race condition with configs
+
         _deployL1Contracts();
         _deployTokens();
         _registerNewTokens(tokens);
@@ -66,6 +69,8 @@ contract AssetRouterIntegrationTest is L1ContractDeployer, ZKChainDeployer, Toke
         // _deployHyperchain(tokens[0]);
         // _deployHyperchain(tokens[1]);
         // _deployHyperchain(tokens[1]);
+
+        releaseConfigLock();
 
         for (uint256 i = 0; i < zkChainIds.length; i++) {
             address contractAddress = makeAddr(string(abi.encode("contract", i)));

--- a/l1-contracts/test/foundry/l1/integration/DeploymentTest.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/DeploymentTest.t.sol
@@ -28,8 +28,9 @@ import {AddressesAlreadyGenerated} from "test/foundry/L1TestsErrors.sol";
 import {DataEncoding} from "contracts/common/libraries/DataEncoding.sol";
 import {IncorrectBridgeHubAddress} from "contracts/common/L1ContractErrors.sol";
 import {MessageRoot} from "contracts/bridgehub/MessageRoot.sol";
+import {ConfigSemaphore} from "./utils/_ConfigSemaphore.sol";
 
-contract DeploymentTests is L1ContractDeployer, ZKChainDeployer, TokenDeployer, L2TxMocker {
+contract DeploymentTests is L1ContractDeployer, ZKChainDeployer, TokenDeployer, L2TxMocker, ConfigSemaphore {
     uint256 constant TEST_USERS_COUNT = 10;
     address[] public users;
     address[] public l2ContractAddresses;
@@ -47,6 +48,7 @@ contract DeploymentTests is L1ContractDeployer, ZKChainDeployer, TokenDeployer, 
     }
 
     function prepare() public {
+        takeConfigLock(); // Prevents race condition with configs
         _generateUserAddresses();
 
         _deployL1Contracts();
@@ -60,6 +62,8 @@ contract DeploymentTests is L1ContractDeployer, ZKChainDeployer, TokenDeployer, 
         // _deployZKChain(tokens[0]);
         // _deployZKChain(tokens[1]);
         // _deployZKChain(tokens[1]);
+
+        releaseConfigLock();
 
         for (uint256 i = 0; i < zkChainIds.length; i++) {
             address contractAddress = makeAddr(string(abi.encode("contract", i)));

--- a/l1-contracts/test/foundry/l1/integration/L1GatewayTests.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/L1GatewayTests.t.sol
@@ -50,7 +50,14 @@ import {L2CanonicalTransaction} from "contracts/common/Messaging.sol";
 import {VerifierParams} from "contracts/state-transition/chain-interfaces/IVerifier.sol";
 import {SemVer} from "contracts/common/libraries/SemVer.sol";
 
-contract L1GatewayTests is L1ContractDeployer, ZKChainDeployer, TokenDeployer, L2TxMocker, GatewayDeployer, ConfigSemaphore {
+contract L1GatewayTests is
+    L1ContractDeployer,
+    ZKChainDeployer,
+    TokenDeployer,
+    L2TxMocker,
+    GatewayDeployer,
+    ConfigSemaphore
+{
     uint256 constant TEST_USERS_COUNT = 10;
     address[] public users;
     address[] public l2ContractAddresses;

--- a/l1-contracts/test/foundry/l1/integration/L1GatewayTests.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/L1GatewayTests.t.sol
@@ -40,7 +40,7 @@ import {DataEncoding} from "contracts/common/libraries/DataEncoding.sol";
 import {IncorrectBridgeHubAddress} from "contracts/common/L1ContractErrors.sol";
 import {ChainAdmin} from "contracts/governance/ChainAdmin.sol";
 import {IAdmin} from "contracts/state-transition/chain-interfaces/IAdmin.sol";
-
+import {ConfigSemaphore} from "./utils/_ConfigSemaphore.sol";
 import {GatewayUtils} from "deploy-scripts/GatewayUtils.s.sol";
 import {Utils} from "../unit/concrete/Utils/Utils.sol";
 import {Diamond} from "contracts/state-transition/libraries/Diamond.sol";
@@ -50,7 +50,7 @@ import {L2CanonicalTransaction} from "contracts/common/Messaging.sol";
 import {VerifierParams} from "contracts/state-transition/chain-interfaces/IVerifier.sol";
 import {SemVer} from "contracts/common/libraries/SemVer.sol";
 
-contract L1GatewayTests is L1ContractDeployer, ZKChainDeployer, TokenDeployer, L2TxMocker, GatewayDeployer {
+contract L1GatewayTests is L1ContractDeployer, ZKChainDeployer, TokenDeployer, L2TxMocker, GatewayDeployer, ConfigSemaphore {
     uint256 constant TEST_USERS_COUNT = 10;
     address[] public users;
     address[] public l2ContractAddresses;
@@ -78,6 +78,7 @@ contract L1GatewayTests is L1ContractDeployer, ZKChainDeployer, TokenDeployer, L
     function prepare() public {
         _generateUserAddresses();
 
+        takeConfigLock(); // Prevents race condition with configs
         _deployL1Contracts();
         _deployTokens();
         _registerNewTokens(tokens);
@@ -101,6 +102,8 @@ contract L1GatewayTests is L1ContractDeployer, ZKChainDeployer, TokenDeployer, L
         }
 
         _initializeGatewayScript();
+
+        releaseConfigLock();
 
         vm.deal(ecosystemConfig.ownerAddress, 100000000000000000000000000000000000);
         migratingChain = IZKChain(IBridgehub(addresses.bridgehub).getZKChain(migratingChainId));

--- a/l1-contracts/test/foundry/l1/integration/utils/_ConfigSemaphore.sol
+++ b/l1-contracts/test/foundry/l1/integration/utils/_ConfigSemaphore.sol
@@ -35,7 +35,7 @@ contract ConfigSemaphore is Script {
             try vm.removeFile(path) {
                 // Successfully removed
             } catch {
-                // Do nothing, hopefully it is removed alredy
+                // Do nothing, hopefully it is removed already
             }
         }
     }

--- a/l1-contracts/test/foundry/l1/integration/utils/_ConfigSemaphore.sol
+++ b/l1-contracts/test/foundry/l1/integration/utils/_ConfigSemaphore.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Script} from "forge-std/Script.sol";
+import {StdStorage, stdStorage} from "forge-std/Test.sol";
+import {stdToml} from "forge-std/StdToml.sol";
+
+contract ConfigSemaphore is Script {
+    using stdToml for string;
+
+    string lockPath = "/test/foundry/l1/integration/deploy-scripts/script-config/.lock";
+
+    /// @dev Acquire lock to prevent race condition
+    /// Note that this implementation is not ideal, but should be good enough for the most cases
+    /// TODO: replace with proper scripts/tests refactoring
+    function takeConfigLock() public {
+        string memory path = string.concat(vm.projectRoot(), lockPath);
+
+        uint256 attempts;
+        while (vm.exists(path)) {
+            vm.sleep(1000);
+            attempts++;
+
+            if (attempts >= 60) {
+                revert("Can't acquire config lock");
+            }
+        }
+
+        vm.writeFile(path, "lock");
+    }
+
+    function releaseConfigLock() public {
+        string memory path = string.concat(vm.projectRoot(), lockPath);
+        if (vm.exists(path)) {
+            try vm.removeFile(path) {
+                // Successfully removed
+            } catch {
+                // Do nothing, hopefully it is removed alredy
+            }
+        }
+    }
+}


### PR DESCRIPTION
# What ❔

Several tests use same local config files in `prepare()` step. Due to parallel test execution we have race condition here and this leads to very flaky tests. This PR adds some kind of semaphore that seems to be working.

Note: this solution is far from ideal and should be replaced with proper scripts/tests refactoring in the future. 

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
