### PR TITLE
feat(L1): Add initial smart contract support for BitcoinDA or feat(contracts): Integrate BitcoinDA L1 components 

### DIFF
--- a/.github/workflows/slither.yaml
+++ b/.github/workflows/slither.yaml
@@ -67,5 +67,7 @@ jobs:
 
       - name: Run Slither for L2 contracts
         working-directory: ./l2-contracts
+        env:
+          FOUNDRY_PROFILE: slither
         run: |
           slither --config ./slither.config.json --skip-assembly .

--- a/AllContractsHashes.json
+++ b/AllContractsHashes.json
@@ -712,6 +712,14 @@
     "evmDeployedBytecodeHash": null
   },
   {
+    "contractName": "l2-contracts/BitcoinL2DAValidator",
+    "zkBytecodeHash": "0x01000119254008b70a7a09f100eab05ebe5cd1153c052a4941db78109f0a4187",
+    "zkBytecodePath": "/l2-contracts/zkout/BitcoinL2DAValidator.sol/BitcoinL2DAValidator.json",
+    "evmBytecodeHash": null,
+    "evmBytecodePath": null,
+    "evmDeployedBytecodeHash": null
+  },
+  {
     "contractName": "l1-contracts/AccessControlRestriction",
     "zkBytecodeHash": "0x0100028164ab08e507abe4d22fbd9b17b62e89f531175b86acf6273555699a6c",
     "zkBytecodePath": "/l1-contracts/zkout/AccessControlRestriction.sol/AccessControlRestriction.json",
@@ -1558,6 +1566,14 @@
     "evmDeployedBytecodeHash": "0xcf4f93386cc8ffcdb9d13795199baac811a668773285cec0607918904dd556e4",
     "zkBytecodeHash": null,
     "zkBytecodePath": null
+  },
+  {
+    "contractName": "l1-contracts/BitcoinL1DAValidator",
+    "evmBytecodeHash": "0xae60ab121ed856019e7a955a6b0e5b7e1862bad02e583b76455dc72dd2db0b19",
+    "evmBytecodePath": "/l1-contracts/out/BitcoinL1DAValidator.sol/BitcoinL1DAValidator.json",
+    "evmDeployedBytecodeHash": "0x7e75a3d4c17a7533e2c9928aaaaf04f6cb78f4c20f7cdfad9a969e77f5a627c4",
+    "zkBytecodeHash": "0x01000067e296e74444e5f49b2fae0f8ea15a8da672fc3094feb6d1c32a869ec3",
+    "zkBytecodePath": "/l1-contracts/zkout/BitcoinL1DAValidator.sol/BitcoinL1DAValidator.json"
   },
   {
     "contractName": "da-contracts/AvailL1DAValidator",

--- a/AllContractsHashes.json
+++ b/AllContractsHashes.json
@@ -384,6 +384,14 @@
     "evmDeployedBytecodeHash": null
   },
   {
+    "contractName": "l2-contracts/BitcoinL2DAValidator",
+    "zkBytecodeHash": "0x01000119254008b70a7a09f100eab05ebe5cd1153c052a4941db78109f0a4187",
+    "zkBytecodePath": "/l2-contracts/zkout/BitcoinL2DAValidator.sol/BitcoinL2DAValidator.json",
+    "evmBytecodeHash": null,
+    "evmBytecodePath": null,
+    "evmDeployedBytecodeHash": null
+  },
+  {
     "contractName": "l2-contracts/BootloaderUtilities",
     "zkBytecodeHash": "0x010006ed0e396b971b54f3cd75d6934fb456119be1cbf18ba830d5484ece99b9",
     "zkBytecodePath": "/l2-contracts/zkout/BootloaderUtilities.sol/BootloaderUtilities.json",
@@ -712,14 +720,6 @@
     "evmDeployedBytecodeHash": null
   },
   {
-    "contractName": "l2-contracts/BitcoinL2DAValidator",
-    "zkBytecodeHash": "0x01000119254008b70a7a09f100eab05ebe5cd1153c052a4941db78109f0a4187",
-    "zkBytecodePath": "/l2-contracts/zkout/BitcoinL2DAValidator.sol/BitcoinL2DAValidator.json",
-    "evmBytecodeHash": null,
-    "evmBytecodePath": null,
-    "evmDeployedBytecodeHash": null
-  },
-  {
     "contractName": "l1-contracts/AccessControlRestriction",
     "zkBytecodeHash": "0x0100028164ab08e507abe4d22fbd9b17b62e89f531175b86acf6273555699a6c",
     "zkBytecodePath": "/l1-contracts/zkout/AccessControlRestriction.sol/AccessControlRestriction.json",
@@ -782,6 +782,14 @@
     "evmBytecodeHash": "0x35ee8709377e972c1f0bc3060bcfe41fb8308a5e20670dc969ed9a61038ee038",
     "evmBytecodePath": "/l1-contracts/out/BeaconProxy.sol/BeaconProxy.json",
     "evmDeployedBytecodeHash": "0xc4df59cf968d64ae659b6788dc35aec9bf5baf0724fb11c0461d42f410e19fb9"
+  },
+  {
+    "contractName": "l1-contracts/BitcoinL1DAValidator",
+    "evmBytecodeHash": "0x571c6173d7a15c95e2d0682f731a835c0224fdf0930af4423e0905db0f7a21cd",
+    "evmBytecodePath": "/l1-contracts/out/BitcoinL1DAValidator.sol/BitcoinL1DAValidator.json",
+    "evmDeployedBytecodeHash": "0xc240537fafe1bc991b4c0426b19abf8b894cf1d89085cfa2bf98051b8abfa418",
+    "zkBytecodeHash": "0x010000673444acfeea801fa1d9d2297e7bda4bc28ea71f65dbcd0331bc8d5385",
+    "zkBytecodePath": "/l1-contracts/zkout/BitcoinL1DAValidator.sol/BitcoinL1DAValidator.json"
   },
   {
     "contractName": "l1-contracts/BridgeHelper",
@@ -1566,14 +1574,6 @@
     "evmDeployedBytecodeHash": "0xcf4f93386cc8ffcdb9d13795199baac811a668773285cec0607918904dd556e4",
     "zkBytecodeHash": null,
     "zkBytecodePath": null
-  },
-  {
-    "contractName": "l1-contracts/BitcoinL1DAValidator",
-    "evmBytecodeHash": "0x571c6173d7a15c95e2d0682f731a835c0224fdf0930af4423e0905db0f7a21cd",
-    "evmBytecodePath": "/l1-contracts/out/BitcoinL1DAValidator.sol/BitcoinL1DAValidator.json",
-    "evmDeployedBytecodeHash": "0xc240537fafe1bc991b4c0426b19abf8b894cf1d89085cfa2bf98051b8abfa418",
-    "zkBytecodeHash": "0x010000673444acfeea801fa1d9d2297e7bda4bc28ea71f65dbcd0331bc8d5385",
-    "zkBytecodePath": "/l1-contracts/zkout/BitcoinL1DAValidator.sol/BitcoinL1DAValidator.json"
   },
   {
     "contractName": "da-contracts/AvailL1DAValidator",

--- a/AllContractsHashes.json
+++ b/AllContractsHashes.json
@@ -1569,10 +1569,10 @@
   },
   {
     "contractName": "l1-contracts/BitcoinL1DAValidator",
-    "evmBytecodeHash": "0xae60ab121ed856019e7a955a6b0e5b7e1862bad02e583b76455dc72dd2db0b19",
+    "evmBytecodeHash": "0x571c6173d7a15c95e2d0682f731a835c0224fdf0930af4423e0905db0f7a21cd",
     "evmBytecodePath": "/l1-contracts/out/BitcoinL1DAValidator.sol/BitcoinL1DAValidator.json",
-    "evmDeployedBytecodeHash": "0x7e75a3d4c17a7533e2c9928aaaaf04f6cb78f4c20f7cdfad9a969e77f5a627c4",
-    "zkBytecodeHash": "0x01000067e296e74444e5f49b2fae0f8ea15a8da672fc3094feb6d1c32a869ec3",
+    "evmDeployedBytecodeHash": "0xc240537fafe1bc991b4c0426b19abf8b894cf1d89085cfa2bf98051b8abfa418",
+    "zkBytecodeHash": "0x010000673444acfeea801fa1d9d2297e7bda4bc28ea71f65dbcd0331bc8d5385",
     "zkBytecodePath": "/l1-contracts/zkout/BitcoinL1DAValidator.sol/BitcoinL1DAValidator.json"
   },
   {

--- a/l1-contracts/contracts/state-transition/data-availability/BitcoinL1DAValidator.sol
+++ b/l1-contracts/contracts/state-transition/data-availability/BitcoinL1DAValidator.sol
@@ -3,7 +3,7 @@
 pragma solidity 0.8.24;
 
 import {IL1DAValidator, L1DAValidatorOutput} from "../chain-interfaces/IL1DAValidator.sol";
-import {OperatorDAInputTooSmall, InvalidL2DAOutputHash}, from "../L1StateTransitionErrors.sol";
+import {OperatorDAInputTooSmall, InvalidL2DAOutputHash} from "../L1StateTransitionErrors.sol";
 
 error BitcoinDAPrecompileCallFailed();
 error BitcoinDAVerificationFailed();

--- a/l1-contracts/contracts/state-transition/data-availability/BitcoinL1DAValidator.sol
+++ b/l1-contracts/contracts/state-transition/data-availability/BitcoinL1DAValidator.sol
@@ -62,9 +62,9 @@ contract BitcoinL1DAValidator is IL1DAValidator {
         address BITCOINDA_PRECOMPILE_ADDRESS = address(0x63);
         uint16 BITCOINDA_PRECOMPILE_COST = 1400;
         (bool success, bytes memory result) = BITCOINDA_PRECOMPILE_ADDRESS.staticcall{gas: BITCOINDA_PRECOMPILE_COST}(abi.encode(_dataHash));
-
-        require(success, "Bitcoin DA precompile call failed.");
-        require(result.length > 0, "Bitcoin DA precompile: Data not found or verification failed.");
+        
+        require(success, "PoDA Staticcall failed.");
+        require(result.length > 0, "Return PoDA must not be empty.");
         
     }
 }

--- a/l1-contracts/contracts/state-transition/data-availability/BitcoinL1DAValidator.sol
+++ b/l1-contracts/contracts/state-transition/data-availability/BitcoinL1DAValidator.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 
 pragma solidity 0.8.24;
-import {OperatorDAInputTooSmall, InvalidL2DAOutputHash} from "../L1StateTransitionErrors.sol";
+
 import {IL1DAValidator, L1DAValidatorOutput} from "../chain-interfaces/IL1DAValidator.sol";
+import {OperatorDAInputTooSmall, InvalidL2DAOutputHash}, from "../L1StateTransitionErrors.sol";
 
 error BitcoinDAPrecompileCallFailed();
 error BitcoinDAVerificationFailed();

--- a/l1-contracts/contracts/state-transition/data-availability/BitcoinL1DAValidator.sol
+++ b/l1-contracts/contracts/state-transition/data-availability/BitcoinL1DAValidator.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+import {OperatorDAInputTooSmall, InvalidL2DAOutputHash} from "../L1StateTransitionErrors.sol";
+import {IL1DAValidator, L1DAValidatorOutput} from "../chain-interfaces/IL1DAValidator.sol";
+
+contract BitcoinL1DAValidator is IL1DAValidator {
+    function checkDA(
+        uint256, // _chainId
+        uint256, // _batchNumber
+        bytes32 _l2DAValidatorOutputHash,
+        bytes calldata _operatorDAInput,
+        uint256 maxBlobsSupported
+    ) external override returns (L1DAValidatorOutput memory output) {
+        {
+            (
+               bytes32 uncompressedStateDiffHash,
+               bytes32 fullPubdataHash
+            ) = _processL2RollupDAValidatorOutputHash(_l2DAValidatorOutputHash, _operatorDAInput);
+            // circuit will commit to the uncompressed diff hash but we related the compressed to the uncompressed one via validatePubData and recomputed the hash to check here. 
+            output.stateDiffHash = uncompressedStateDiffHash;
+            // fullPubdataHash should include user_logs, l2_to_l1_messages, published_bytecodes, compressed state_diffs
+            _verifyBitcoinDA(fullPubdataHash);
+        }
+        // The rest of the fields that relate to blobs are empty.
+        output.blobsLinearHashes = new bytes32[](maxBlobsSupported);
+        output.blobsOpeningCommitments = new bytes32[](maxBlobsSupported);
+    }
+
+    function _processL2RollupDAValidatorOutputHash(
+        bytes32 _l2DAValidatorOutputHash,
+        bytes calldata _operatorDAInput
+    )
+        internal
+        pure
+        returns (
+            bytes32 uncompressedStateDiffHash,
+            bytes32 fullPubdataHash
+        )
+    {
+        if (_operatorDAInput.length < 64) {
+            revert OperatorDAInputTooSmall(_operatorDAInput.length, 64);
+        }
+        // we are isolating fullPubdataHash to ensure its correctness here by checking state diff(validated) + full data hash(unvalidated) == l2 DA validator output(validated)
+        // fullPubdataHash is used as DA and commits to the compressed state diff (zk circuit input)
+        uncompressedStateDiffHash = bytes32(_operatorDAInput[:32]);
+        fullPubdataHash = bytes32(_operatorDAInput[32:64]);
+
+        // Now, we need to double check that the provided input was indeed returned by the L2 DA validator.
+        if (keccak256(_operatorDAInput[:64]) != _l2DAValidatorOutputHash) {
+            revert InvalidL2DAOutputHash(_l2DAValidatorOutputHash);
+        }
+    }
+
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == type(IL1DAValidator).interfaceId;
+    }
+
+    function _verifyBitcoinDA(
+        bytes32 _dataHash
+    ) internal view {
+        address BITCOINDA_PRECOMPILE_ADDRESS = address(0x63);
+        uint16 BITCOINDA_PRECOMPILE_COST = 1400;
+        (bool success, bytes memory result) = BITCOINDA_PRECOMPILE_ADDRESS.staticcall{gas: BITCOINDA_PRECOMPILE_COST}(abi.encode(_dataHash));
+
+        require(success, "Bitcoin DA precompile call failed.");
+        require(result.length > 0, "Bitcoin DA precompile: Data not found or verification failed.");
+        
+    }
+}

--- a/l1-contracts/contracts/state-transition/data-availability/BitcoinL1DAValidator.sol
+++ b/l1-contracts/contracts/state-transition/data-availability/BitcoinL1DAValidator.sol
@@ -16,11 +16,11 @@ contract BitcoinL1DAValidator is IL1DAValidator {
         uint256 maxBlobsSupported
     ) external override returns (L1DAValidatorOutput memory output) {
         {
-            (
-               bytes32 uncompressedStateDiffHash,
-               bytes32 fullPubdataHash
-            ) = _processL2RollupDAValidatorOutputHash(_l2DAValidatorOutputHash, _operatorDAInput);
-            // circuit will commit to the uncompressed diff hash but we related the compressed to the uncompressed one via validatePubData and recomputed the hash to check here. 
+            (bytes32 uncompressedStateDiffHash, bytes32 fullPubdataHash) = _processL2RollupDAValidatorOutputHash(
+                _l2DAValidatorOutputHash,
+                _operatorDAInput
+            );
+            // circuit will commit to the uncompressed diff hash but we related the compressed to the uncompressed one via validatePubData and recomputed the hash to check here.
             output.stateDiffHash = uncompressedStateDiffHash;
             // fullPubdataHash should include user_logs, l2_to_l1_messages, published_bytecodes, compressed state_diffs
             _verifyBitcoinDA(fullPubdataHash);
@@ -33,14 +33,7 @@ contract BitcoinL1DAValidator is IL1DAValidator {
     function _processL2RollupDAValidatorOutputHash(
         bytes32 _l2DAValidatorOutputHash,
         bytes calldata _operatorDAInput
-    )
-        internal
-        pure
-        returns (
-            bytes32 uncompressedStateDiffHash,
-            bytes32 fullPubdataHash
-        )
-    {
+    ) internal pure returns (bytes32 uncompressedStateDiffHash, bytes32 fullPubdataHash) {
         if (_operatorDAInput.length < 64) {
             revert OperatorDAInputTooSmall(_operatorDAInput.length, 64);
         }
@@ -59,19 +52,19 @@ contract BitcoinL1DAValidator is IL1DAValidator {
         return interfaceId == type(IL1DAValidator).interfaceId;
     }
 
-    function _verifyBitcoinDA(
-        bytes32 _dataHash
-    ) internal view {
+    function _verifyBitcoinDA(bytes32 _dataHash) internal view {
         address BITCOINDA_PRECOMPILE_ADDRESS = address(0x63);
         uint16 BITCOINDA_PRECOMPILE_COST = 1400;
-        (bool success, bytes memory result) = BITCOINDA_PRECOMPILE_ADDRESS.staticcall{gas: BITCOINDA_PRECOMPILE_COST}(abi.encode(_dataHash));
+        (bool success, bytes memory result) = BITCOINDA_PRECOMPILE_ADDRESS.staticcall{gas: BITCOINDA_PRECOMPILE_COST}(
+            abi.encode(_dataHash)
+        );
 
         if (!success) {
             revert BitcoinDAPrecompileCallFailed();
         }
-        if (result.length == 0) { // Assuming empty result means not found or verification failed
+        if (result.length == 0) {
+            // Assuming empty result means not found or verification failed
             revert BitcoinDAVerificationFailed();
         }
-        
     }
 }

--- a/l1-contracts/deploy-scripts/DeployL1.s.sol
+++ b/l1-contracts/deploy-scripts/DeployL1.s.sol
@@ -786,7 +786,7 @@ contract DeployL1Script is Script, DeployUtils {
             return Utils.readAvailL1DAValidatorBytecode();
         } else if (compareStrings(contractName, "DummyAvailBridge")) {
             return Utils.readDummyAvailBridgeBytecode();
-        // SYSCOIN
+            // SYSCOIN
         } else if (compareStrings(contractName, "BitcoinL1DAValidator")) {
             return Utils.readBitcoinL1DAValidatorBytecode();
         } else if (compareStrings(contractName, "Verifier")) {

--- a/l1-contracts/deploy-scripts/DeployL2Contracts.sol
+++ b/l1-contracts/deploy-scripts/DeployL2Contracts.sol
@@ -178,7 +178,7 @@ contract DeployL2Script is Script {
             bytecode = L2ContractsBytecodesLib.readNoDAL2DAValidatorBytecode();
         } else if (config.validatorType == DAValidatorType.Avail) {
             bytecode = L2ContractsBytecodesLib.readAvailL2DAValidatorBytecode();
-        // SYSCOIN
+            // SYSCOIN
         } else if (config.validatorType == DAValidatorType.Bitcoin) {
             bytecode = L2ContractsBytecodesLib.readBitcoinL2DAValidatorBytecode();
         } else {

--- a/l1-contracts/deploy-scripts/DeployL2Contracts.sol
+++ b/l1-contracts/deploy-scripts/DeployL2Contracts.sol
@@ -24,7 +24,8 @@ contract DeployL2Script is Script {
     enum DAValidatorType {
         Rollup,
         NoDA,
-        Avail
+        Avail,
+        Bitcoin
     }
 
     // solhint-disable-next-line gas-struct-packing
@@ -151,7 +152,8 @@ contract DeployL2Script is Script {
         config.eraChainId = toml.readUint("$.era_chain_id");
 
         uint256 validatorTypeUint = toml.readUint("$.da_validator_type");
-        require(validatorTypeUint < 3, "Invalid DA validator type");
+        // SYSCOIN
+        require(validatorTypeUint < 4, "Invalid DA validator type");
         config.validatorType = DAValidatorType(validatorTypeUint);
     }
 
@@ -176,6 +178,9 @@ contract DeployL2Script is Script {
             bytecode = L2ContractsBytecodesLib.readNoDAL2DAValidatorBytecode();
         } else if (config.validatorType == DAValidatorType.Avail) {
             bytecode = L2ContractsBytecodesLib.readAvailL2DAValidatorBytecode();
+        // SYSCOIN
+        } else if (config.validatorType == DAValidatorType.Bitcoin) {
+            bytecode = L2ContractsBytecodesLib.readBitcoinL2DAValidatorBytecode();
         } else {
             revert("Invalid DA validator type");
         }

--- a/l1-contracts/deploy-scripts/DeployUtils.s.sol
+++ b/l1-contracts/deploy-scripts/DeployUtils.s.sol
@@ -419,6 +419,9 @@ abstract contract DeployUtils is Create2FactoryUtils {
             return abi.encode(addresses.daAddresses.availBridge);
         } else if (compareStrings(contractName, "DummyAvailBridge")) {
             return abi.encode();
+        // SYSCOIN
+        } else if (compareStrings(contractName, "BitcoinL1DAValidator")) {
+            return abi.encode();
         } else if (compareStrings(contractName, "Verifier")) {
             return abi.encode(addresses.stateTransition.verifierFflonk, addresses.stateTransition.verifierPlonk);
         } else if (compareStrings(contractName, "VerifierFflonk")) {

--- a/l1-contracts/deploy-scripts/DeployUtils.s.sol
+++ b/l1-contracts/deploy-scripts/DeployUtils.s.sol
@@ -419,7 +419,7 @@ abstract contract DeployUtils is Create2FactoryUtils {
             return abi.encode(addresses.daAddresses.availBridge);
         } else if (compareStrings(contractName, "DummyAvailBridge")) {
             return abi.encode();
-        // SYSCOIN
+            // SYSCOIN
         } else if (compareStrings(contractName, "BitcoinL1DAValidator")) {
             return abi.encode();
         } else if (compareStrings(contractName, "Verifier")) {

--- a/l1-contracts/deploy-scripts/DeployUtils.s.sol
+++ b/l1-contracts/deploy-scripts/DeployUtils.s.sol
@@ -63,6 +63,8 @@ struct DataAvailabilityDeployedAddresses {
     address noDAValidiumL1DAValidator;
     address availBridge;
     address availL1DAValidator;
+    // SYSCOIN
+    address bitcoinL1DAValidator;
 }
 
 // solhint-disable-next-line gas-struct-packing

--- a/l1-contracts/deploy-scripts/L2ContractsBytecodesLib.sol
+++ b/l1-contracts/deploy-scripts/L2ContractsBytecodesLib.sol
@@ -87,6 +87,12 @@ library L2ContractsBytecodesLib {
     function readNoDAL2DAValidatorBytecode() internal view returns (bytes memory) {
         return Utils.readZKFoundryBytecodeL2("ValidiumL2DAValidator.sol", "ValidiumL2DAValidator");
     }
+    // SYSCOIN
+    /// @notice Reads the bytecode of the BitcoinL2DAValidator contract for Bitcoin DA.
+    /// @return The bytecode of the BitcoinL2DAValidator contract.
+    function readBitcoinL2DAValidatorBytecode() internal view returns (bytes memory) {
+        return Utils.readZKFoundryBytecodeL2("BitcoinL2DAValidator.sol", "BitcoinL2DAValidator");
+    }
 
     /// @notice Reads the bytecode of the ChainTypeManager contract.
     /// @return The bytecode of the ChainTypeManager contract.

--- a/l1-contracts/deploy-scripts/Utils.sol
+++ b/l1-contracts/deploy-scripts/Utils.sol
@@ -1303,7 +1303,7 @@ library Utils {
     }
     // SYSCOIN
     function readBitcoinL1DAValidatorBytecode() internal view returns (bytes memory bytecode) {
-        bytecode = readFoundryBytecode("/../da-contracts/out/BitcoinL1DAValidator.sol/BitcoinL1DAValidator.json");
+        bytecode = readFoundryBytecode("/../l1-contracts/out/BitcoinL1DAValidator.sol/BitcoinL1DAValidator.json");
     }
 
     function mergeCalls(Call[] memory a, Call[] memory b) public pure returns (Call[] memory result) {

--- a/l1-contracts/deploy-scripts/Utils.sol
+++ b/l1-contracts/deploy-scripts/Utils.sol
@@ -1301,6 +1301,10 @@ library Utils {
     function readDummyAvailBridgeBytecode() internal view returns (bytes memory bytecode) {
         bytecode = readFoundryBytecode("/../da-contracts/out/DummyAvailBridge.sol/DummyAvailBridge.json");
     }
+    // SYSCOIN
+    function readBitcoinL1DAValidatorBytecode() internal view returns (bytes memory bytecode) {
+        bytecode = readFoundryBytecode("/../da-contracts/out/BitcoinL1DAValidator.sol/BitcoinL1DAValidator.json");
+    }
 
     function mergeCalls(Call[] memory a, Call[] memory b) public pure returns (Call[] memory result) {
         result = new Call[](a.length + b.length);

--- a/l1-contracts/src.ts/deploy-utils.ts
+++ b/l1-contracts/src.ts/deploy-utils.ts
@@ -247,6 +247,8 @@ export interface DeployedAddresses {
   RollupL1DAValidator: string;
   ValidiumL1DAValidator: string;
   RelayedSLDAValidator: string;
+  // SYSCOIN
+  BitcoinL1DAValidator: string;
   Create2Factory: string;
 }
 
@@ -304,6 +306,8 @@ export function deployedAddressesFromEnv(): DeployedAddresses {
     RollupL1DAValidator: getAddressFromEnv("CONTRACTS_L1_ROLLUP_DA_VALIDATOR"),
     ValidiumL1DAValidator: getAddressFromEnv("CONTRACTS_L1_VALIDIUM_DA_VALIDATOR"),
     RelayedSLDAValidator: getAddressFromEnv("CONTRACTS_L1_RELAYED_SL_DA_VALIDATOR"),
+    // SYSCOIN
+    BitcoinL1DAValidator: getAddressFromEnv("CONTRACTS_L1_BITCOIN_DA_VALIDATOR_ADDR"),
     BaseToken: getAddressFromEnv("CONTRACTS_BASE_TOKEN_ADDR"),
     BaseTokenAssetId: baseTokenAssetId,
     TransparentProxyAdmin: getAddressFromEnv("CONTRACTS_TRANSPARENT_PROXY_ADMIN_ADDR"),

--- a/l1-contracts/src.ts/deploy.ts
+++ b/l1-contracts/src.ts/deploy.ts
@@ -1798,6 +1798,19 @@ export class Deployer {
     this.addresses.RollupL1DAValidator = rollupDAValidatorAddress;
     this.addresses.ValidiumL1DAValidator = validiumDAValidatorAddress;
     this.addresses.RelayedSLDAValidator = relayedSLDAValidator;
+
+    // SYSCOIN Deploy Bitcoin L1 DA Validator
+    const bitcoinL1DAValidatorAddress = await this.deployViaCreate2(
+      "BitcoinL1DAValidator",
+      [], // Constructor arguments
+      create2Salt,
+      ethTxOptions,
+      undefined // Libraries
+    );
+    if (this.verbose) {
+      console.log(`CONTRACTS_L1_BITCOIN_DA_VALIDATOR_ADDR=${bitcoinL1DAValidatorAddress}`);
+    }
+    this.addresses.BitcoinL1DAValidator = bitcoinL1DAValidatorAddress;
   }
 
   public async updateBlobVersionedHashRetrieverZkMode() {

--- a/l2-contracts/contracts/data-availability/BitcoinL2DAValidator.sol
+++ b/l2-contracts/contracts/data-availability/BitcoinL2DAValidator.sol
@@ -22,11 +22,11 @@ contract BitcoinL2DAValidator is IL2DAValidator, StateDiffL2DAValidator {
         // Operator data, that is related to the DA itself
         bytes calldata _totalL2ToL1PubdataAndStateDiffs
     ) external returns (bytes32 outputHash) {
-        (bytes32 uncompressedStateDiffHash, bytes calldata _totalPubdata, bytes calldata leftover) = _produceStateDiffPubdata(
-            _chainedMessagesHash,
-            _chainedBytecodesHash,
-            _totalL2ToL1PubdataAndStateDiffs
-        );
+        (
+            bytes32 uncompressedStateDiffHash,
+            bytes calldata _totalPubdata,
+            bytes calldata leftover
+        ) = _produceStateDiffPubdata(_chainedMessagesHash, _chainedBytecodesHash, _totalL2ToL1PubdataAndStateDiffs);
 
         /// Check for calldata strict format
         if (leftover.length != 0) {
@@ -37,11 +37,6 @@ contract BitcoinL2DAValidator is IL2DAValidator, StateDiffL2DAValidator {
         // - First 32 bytes are the hash of the uncompressed state diff.
         // - Then, there is a 32-byte hash of the DA.
 
-        outputHash = keccak256(
-            abi.encodePacked(
-                uncompressedStateDiffHash,
-                EfficientCall.keccak(_totalPubdata)
-            )
-        );
+        outputHash = keccak256(abi.encodePacked(uncompressedStateDiffHash, EfficientCall.keccak(_totalPubdata)));
     }
 }

--- a/l2-contracts/contracts/data-availability/BitcoinL2DAValidator.sol
+++ b/l2-contracts/contracts/data-availability/BitcoinL2DAValidator.sol
@@ -2,8 +2,6 @@
 
 pragma solidity 0.8.24;
 
-// solhint-disable gas-custom-errors, reason-string
-
 import {IL2DAValidator} from "../interfaces/IL2DAValidator.sol";
 import {StateDiffL2DAValidator} from "./StateDiffL2DAValidator.sol";
 

--- a/l2-contracts/contracts/data-availability/BitcoinL2DAValidator.sol
+++ b/l2-contracts/contracts/data-availability/BitcoinL2DAValidator.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.24;
+
+// solhint-disable gas-custom-errors, reason-string
+
+import {IL2DAValidator} from "../interfaces/IL2DAValidator.sol";
+import {StateDiffL2DAValidator} from "./StateDiffL2DAValidator.sol";
+
+import {EfficientCall} from "@matterlabs/zksync-contracts/l2/system-contracts/libraries/EfficientCall.sol";
+import {ReconstructionMismatch, PubdataField} from "./DAErrors.sol";
+
+/// BitcoinDA validator. It will publish inclusion data that would allow to verify the inclusion.
+contract BitcoinL2DAValidator is IL2DAValidator, StateDiffL2DAValidator {
+    function validatePubdata(
+        // The rolling hash of the user L2->L1 logs.
+        bytes32,
+        // The root hash of the user L2->L1 logs.
+        bytes32,
+        // The chained hash of the L2->L1 messages
+        bytes32 _chainedMessagesHash,
+        // The chained hash of uncompressed bytecodes sent to L1
+        bytes32 _chainedBytecodesHash,
+        // Operator data, that is related to the DA itself
+        bytes calldata _totalL2ToL1PubdataAndStateDiffs
+    ) external returns (bytes32 outputHash) {
+        (bytes32 uncompressedStateDiffHash, bytes calldata _totalPubdata, bytes calldata leftover) = _produceStateDiffPubdata(
+            _chainedMessagesHash,
+            _chainedBytecodesHash,
+            _totalL2ToL1PubdataAndStateDiffs
+        );
+
+        /// Check for calldata strict format
+        if (leftover.length != 0) {
+            revert ReconstructionMismatch(PubdataField.ExtraData, bytes32(0), bytes32(leftover.length));
+        }
+
+        // The preimage under the hash `outputHash` is expected to be in the following format:
+        // - First 32 bytes are the hash of the uncompressed state diff.
+        // - Then, there is a 32-byte hash of the DA.
+
+        outputHash = keccak256(
+            abi.encodePacked(
+                uncompressedStateDiffHash,
+                EfficientCall.keccak(_totalPubdata)
+            )
+        );
+    }
+}

--- a/l2-contracts/foundry.toml
+++ b/l2-contracts/foundry.toml
@@ -25,3 +25,15 @@ fs_permissions = [
 [profile.default.zksync] 
 enable_eravm_extensions = true
 zksolc = "1.5.7"
+
+[profile.slither]
+# Inherit everything from the default profile but turn the IR pipeline off
+via_ir = false
+
+# Recompile system-contracts with IR so they don't hit the stack-depth limit.
+additional_compiler_profiles = [ { name = "ir", via_ir = true } ]
+
+compilation_restrictions = [
+  { paths = "lib/@matterlabs/**", via_ir = true },
+  { paths = "../system-contracts/**", via_ir = true }
+]

--- a/l2-contracts/slither.config.json
+++ b/l2-contracts/slither.config.json
@@ -1,5 +1,5 @@
 {
-  "filter_paths": "(contracts/dev-contracts|contracts/TestnetPaymaster.sol|lib|node_modules|src)",
+  "filter_paths": "(contracts/dev-contracts|contracts/TestnetPaymaster.sol|lib|node_modules|src|../system-contracts)",
   "detectors_to_exclude": "assembly,solc-version,low-level-calls,conformance-to-solidity-naming-conventions,incorrect-equality,uninitialized-local",
   "exclude_dependencies": true,
   "compile_force_framework": "foundry",

--- a/l2-contracts/slither.config.json
+++ b/l2-contracts/slither.config.json
@@ -1,5 +1,5 @@
 {
-  "filter_paths": "(contracts/dev-contracts|contracts/TestnetPaymaster.sol|contracts/data-availability/BitcoinL2DAValidator.sol|lib|node_modules|src)",
+  "filter_paths": "(contracts/dev-contracts|contracts/TestnetPaymaster.sol|lib|node_modules|src)",
   "detectors_to_exclude": "assembly,solc-version,low-level-calls,conformance-to-solidity-naming-conventions,incorrect-equality,uninitialized-local",
   "exclude_dependencies": true,
   "compile_force_framework": "foundry",

--- a/l2-contracts/slither.config.json
+++ b/l2-contracts/slither.config.json
@@ -1,5 +1,5 @@
 {
-  "filter_paths": "(contracts/dev-contracts|contracts/TestnetPaymaster.sol|lib|node_modules|src)",
+  "filter_paths": "(contracts/dev-contracts|contracts/TestnetPaymaster.sol|contracts/data-availability/BitcoinL2DAValidator.sol|lib|node_modules|src)",
   "detectors_to_exclude": "assembly,solc-version,low-level-calls,conformance-to-solidity-naming-conventions,incorrect-equality,uninitialized-local",
   "exclude_dependencies": true,
   "compile_force_framework": "foundry",

--- a/l2-contracts/slither.config.json
+++ b/l2-contracts/slither.config.json
@@ -1,7 +1,7 @@
 {
   "filter_paths": "(contracts/dev-contracts|contracts/TestnetPaymaster.sol|lib|node_modules|src)",
   "detectors_to_exclude": "assembly,solc-version,low-level-calls,conformance-to-solidity-naming-conventions,incorrect-equality,uninitialized-local",
-  "exclude_dependencies": false,
+  "exclude_dependencies": true,
   "compile_force_framework": "foundry",
   "exclude_medium": false,
   "exclude_high": false,

--- a/l2-contracts/slither.config.json
+++ b/l2-contracts/slither.config.json
@@ -1,5 +1,5 @@
 {
-  "filter_paths": "(contracts/dev-contracts|contracts/TestnetPaymaster.sol|lib|node_modules|src|../system-contracts)",
+  "filter_paths": "(contracts/dev-contracts|contracts/TestnetPaymaster.sol|lib|node_modules|src)",
   "detectors_to_exclude": "assembly,solc-version,low-level-calls,conformance-to-solidity-naming-conventions,incorrect-equality,uninitialized-local",
   "exclude_dependencies": true,
   "compile_force_framework": "foundry",

--- a/l2-contracts/slither.config.json
+++ b/l2-contracts/slither.config.json
@@ -3,6 +3,7 @@
   "detectors_to_exclude": "assembly,solc-version,low-level-calls,conformance-to-solidity-naming-conventions,incorrect-equality,uninitialized-local",
   "exclude_dependencies": true,
   "compile_force_framework": "foundry",
+  "compile_custom_build": "forge build --zksync --build-info",
   "exclude_medium": false,
   "exclude_high": false,
   "exclude_low": true,

--- a/l2-contracts/slither.config.json
+++ b/l2-contracts/slither.config.json
@@ -1,9 +1,8 @@
 {
   "filter_paths": "(contracts/dev-contracts|contracts/TestnetPaymaster.sol|lib|node_modules|src)",
   "detectors_to_exclude": "assembly,solc-version,low-level-calls,conformance-to-solidity-naming-conventions,incorrect-equality,uninitialized-local",
-  "exclude_dependencies": true,
+  "exclude_dependencies": false,
   "compile_force_framework": "foundry",
-  "compile_custom_build": "forge build --zksync --build-info",
   "exclude_medium": false,
   "exclude_high": false,
   "exclude_low": true,


### PR DESCRIPTION
## What ❔

This PR introduces the initial L1 smart contract changes required to support Syscoin's BitcoinDA as a Data Availability (DA) layer for ZKsync Era.

The key modifications involve:
*   **Adding a new DA validator contract specific to BitcoinDA For L1 and L2.**
*   **Modifying existing contracts (like the main ZKsync contract or a Bridgehub/DA manager contract) to:**
    *   Recognize a new DA type or ID for BitcoinDA.
    *   Interface with the new BitcoinDA validator contract for posting/verifying batch commitments.
    *   Potentially updating structs or enums related to DA layer choice or batch submission.
*   **Adding new events or error codes related to BitcoinDA.**
*   **Updating deployment scripts or configuration files for these new contracts.**

This PR is focused on integrating the on-chain components for BitcoinDA.

## Why ❔

These L1 smart contract modifications are essential to enable ZKsync Era chains (specifically Validiums) to use Syscoin's BitcoinDA for data availability. By integrating at the L1 contract level, we allow for:

*   **Syscoin pedigree:** merge-mined with Bitcoin since 2014, bringing 10 + years of Bitcoin hash-power to zkSync Era.
*   **BitVM2 roadmap:** Groundwork for a trust-minimised BTC ↔ L2 bridge once BitVM2 exits research. Pending whitepaper.
*   **On-chain verification of data availability:** Ensuring that batch data published to BitcoinDA can be cryptographically verified by the L1 ZKsync Era contracts.
*   **Trustless operation:** Providing a transparent and verifiable mechanism for DA, leveraging the security of the Syscoin network.
*   **Choice and Flexibility:** Offering ZK Stack deployers another robust and decentralized DA option, expanding the ecosystem.
*   **Governance-gated:** BitcoinDA validator must be added by Governance.addValidator() exactly like existing DA modules; nothing activates by default.

This work complements the off-chain integration of the BitcoinDA client in the ZKsync Era node software, providing the necessary on-chain counterpart for full BitcoinDA support. It allows for us to run on Syscoin with our precompile at 0x63 to support BitcoinDA. The motivation for the design is to remain compatible with your existing infrastructure and enable the new feature.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs). (Suggest: `feat(L1): Add initial smart contract support for BitcoinDA`)
- [ ] Tests for the changes have been added / updated. (Crucial: Have you added or updated L1 contract tests to cover the BitcoinDA path?)
- [x] Documentation comments have been added / updated. (Natspec for new contracts/functions, comments for complex logic).