### PR TITLE
test: ignore unused files in coverage

### DIFF
--- a/.github/workflows/l1-contracts-ci.yaml
+++ b/.github/workflows/l1-contracts-ci.yaml
@@ -336,15 +336,14 @@ jobs:
 
       # To ignore coverage for certain directories modify the paths in this step as needed. The
       # below default ignores coverage results for the test and script directories. It also ignores
-      # the ChainRegistrar and GatewayTransactionFilterer contracts since they are unused. Alternatively,
-      # to include coverage in all directories, comment out this step. Note that because this
-      # filtering applies to the lcov file, the summary table generated in the previous step will
-      # still include all files and directories.
-      # The `--rc branch_coverage=1` part keeps branch info in the filtered report, since lcov
-      # defaults to removing branch info.
+      # the ChainRegistrar contract since it is unused. Alternatively, to include coverage in all
+      # directories, comment out this step. Note that because this filtering applies to the lcov
+      # file, the summary table generated in the previous step will still include all files and
+      # directories. The `--rc branch_coverage=1` part keeps branch info in the filtered report,
+      # since lcov defaults to removing branch info.
       - name: Filter directories
         run: |
-          lcov --ignore-errors unused --remove lcov.info 'test/*' 'contracts/dev-contracts/*' 'lib/*' '../lib/*' 'lib/' 'deploy-scripts/*' 'contracts/chain-registrar/ChainRegistrar.sol' `contracts/transactionFilterer/GatewayTransactionFilterer.sol` --output-file lcov.info --rc branch_coverage=1
+          lcov --ignore-errors unused --remove lcov.info 'test/*' 'contracts/dev-contracts/*' 'lib/*' '../lib/*' 'lib/' 'deploy-scripts/*' 'contracts/chain-registrar/ChainRegistrar.sol' --output-file lcov.info --rc branch_coverage=1
 
       # This step posts a detailed coverage report as a comment and deletes previous comments on
       # each push. The below step is used to fail coverage if the specified coverage threshold is

--- a/.github/workflows/l1-contracts-ci.yaml
+++ b/.github/workflows/l1-contracts-ci.yaml
@@ -335,7 +335,8 @@ jobs:
           ref: v1.16
 
       # To ignore coverage for certain directories modify the paths in this step as needed. The
-      # below default ignores coverage results for the test and script directories. Alternatively,
+      # below default ignores coverage results for the test and script directories. It also ignores
+      # the ChainRegistrar and GatewayTransactionFilterer contracts since they are unused. Alternatively,
       # to include coverage in all directories, comment out this step. Note that because this
       # filtering applies to the lcov file, the summary table generated in the previous step will
       # still include all files and directories.
@@ -343,7 +344,7 @@ jobs:
       # defaults to removing branch info.
       - name: Filter directories
         run: |
-          lcov --ignore-errors unused --remove lcov.info 'test/*' 'contracts/dev-contracts/*' 'lib/*' '../lib/*' 'lib/' 'deploy-scripts/*' --output-file lcov.info --rc branch_coverage=1
+          lcov --ignore-errors unused --remove lcov.info 'test/*' 'contracts/dev-contracts/*' 'lib/*' '../lib/*' 'lib/' 'deploy-scripts/*' 'contracts/chain-registrar/ChainRegistrar.sol' `contracts/transactionFilterer/GatewayTransactionFilterer.sol` --output-file lcov.info --rc branch_coverage=1
 
       # This step posts a detailed coverage report as a comment and deletes previous comments on
       # each push. The below step is used to fail coverage if the specified coverage threshold is


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
Ignore ChainRegistrar and GatewayTransactionFilterer contracts in coverage since they are unused. Once they will be used, tests for them will be competed (currently located in `l1-contracts/test/foundry/unit/concrete/...` and the contracts will be included in coverage.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->


## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
