### PR TITLE
Fix and refactor `recompute_hashes.sh`

### DIFF
--- a/AllContractsHashes.json
+++ b/AllContractsHashes.json
@@ -216,6 +216,14 @@
     "evmDeployedBytecodeHash": null
   },
   {
+    "contractName": "system-contracts/L2InteropRootStorage",
+    "zkBytecodeHash": "0x01000047d538cf3b3c0c262af843f5f6ae529b7a3585f6edd95bb60e27d6a3ce",
+    "zkBytecodePath": "/system-contracts/zkout/L2InteropRootStorage.sol/L2InteropRootStorage.json",
+    "evmBytecodeHash": null,
+    "evmBytecodePath": null,
+    "evmDeployedBytecodeHash": null
+  },
+  {
     "contractName": "system-contracts/L2LegacyBridgeFixUpgrade",
     "zkBytecodeHash": "0x01000353486fa25a8e732779a8598b6ddb631006a5721280b482fd228c031da0",
     "zkBytecodePath": "/system-contracts/zkout/L2LegacyBridgeFixUpgrade.sol/L2LegacyBridgeFixUpgrade.json",
@@ -729,865 +737,865 @@
   },
   {
     "contractName": "l1-contracts/AccessControlRestriction",
-    "zkBytecodeHash": "0x01000295229f9936e3d2404805a81a8cb3354e5613b3879b4f2cc6af89a1d77b",
+    "zkBytecodeHash": "0x0100029550442c1126374a1109539ae992df5416d6277c565e95f1f204381268",
     "zkBytecodePath": "/l1-contracts/zkout/AccessControlRestriction.sol/AccessControlRestriction.json",
-    "evmBytecodeHash": "0x39b5cb4e9712868d8e2a60a009348707e98eb1cf693cf9734436f9072c0fa273",
+    "evmBytecodeHash": "0x38c142e70210ac9d894120b99f6a4bfda3080390c44cdad9e482c0709a1236fe",
     "evmBytecodePath": "/l1-contracts/out/AccessControlRestriction.sol/AccessControlRestriction.json",
-    "evmDeployedBytecodeHash": "0x2b692598c4ebcb45a3ea3fddc1d45544c9c98131fffe2d41d3b63c4ae80be08d"
+    "evmDeployedBytecodeHash": "0xd72cd3b4248bab8c953ea061bd9e33f1e01f5b1adba93527a1d0dc6268c2c74e"
   },
   {
     "contractName": "l1-contracts/Address",
     "zkBytecodeHash": "0x01000007920a76c05c5b8a6eb413a4f61d7406617edbda6fa1e6fda77c58717a",
     "zkBytecodePath": "/l1-contracts/zkout/Address.sol/Address.json",
-    "evmBytecodeHash": "0x50642dd87abdb731d22b845d534a61bbe9c5145492fc6ac2ad5de86e1332cc71",
+    "evmBytecodeHash": "0x44f31887d1a9f5019a97ab46ccb9e5adbde4192848b5ef95525ab928d2b957d1",
     "evmBytecodePath": "/l1-contracts/out/Address.sol/Address.json",
-    "evmDeployedBytecodeHash": "0x816f1255a594513f2ebe09ca6f43588b0c34892a1e6e5c235b55e5fa28487816"
+    "evmDeployedBytecodeHash": "0x655bf5d2a1c24731b8b4aec6f333821c89123834d1a278594829425320924054"
   },
   {
     "contractName": "l1-contracts/AddressAliasHelper",
     "zkBytecodeHash": "0x010000078fadbc6298ac00b9ee69ced598d5c9454899747ac6f08a29b86110f9",
     "zkBytecodePath": "/l1-contracts/zkout/AddressAliasHelper.sol/AddressAliasHelper.json",
-    "evmBytecodeHash": "0xa9c1c49bb2dc3ad3182267f52b36454f72959ec8bb22899d190c77dd91ce3b64",
+    "evmBytecodeHash": "0xa203c642cfb209b70f35eec2c5d935f44a56e5d774c11ab13408549c7949b571",
     "evmBytecodePath": "/l1-contracts/out/AddressAliasHelper.sol/AddressAliasHelper.json",
-    "evmDeployedBytecodeHash": "0xe9b3508255462e7b382bf6008b3dba201391e80cca4cfc2d6b7ede176f7839d1"
+    "evmDeployedBytecodeHash": "0x8ab7bc69dd58eee0c4e0e7605c1947ac2f85478e86f2a66b9d573d70b16bdec0"
   },
   {
     "contractName": "l1-contracts/AddressUpgradeable",
     "zkBytecodeHash": "0x01000007dd0acb212a28acc95b5ec6fe781397ecee8013ec1953673209b7cd2b",
     "zkBytecodePath": "/l1-contracts/zkout/AddressUpgradeable.sol/AddressUpgradeable.json",
-    "evmBytecodeHash": "0x4e0dd43198a7ecb617561dc97b3fc4467f867cb91367cbec9163e31db17f9fa7",
+    "evmBytecodeHash": "0x38a29ed8beba53a99f1b6ef47652ee69c312448e33ab432800b14b8ee2cfc9ed",
     "evmBytecodePath": "/l1-contracts/out/AddressUpgradeable.sol/AddressUpgradeable.json",
-    "evmDeployedBytecodeHash": "0x6e925f804c21aa518203e10d04e838ca56322a9fabf41a2105ea063025a50a6f"
+    "evmDeployedBytecodeHash": "0x53e2ffa4c1c1413a5f6916111fee0f060b5b33ffb198a3cc8e5334f9a7266376"
   },
   {
     "contractName": "l1-contracts/AdminFacet",
-    "zkBytecodeHash": "0x010006c34690575ed79e4b02ef70d518a28ca543029c544849bdcd613b0dcf3d",
+    "zkBytecodeHash": "0x010006c709b842725cbcab7ccc323dc66ee1bfabacd5ea505333c4595481c27a",
     "zkBytecodePath": "/l1-contracts/zkout/Admin.sol/AdminFacet.json",
-    "evmBytecodeHash": "0x8ae3efc9ad8f2f615f2950a36808afe0d14f8aef24e7c0042fe019bd0b48fa7a",
+    "evmBytecodeHash": "0x3d4447186f0fa3425e42698bf1c15ddcf8728a947566eaba51bbe46a6966e021",
     "evmBytecodePath": "/l1-contracts/out/Admin.sol/AdminFacet.json",
-    "evmDeployedBytecodeHash": "0x9e116dcd0984c25e00313f594856cc6ae356fa29f4acc551a50a39a5c1f7f970"
+    "evmDeployedBytecodeHash": "0x3eab51eb07f131642d1f38cab4f5d546d7ddf13b45cc439ff97562d369cdd6a7"
   },
   {
     "contractName": "l1-contracts/Arrays",
     "zkBytecodeHash": "0x01000007ec54bcf91f8c27aa52160019edf07d15a0873f8757f565fbe77be64f",
     "zkBytecodePath": "/l1-contracts/zkout/Arrays.sol/Arrays.json",
-    "evmBytecodeHash": "0x3cdeb1ca49960f6361b81b9b34d95c39948fdfa5462e8e7bc99b901695eae79d",
+    "evmBytecodeHash": "0x26fd7744016ac6d4e37dfccffe4cfaa43e45bfaaca6f8b0f0ba79d7dfddeb204",
     "evmBytecodePath": "/l1-contracts/out/Arrays.sol/Arrays.json",
-    "evmDeployedBytecodeHash": "0xd13cce6d13fb1d0e6f6a6eb48827fa0800dc6ad4fc62e749fb667a42ce0273f9"
+    "evmDeployedBytecodeHash": "0x59a1ee26daaee608ed635912f11226ea3cd5ea90f0b9ac280af8f9608cea0647"
   },
   {
     "contractName": "l1-contracts/BatchDecoder",
-    "zkBytecodeHash": "0x01000007c59ea8b9d6097aee27ee74b687ffb589d657315429409e65a368e989",
+    "zkBytecodeHash": "0x01000007d52b46a2d92f1ae481eadc2b67bbcba098f20449a346e46c23b39939",
     "zkBytecodePath": "/l1-contracts/zkout/BatchDecoder.sol/BatchDecoder.json",
-    "evmBytecodeHash": "0x3c8e8dc37c3d596722cbd0006551efae50fc52fc6d0eedfb9c577fa9a9551fd3",
+    "evmBytecodeHash": "0x149dfbb6253c7b149a09f54cb80ccffd95eabd17b5152e016ced518256904c96",
     "evmBytecodePath": "/l1-contracts/out/BatchDecoder.sol/BatchDecoder.json",
-    "evmDeployedBytecodeHash": "0x4e54a9f0e8c17d8d415a92fd1a4238fd9c9bc3afa5e5f1049b1231c9c41148ef"
+    "evmDeployedBytecodeHash": "0x590f278af86aae2e06d40b06e8d48a57fb34ae6031c912c39ecfcb6dfc3de15a"
   },
   {
     "contractName": "l1-contracts/BeaconProxy",
     "zkBytecodeHash": "0x010000f1477ebc7355591c664c501757b31e9cd0025d565546fc0054f28a6411",
     "zkBytecodePath": "/l1-contracts/zkout/BeaconProxy.sol/BeaconProxy.json",
-    "evmBytecodeHash": "0x70fe6fb533ade74d2bf2cd6ba8e7a10c9bf9831c65b6d01ac968ada913ca5e88",
+    "evmBytecodeHash": "0x184b5575274b77332c1f67fd7bc9ac5df10e3ad555496bb7fb002163b5a9a53b",
     "evmBytecodePath": "/l1-contracts/out/BeaconProxy.sol/BeaconProxy.json",
-    "evmDeployedBytecodeHash": "0xd98972a966e6a38b007ca6c285511cbeb70fbebd6a4dbab9b0ba94c29a60392a"
+    "evmDeployedBytecodeHash": "0x0cafcc6e6241661129e1b2f13ff9922ea1280d30a803869b62956053af3d70b3"
   },
   {
     "contractName": "l1-contracts/BridgeHelper",
-    "zkBytecodeHash": "0x0100000762d0b67f55fe3efb43f24ad666cd2d542ee96931bc77946154703349",
+    "zkBytecodeHash": "0x01000007f3f470053ee2cfed6e90051dab2aaf0be7ea62160027270669a3e045",
     "zkBytecodePath": "/l1-contracts/zkout/BridgeHelper.sol/BridgeHelper.json",
-    "evmBytecodeHash": "0x1ca92fdd89d479c0105f67c46560649f91b7a5272e29aeeecfe89b27dd7fb601",
+    "evmBytecodeHash": "0xaff771514164087c9edcc8340964a445f256a88e44e1fc3d0ca09373f90fa8de",
     "evmBytecodePath": "/l1-contracts/out/BridgeHelper.sol/BridgeHelper.json",
-    "evmDeployedBytecodeHash": "0xac6d9cf90c603667c47d53fba4694fe99fa75b21c16608f2dccaa0e25ee5e159"
+    "evmDeployedBytecodeHash": "0x7a218948144b97c7ec8e48403ad4af6a6ea66ab014d14725f2016aeabc95fff5"
   },
   {
     "contractName": "l1-contracts/BridgedStandardERC20",
-    "zkBytecodeHash": "0x010004ed25522dee429288e9857d1215f2b4134e466faaf4aabaf4d774839d19",
+    "zkBytecodeHash": "0x010004edd0dcee5e504345c61ce0da6ea179688d4657ea9102e16c1633de68f8",
     "zkBytecodePath": "/l1-contracts/zkout/BridgedStandardERC20.sol/BridgedStandardERC20.json",
-    "evmBytecodeHash": "0xe824c9edc9d1cdb8ec6a41c00a0ae52a1b1ef9402b1641cdfe743b03d62b96bf",
+    "evmBytecodeHash": "0x72a12fda3399c4ed488108ed68af40215dd7dce76ab0ab2bb90e044c147dce0a",
     "evmBytecodePath": "/l1-contracts/out/BridgedStandardERC20.sol/BridgedStandardERC20.json",
-    "evmDeployedBytecodeHash": "0x2f50ce99191d4c1382b96b2e748846f6211fe62f2475d06515ab20a73213c39d"
+    "evmDeployedBytecodeHash": "0x51944f89b5b4e6372a11874b00d1160060ee37ae72b980e088a50dd317e1ef10"
   },
   {
     "contractName": "l1-contracts/Bridgehub",
-    "zkBytecodeHash": "0x010009d5ac2d5cf0036cfa674e66f73d21336371b4bd4204a61f7e4e340f84f2",
+    "zkBytecodeHash": "0x010009c97198e192d8171fe8f1c9ed4fa5d664db0e7b0c64d26f34c90bfb816e",
     "zkBytecodePath": "/l1-contracts/zkout/Bridgehub.sol/Bridgehub.json",
-    "evmBytecodeHash": "0x1f094031646478d900eaeb7189ba870e1697c880afc29ea269ac2f3d6be0d0d5",
+    "evmBytecodeHash": "0xe9dcf0ab39efe7d235e26532b481a840eb81dbe09ca9d4e90d81a05f0e2143ab",
     "evmBytecodePath": "/l1-contracts/out/Bridgehub.sol/Bridgehub.json",
-    "evmDeployedBytecodeHash": "0x426e689a89514f451fb3c20694dff76c956496bf4cd58903e034344ee16c26fe"
+    "evmDeployedBytecodeHash": "0x13c62a7ab49e4955757fac02268e16ed4702dcd9a0e3472e9229db5423bdbc82"
   },
   {
     "contractName": "l1-contracts/BytecodesSupplier",
-    "zkBytecodeHash": "0x010000bf45b6ad126be2275c2e9eee3cf9fe69725e2a4e561eb1ca9c12cc999f",
+    "zkBytecodeHash": "0x010000bf2e60ab49acfe5336f2b7b6fb66099ddf0beeb2f6e72a35c48fc46c55",
     "zkBytecodePath": "/l1-contracts/zkout/BytecodesSupplier.sol/BytecodesSupplier.json",
-    "evmBytecodeHash": "0xa0021e76547cbb301bfdbc48d6237a8b77d8ce26cd5123c4415629c0c63e2209",
+    "evmBytecodeHash": "0x599ca44f8ed56e298148acea1946646bfd75476a68dc0d8bffbef74633101807",
     "evmBytecodePath": "/l1-contracts/out/BytecodesSupplier.sol/BytecodesSupplier.json",
-    "evmDeployedBytecodeHash": "0xfdf86dbb17acb53c3c76e28b48f410683140df3cec0d47ae217dee60226ec0ee"
+    "evmDeployedBytecodeHash": "0x727e370e56d7fce69876581448c1b81ee99f3bf6fa40404883d62e714180abf9"
   },
   {
     "contractName": "l1-contracts/CTMDeploymentTracker",
-    "zkBytecodeHash": "0x01000177ea407523e0721ed65c782d9585dc32a8d284d6c7f3186b93b7a5c517",
+    "zkBytecodeHash": "0x01000177d3a4f9301ff9709fd69a6249a67bd5bcc163f551ff86902aea3f2562",
     "zkBytecodePath": "/l1-contracts/zkout/CTMDeploymentTracker.sol/CTMDeploymentTracker.json",
-    "evmBytecodeHash": "0x87effb2a3e0d8ebd472911e09e6c318f579adeecfe2f17b9839e13f1a1f4be56",
+    "evmBytecodeHash": "0x455908e97f08485e6dfa4705c95a53f568d4ef00ac4dda9ecf184c67649218b0",
     "evmBytecodePath": "/l1-contracts/out/CTMDeploymentTracker.sol/CTMDeploymentTracker.json",
-    "evmDeployedBytecodeHash": "0xfae865db67becc197d940421633afff1b861898647fee67bb3f5bfcc3f280531"
+    "evmDeployedBytecodeHash": "0x5ee33f5b2fc950bfd440a4771f237804f854e3613b22bcaebab7cc342ca3bd03"
   },
   {
     "contractName": "l1-contracts/ChainAdmin",
-    "zkBytecodeHash": "0x010001b17e319b8d66255ba940c6f1833fc1b05e8862bebe7a254e706949e8fd",
+    "zkBytecodeHash": "0x0100019b5ca862ca5064ac05f9bcbc063339a69fff2e645500a6a420e333e26f",
     "zkBytecodePath": "/l1-contracts/zkout/ChainAdmin.sol/ChainAdmin.json",
-    "evmBytecodeHash": "0x587c46f6e13429245ec3bc09a08a1888098ba322664c76ceb6004120a1c5168f",
+    "evmBytecodeHash": "0xcaaa1486d673a28894dfbba266e9803cccd25473a24d2df119005e9815a2f086",
     "evmBytecodePath": "/l1-contracts/out/ChainAdmin.sol/ChainAdmin.json",
-    "evmDeployedBytecodeHash": "0x8db736432f243d5b45667a154a5ecf910f31eac2ca750eebf5a3d5a4010ee898"
+    "evmDeployedBytecodeHash": "0xccab08cdceebcaa3500b356607ea6ca86b91c23b96fb6a91aaa902ddd26aa581"
   },
   {
     "contractName": "l1-contracts/ChainAdminOwnable",
-    "zkBytecodeHash": "0x0100012194f71c85a9b83393fe05f883f7cd276134347c0cf889e22cedef6172",
+    "zkBytecodeHash": "0x01000121d2fdfe47e971ee0db76d891cd3731eb1baad4a075115556eeb1a5aea",
     "zkBytecodePath": "/l1-contracts/zkout/ChainAdminOwnable.sol/ChainAdminOwnable.json",
-    "evmBytecodeHash": "0x606be3e3cb5d61cc41737572f8b51a50c80175d26f3c6d815dc1705ce00e8c29",
+    "evmBytecodeHash": "0x2deb556b48b1b85a3aedae9670b5262b342de3178464c0f151e65d972f55e5a6",
     "evmBytecodePath": "/l1-contracts/out/ChainAdminOwnable.sol/ChainAdminOwnable.json",
-    "evmDeployedBytecodeHash": "0x4ad4607a2c1b074d830c0d4e0f70566296558239f784054503c4c3309f17b101"
+    "evmDeployedBytecodeHash": "0x0a9bf32d442ca7f42f0c2809b301de0eef07f64b7a06fa18488259476ef118ad"
   },
   {
     "contractName": "l1-contracts/ChainRegistrar",
-    "zkBytecodeHash": "0x010001fbba7afbe068be6b3d40f74ce20b16b07108818a9bd1f5dde10936dbdc",
+    "zkBytecodeHash": "0x010001fbf67ee2ca32d0662a845c67c1b98e98d5fefdb05db42db7a0b9014d10",
     "zkBytecodePath": "/l1-contracts/zkout/ChainRegistrar.sol/ChainRegistrar.json",
-    "evmBytecodeHash": "0x59d4e3ff008762de15c7a274d8bd9aac19b497a14a65858a3784863df0d9ecde",
+    "evmBytecodeHash": "0xaea2949602f30c92d43b2270ed3773a87cf940c1106e539fd3e47dc4e064cf94",
     "evmBytecodePath": "/l1-contracts/out/ChainRegistrar.sol/ChainRegistrar.json",
-    "evmDeployedBytecodeHash": "0x620fa4531a3ef7a25b857e6f4704d4f98f6b24fcb5f8582547a7d95da26456ed"
+    "evmDeployedBytecodeHash": "0xef0576d805b732742d023208e654b8d6533220d60196be16521f4ee99b674b4d"
   },
   {
     "contractName": "l1-contracts/ChainTypeManager",
-    "zkBytecodeHash": "0x01000743b93a3a824fd5b2677056bed91593f327a371d83964cc20735731ca5f",
+    "zkBytecodeHash": "0x01000745e9ecbf68f380b7e6f09e6b6e07a41fa5abfa464012d8a3895053fe09",
     "zkBytecodePath": "/l1-contracts/zkout/ChainTypeManager.sol/ChainTypeManager.json",
-    "evmBytecodeHash": "0x5e7f7632a506b0b34e1c012ce3e73e873585fd91e7e7bc84daff986e7d3315fd",
+    "evmBytecodeHash": "0x8fac656b88d3769ed9033819ecd3cb37dc5ecd6546e333a8a7a3df75e559d785",
     "evmBytecodePath": "/l1-contracts/out/ChainTypeManager.sol/ChainTypeManager.json",
-    "evmDeployedBytecodeHash": "0x5200c2445f5d18e1ece3fd7331e730afa7c2285a6b65b6ad1b2fe3e98f682595"
+    "evmDeployedBytecodeHash": "0x2d08afdf12df31c310a64c5b823e786d36b930baa8de92c548efdd9ed52f2c53"
   },
   {
     "contractName": "l1-contracts/CountersUpgradeable",
     "zkBytecodeHash": "0x010000076df32a9bc96f42e9f3855c4229b8786a032635908de44c9ceb7bbe91",
     "zkBytecodePath": "/l1-contracts/zkout/CountersUpgradeable.sol/CountersUpgradeable.json",
-    "evmBytecodeHash": "0x2db8e6cd3078849ce3926a8eb9841fb5fd9d5ffe7d1d832cd84b8c7ae267c7e9",
+    "evmBytecodeHash": "0x7071434076da217427c816f5de5ab5bac551021e2f12c958867deddc27a39a8e",
     "evmBytecodePath": "/l1-contracts/out/CountersUpgradeable.sol/CountersUpgradeable.json",
-    "evmDeployedBytecodeHash": "0x5554cc69a5d787990518c0dfb3eb3aeb5fda0ac7d25d756bfa6faa3644fb7ecc"
+    "evmDeployedBytecodeHash": "0x3db860cb3f8135afaaf7c435ea1344bba7c9b5bdc73814c552badcdf8c75ef00"
   },
   {
     "contractName": "l1-contracts/Create2",
     "zkBytecodeHash": "0x01000007f2c54e57fe601024b571320f761a2811d849b0dfd82f4a43ac289a0d",
     "zkBytecodePath": "/l1-contracts/zkout/Create2.sol/Create2.json",
-    "evmBytecodeHash": "0xbf8297a1cb4ff4fc6dcd199d8a66b32f7b21b9e9a18d6d635d4e71e0d54fcc63",
+    "evmBytecodeHash": "0x9aed1d316c1467ea5f85421e1bd83802a6a348032231a774959b3cfcfabc6019",
     "evmBytecodePath": "/l1-contracts/out/Create2.sol/Create2.json",
-    "evmDeployedBytecodeHash": "0xed794d8d33062a4df19b10cb44c2eb16b1c89bf1227becbef7622365b9d6d1e5"
+    "evmDeployedBytecodeHash": "0xeb6028cf0aa18610f702b451f2dea9064d8ca35cedefeed9a82bb35a4431d859"
   },
   {
     "contractName": "l1-contracts/DataEncoding",
-    "zkBytecodeHash": "0x010000077e85db951824be45c9489ae331fc5fe111c1c042190c525a988d6610",
+    "zkBytecodeHash": "0x01000007ed4dacf956c64b68e39c996c25b38a7c472de449fe4b612a5a9779f0",
     "zkBytecodePath": "/l1-contracts/zkout/DataEncoding.sol/DataEncoding.json",
-    "evmBytecodeHash": "0xfbd68ec867cd725445406cce0548b62b0b37034b2894700acad9e6dad31acf44",
+    "evmBytecodeHash": "0x3951cb3b0a8faf119966f906889b8f22252b29b0f67cbfcfa27900d16a039cca",
     "evmBytecodePath": "/l1-contracts/out/DataEncoding.sol/DataEncoding.json",
-    "evmDeployedBytecodeHash": "0x0654c30ee5ab4cce0b8e1fe4d17adee5875a72e1dba137782a044a75caa41774"
+    "evmDeployedBytecodeHash": "0x9c1e0577e06dad84bd3dae065d931d56d8855f9afd8a15ec1991ca0de86aa348"
   },
   {
     "contractName": "l1-contracts/DefaultUpgrade",
-    "zkBytecodeHash": "0x010002c783437a52fa6e575c94fe0fe85c405cabe9eab0005a1c6ebe03643c35",
+    "zkBytecodeHash": "0x010002c7a9401404ede707cf682d6b1b787879f5037b25a0410ff55932a9f309",
     "zkBytecodePath": "/l1-contracts/zkout/DefaultUpgrade.sol/DefaultUpgrade.json",
-    "evmBytecodeHash": "0x11c0bee8cd7dd432e70ecffbdf9be50c84435023d60b2a5807d5fa0cf5328dc3",
+    "evmBytecodeHash": "0x67564082bc1d345d3ca3ae55e9110821b9d384f41c6c90e35508caa73c864013",
     "evmBytecodePath": "/l1-contracts/out/DefaultUpgrade.sol/DefaultUpgrade.json",
-    "evmDeployedBytecodeHash": "0x0ab59afc6a5d1a26274f02891ba0c11fc72fa16df7b1f9b98ad51a1b699356cf"
+    "evmDeployedBytecodeHash": "0x99450820201a59a3162fd85af7cb09da43c22cf9bbf37298d0cbf91fa483da90"
   },
   {
     "contractName": "l1-contracts/Diamond",
-    "zkBytecodeHash": "0x01000007a2fba73c5ea196fa51223985de117d9bead503b2e8cf0121882b832f",
+    "zkBytecodeHash": "0x010000071007cf298d54770f11cb8e6b844007937640e2b18c670072bfda3ebc",
     "zkBytecodePath": "/l1-contracts/zkout/Diamond.sol/Diamond.json",
-    "evmBytecodeHash": "0x2d9cf5c0ef00117fe07c65c008407168ab6572aaecec28e3d5689cb618795369",
+    "evmBytecodeHash": "0x674e6c3a941dbe1e931ced3754c01af17f9e1fe37dbb2032872eb5254118b546",
     "evmBytecodePath": "/l1-contracts/out/Diamond.sol/Diamond.json",
-    "evmDeployedBytecodeHash": "0xb4e24d5bbb7f506bddead022286dcaf5f0d9d5bfe140ded61d7ad8b5c7b682c1"
+    "evmDeployedBytecodeHash": "0xf5375d350a6f98acc8d77a8d9e235c3e3547e734f5ecda732fe029c4d7000326"
   },
   {
     "contractName": "l1-contracts/DiamondInit",
-    "zkBytecodeHash": "0x0100006b098af0bcc8151eb1abce1403608ba1138e48aee54b7ff79743646259",
+    "zkBytecodeHash": "0x0100006bcac00f492980d4483ade04571bc1bd8ff4baf59bc53acd0224ddd90e",
     "zkBytecodePath": "/l1-contracts/zkout/DiamondInit.sol/DiamondInit.json",
-    "evmBytecodeHash": "0x6ba463fbc4518dab57c9e1f1283465c2c4b7c28fd5eb70c19a451b32f5b8143f",
+    "evmBytecodeHash": "0xfe7a311dc0672fc64b4eeefb785c9f28b56509449029f749564c8ea2eef5b8f0",
     "evmBytecodePath": "/l1-contracts/out/DiamondInit.sol/DiamondInit.json",
-    "evmDeployedBytecodeHash": "0x6184d15cb5fe76323309b311ac8a57819a6c5aaa984318c2642a01cd6cff78ea"
+    "evmDeployedBytecodeHash": "0x047eae86337f41268fb7e7826c08bcd8d1ced0a117eb51e4108496992e6ca96d"
   },
   {
     "contractName": "l1-contracts/DiamondProxy",
-    "zkBytecodeHash": "0x0100024595152492dfcd1739a168ebf27b94718adf651c18ce96942ed6f8813b",
+    "zkBytecodeHash": "0x010002451ccc94333715a157585d842249a239fe7f82a1dfa0f978ea2d81c457",
     "zkBytecodePath": "/l1-contracts/zkout/DiamondProxy.sol/DiamondProxy.json",
-    "evmBytecodeHash": "0xe467b4076fa13ab668f5ad6aa38e1ad86e803b260f9078491743c774c2472590",
+    "evmBytecodeHash": "0x6389ef87cfa71495919cbef60e22d6ab39e0e72809a7a685fc215f93a79b561f",
     "evmBytecodePath": "/l1-contracts/out/DiamondProxy.sol/DiamondProxy.json",
-    "evmDeployedBytecodeHash": "0x1bac0f438e678d28a1700daed6a25590c84578e06cbb1ce678e410bf72b5d928"
+    "evmDeployedBytecodeHash": "0x26298c6ccc0b1c4aacc3599cb31d401f9f247d0f92bc5f8473a5ee80ab1b08eb"
   },
   {
     "contractName": "l1-contracts/DualVerifier",
-    "zkBytecodeHash": "0x010000d3a881fbe860ae23f4a4fa3ef83d6e3f5aa50641f12ad7cac7ee04e689",
+    "zkBytecodeHash": "0x010000d39c263c420bad51525f248ee58f1c15b45c8366138ec177701599ebd7",
     "zkBytecodePath": "/l1-contracts/zkout/DualVerifier.sol/DualVerifier.json",
-    "evmBytecodeHash": "0x87ba66ed487f61eae43ae2d2f531a5251c9bef604d772b62f2df5461cc76bb61",
+    "evmBytecodeHash": "0xc283bf9a9d6ef0e66066febfcaa17c6388fdd1f13a2a20bc9143e03fc12578d9",
     "evmBytecodePath": "/l1-contracts/out/DualVerifier.sol/DualVerifier.json",
-    "evmDeployedBytecodeHash": "0xcc942920333ee9422c7dbd9f3bd587cee79122d7f2e57749982b657edff4d549"
+    "evmDeployedBytecodeHash": "0x199bbbd1b6dd9f0ca27a17f06c5d3b912d2adbdbec75c959322fbcc892741177"
   },
   {
     "contractName": "l1-contracts/DynamicIncrementalMerkle",
-    "zkBytecodeHash": "0x01000007816d4ab72fc47366a8656769ac363517273369449a0b02ac9200d9b6",
+    "zkBytecodeHash": "0x010000070e28c4ddfa974e05b5b13b28fac5bee98548df2d65984280eab62f4c",
     "zkBytecodePath": "/l1-contracts/zkout/DynamicIncrementalMerkle.sol/DynamicIncrementalMerkle.json",
-    "evmBytecodeHash": "0x3876164de3da0d9b9eb9637efb892417aa191759fa7585d43cf6181eee6fbadc",
+    "evmBytecodeHash": "0xb1c1c1d81126b63be743618ac825a4ac258285f7ef61b6e200757232daa44ae4",
     "evmBytecodePath": "/l1-contracts/out/DynamicIncrementalMerkle.sol/DynamicIncrementalMerkle.json",
-    "evmDeployedBytecodeHash": "0x5b0c4c24b0f5ee9e7094b26cd07cb0ddbc645de97965ff13e61b6b987bd6fd2f"
+    "evmDeployedBytecodeHash": "0x3cf5f79100c0bb8b323f7dfb34471c95be04463845a9c389ad44bf909a2d85bb"
   },
   {
     "contractName": "l1-contracts/ECDSAUpgradeable",
     "zkBytecodeHash": "0x01000007060437b2f23712de7b3e19db54d9e77235802daf5be2e79f723f32af",
     "zkBytecodePath": "/l1-contracts/zkout/ECDSAUpgradeable.sol/ECDSAUpgradeable.json",
-    "evmBytecodeHash": "0x4dc94826ab3488229991b6a087799cb74c70e08ea543a0b4a79b83cd3738774b",
+    "evmBytecodeHash": "0x45b0989dd4d1bcb68f7bdb8ce184007fec943b96e9189921edbab7f385d9d19a",
     "evmBytecodePath": "/l1-contracts/out/ECDSAUpgradeable.sol/ECDSAUpgradeable.json",
-    "evmDeployedBytecodeHash": "0x5f8548a188370531952b89772e90dd048fd6f5f17518bf03f7207d9f9f9e1841"
+    "evmDeployedBytecodeHash": "0xb2ec41d689db29b06d4c6b47428de1e9b76009f79ad4773c5121936660be820c"
   },
   {
     "contractName": "l1-contracts/ERC1967Proxy",
     "zkBytecodeHash": "0x010000995b4bcbf4b9d2eede849e79ef7f2019fdbfca92122e14bcd8f21172ee",
     "zkBytecodePath": "/l1-contracts/zkout/ERC1967Proxy.sol/ERC1967Proxy.json",
-    "evmBytecodeHash": "0x76536d2506147297710c71ebb9b13960c8f7aaddd512d48ccd4fe8ac00d6ddc7",
+    "evmBytecodeHash": "0x639e924e702f9bf05d79ad5df5ed8385db8f864b4fa76d35ba07cac84fff5ea0",
     "evmBytecodePath": "/l1-contracts/out/ERC1967Proxy.sol/ERC1967Proxy.json",
-    "evmDeployedBytecodeHash": "0x95eebd4d5e1c0c7747e3f02a11196ef6bf2096c1cbfb847291cc70481b9ae4c0"
+    "evmDeployedBytecodeHash": "0x8f3c2962f60b63a8099a4fdd81c56cc3a41691a0b6f4489fecee93c2523c6e30"
   },
   {
     "contractName": "l1-contracts/ERC20",
     "zkBytecodeHash": "0x0100014f180f4dd3eb99a9434dbc88812b1d0d009b4923a2c8bb1734b406dc06",
     "zkBytecodePath": "/l1-contracts/zkout/ERC20.sol/ERC20.json",
-    "evmBytecodeHash": "0xfdf9dcaa39e27121a9fb4c600f83e3071bea4322fc4c017116eca67995b1c1a4",
+    "evmBytecodeHash": "0xeb8f010e1d1170e3b4f4dd40885a44721d9af8217c99a45ea67a75cfb70409de",
     "evmBytecodePath": "/l1-contracts/out/ERC20.sol/ERC20.json",
-    "evmDeployedBytecodeHash": "0xc06fb68d0c98fb02aa89485a16a0972d2858547af602234de6fbcab34663cd1c"
+    "evmDeployedBytecodeHash": "0x413b2a40df22f17f003682d2c9d5fc6f8935f321f890b9dceee64f55c9719282"
   },
   {
     "contractName": "l1-contracts/ERC20Upgradeable",
     "zkBytecodeHash": "0x010000e522ee538248b60f5b06dc3a55ab2639adecc19bd76edf57a4379dba0e",
     "zkBytecodePath": "/l1-contracts/zkout/ERC20Upgradeable.sol/ERC20Upgradeable.json",
-    "evmBytecodeHash": "0xf043b0e2a047d3cc7fa1a836ec4044b72c649718c0ce9e2505058abb6690c3be",
+    "evmBytecodeHash": "0xddd70a6696fb17ffaf8d16c3632316a2e9318ae0e8ba60bf6dfa418c0f32bc3c",
     "evmBytecodePath": "/l1-contracts/out/ERC20Upgradeable.sol/ERC20Upgradeable.json",
-    "evmDeployedBytecodeHash": "0x4b1e528e3ec0896a541d0abb856de38b7ff3c2ab94ab0964c8ad02019bd56b1a"
+    "evmDeployedBytecodeHash": "0x4321a72ace1a62ab2bd9c5b69b7091a0ffa53604bb9071b2b87d3df627900129"
   },
   {
     "contractName": "l1-contracts/EnumerableMap",
     "zkBytecodeHash": "0x01000007a146063593c95a2bbfdd41cea358ddc106150b57d75a197d51845684",
     "zkBytecodePath": "/l1-contracts/zkout/EnumerableMap.sol/EnumerableMap.json",
-    "evmBytecodeHash": "0x4e706b5cad8582565eb327d5015400b5be85d84adb2a33bc45578e518e8a2a3f",
+    "evmBytecodeHash": "0xdbaf071446f208e5897c283d52b4137da89e4cf7a6c48a4ee5e4135477c13110",
     "evmBytecodePath": "/l1-contracts/out/EnumerableMap.sol/EnumerableMap.json",
-    "evmDeployedBytecodeHash": "0x1f1fb0750fad0a17767d83937946295d75e4c8cf1cd7da1a34926f3240e4b51c"
+    "evmDeployedBytecodeHash": "0xf8202694c98600ac6cada19deaf7078aa60d54ad9285c7f78007f74e8a4b730a"
   },
   {
     "contractName": "l1-contracts/EnumerableSet",
     "zkBytecodeHash": "0x01000007b58459aa05910ae26cf0ae5c1df59de5bd23590c8553f007c47a3240",
     "zkBytecodePath": "/l1-contracts/zkout/EnumerableSet.sol/EnumerableSet.json",
-    "evmBytecodeHash": "0x1b75be205e5012e35adff478e243862487084bc9e6020a58ed475d4c6b137a0a",
+    "evmBytecodeHash": "0x442a7e4ecc0cfb1fcba4ba78c446aff03ac29c83f7d272f4234982113cf211cb",
     "evmBytecodePath": "/l1-contracts/out/EnumerableSet.sol/EnumerableSet.json",
-    "evmDeployedBytecodeHash": "0xf1f6f341abf71b89aaf7cfb81a9eca19e5fe6f61c2ce541277a43c8f246530c6"
+    "evmDeployedBytecodeHash": "0x0f35afce43ac4926b0e8db603480bbe7c345e75fdba1bca421e53374d99c899d"
   },
   {
     "contractName": "l1-contracts/ExecutorFacet",
-    "zkBytecodeHash": "0x01000647b6725c7b423bf7db595b0871020be1d939ebcd0f0660f6000956629d",
+    "zkBytecodeHash": "0x010006a56ca8074f0224489ad67b22658612855a23596201b47fbf3c75686505",
     "zkBytecodePath": "/l1-contracts/zkout/Executor.sol/ExecutorFacet.json",
-    "evmBytecodeHash": "0x236882dec60090d2fa6ebbc22d57cae86a63f3f45cf20e63813e5331267dcae7",
+    "evmBytecodeHash": "0x61eb4d8ebe7428bc306b0a23d545d5e5f83725b28cf70ec2fe72ed8d3fd024db",
     "evmBytecodePath": "/l1-contracts/out/Executor.sol/ExecutorFacet.json",
-    "evmDeployedBytecodeHash": "0xecbb1341d7ce9cd48d6798b09369faebd54f6db2722b554af02fb6d63fd25c1d"
+    "evmDeployedBytecodeHash": "0x69332d0469c630d87b7473d49cdefd2837c5fdc66a0e93eb00e49a3831ca9c94"
   },
   {
     "contractName": "l1-contracts/FullMerkle",
-    "zkBytecodeHash": "0x01000007550f32006132801d8b2e71cae744f168c4ec8a71e8a69e22e52a5a03",
+    "zkBytecodeHash": "0x01000007b4e7dfdde2b24938df2ef0851f40d48553350f1748e6364ea4548155",
     "zkBytecodePath": "/l1-contracts/zkout/FullMerkle.sol/FullMerkle.json",
-    "evmBytecodeHash": "0xed3af20ae70ba17df8e964dced1fd96f7d70aaf1d227a59c9ed6d81f5282fcb2",
+    "evmBytecodeHash": "0xe394b4d470725a2ccb0550f0dc192c7c0a0df511084e67d8270a3c9df9a612ef",
     "evmBytecodePath": "/l1-contracts/out/FullMerkle.sol/FullMerkle.json",
-    "evmDeployedBytecodeHash": "0x9118ad427529fc383b9b0dc2df9336fa64246479509df6d38154cce6ba127843"
+    "evmDeployedBytecodeHash": "0x9e59d774b5dbc1156485ecf651fde091fc712335b6359fbf285e3703c3a3c1e5"
   },
   {
     "contractName": "l1-contracts/GatewayCTMDeployer",
-    "zkBytecodeHash": "0x010003bf65c147505fd82772d973b76721364258462cbd115cef674ea916fbdf",
+    "zkBytecodeHash": "0x010003bf34ce3714783600c89fb39a7be79730bf5c81778876cd70864bf802a0",
     "zkBytecodePath": "/l1-contracts/zkout/GatewayCTMDeployer.sol/GatewayCTMDeployer.json",
-    "evmBytecodeHash": "0x19b91ed0237c81cc3b42469e3ac8c309366fc8de8dd8e1d946e94f5bf2c866a7",
+    "evmBytecodeHash": "0x03906e83248016fc3b8a71c0ca478bb4a01e0cfa01f6329b8dca7e526210a666",
     "evmBytecodePath": "/l1-contracts/out/GatewayCTMDeployer.sol/GatewayCTMDeployer.json",
-    "evmDeployedBytecodeHash": "0x2878ce6ca6eaea776c221e7e9bd45382f0dc4d399992b7bb96edc0f4f61bcf56"
+    "evmDeployedBytecodeHash": "0xbd3e32d957a40331bdf7a0c11e063ccb17a92432002fc502bde446da69b7c8f2"
   },
   {
     "contractName": "l1-contracts/GatewayTransactionFilterer",
-    "zkBytecodeHash": "0x0100013d861a00847ed28ea6f9b3590436b6e5a30fd54ce4003b9bd3b308e21d",
+    "zkBytecodeHash": "0x0100013df55e2a8f0501ff176014704ce6872c994dbcfe4c2d2b66fc1733300a",
     "zkBytecodePath": "/l1-contracts/zkout/GatewayTransactionFilterer.sol/GatewayTransactionFilterer.json",
-    "evmBytecodeHash": "0x23d1348c63ca21b735fe95c3687319512e56c6b2df1d41a1b8b378312ff9731e",
+    "evmBytecodeHash": "0x15ae611d17d0e9c3f485d298c82ecbe406301459a0df659f174723e21fb56dec",
     "evmBytecodePath": "/l1-contracts/out/GatewayTransactionFilterer.sol/GatewayTransactionFilterer.json",
-    "evmDeployedBytecodeHash": "0xa68a869e457533ea13e2bebca4acaafb46dc0d1f4eb638079134e776cb9948b9"
+    "evmDeployedBytecodeHash": "0xa1d326ff21db4a5e638594e224b0f32909224b03428dc0213aa55c2f93624a01"
   },
   {
     "contractName": "l1-contracts/GatewayUpgrade",
-    "zkBytecodeHash": "0x0100058103c1bee5350dca67fe2e29be6fec83a102c38a19b4ab6fe98cf260df",
+    "zkBytecodeHash": "0x01000581f32862ebf72fdcc9d110ba43c839758551207a65d0423ba52dafc7f8",
     "zkBytecodePath": "/l1-contracts/zkout/GatewayUpgrade.sol/GatewayUpgrade.json",
-    "evmBytecodeHash": "0x42172fcde94a819c275d1ba8cfe980498292d0772d454b9ace04eb4997caf670",
+    "evmBytecodeHash": "0x2a4763758477aa66a7fd1294a8f1c9ce982b1b13c4f3b36dabde4145f27688e4",
     "evmBytecodePath": "/l1-contracts/out/GatewayUpgrade.sol/GatewayUpgrade.json",
-    "evmDeployedBytecodeHash": "0x06c40046761fa7d7647f03e14bc031eb55d139b9a16afc86bd718f3b6b601a11"
+    "evmDeployedBytecodeHash": "0x5de4438639d9de6d5d123ab9b7e4ee6c82e764deda7e7c0adabdd7c3f198230e"
   },
   {
     "contractName": "l1-contracts/GettersFacet",
-    "zkBytecodeHash": "0x010001b5dcc1085d73535264f45b36874b62fb280bb266e9b47307586e8eb654",
+    "zkBytecodeHash": "0x010001b5508147f67c1a44bfd440da83abcc36cce630ba88ab19c9982b869a58",
     "zkBytecodePath": "/l1-contracts/zkout/Getters.sol/GettersFacet.json",
-    "evmBytecodeHash": "0x87b2444e1a7223ef8668cb441d7e32a5eac7580395badab260c5b6ce82480075",
+    "evmBytecodeHash": "0x6f0288fe5fabf444dd1043218572e97e5c411fb886688776e834956a08ebb3da",
     "evmBytecodePath": "/l1-contracts/out/Getters.sol/GettersFacet.json",
-    "evmDeployedBytecodeHash": "0x77fd1c1a6e9ec7612f57fbf9c0f99cc3f2110547aa8100428ee23732da26f0be"
+    "evmDeployedBytecodeHash": "0x1679cc9af0a6024b3d12e77e770ad25a218cc3fd1212aff3d3242c1ad54c52d7"
   },
   {
     "contractName": "l1-contracts/Governance",
-    "zkBytecodeHash": "0x010003010c86e3b595b9c670d21e1923e4a8623603aca69f188682f1df5a0217",
+    "zkBytecodeHash": "0x01000301b9682418b287cac18ee087d651b46572c946d4da75fa6541e5aaea9c",
     "zkBytecodePath": "/l1-contracts/zkout/Governance.sol/Governance.json",
-    "evmBytecodeHash": "0x0bcec36748b65c451287bc2353d8b180663153873394e0f9d863ecae6e47ed53",
+    "evmBytecodeHash": "0x35078e0e2ad9e3eb37a8ba264d7736db5117ecead45f837e6ecab65f9f5c6234",
     "evmBytecodePath": "/l1-contracts/out/Governance.sol/Governance.json",
-    "evmDeployedBytecodeHash": "0x0105064fe49bd8e98b838bfb1396ef3ebbd929b8ed11b39508af93263e94a4b5"
+    "evmDeployedBytecodeHash": "0x76711bae10276f7b55d42afee7345062a7a7151e371c6331b788fc687c5919a5"
   },
   {
     "contractName": "l1-contracts/GovernanceUpgradeTimer",
-    "zkBytecodeHash": "0x010000c10f09d0baf7f72526c98030961374a4b12a4df8e32b8c6270911b4723",
+    "zkBytecodeHash": "0x010000c10dbbeb888dde882cde14687478d4f21c0e0e793ad2d504356f4c4324",
     "zkBytecodePath": "/l1-contracts/zkout/GovernanceUpgradeTimer.sol/GovernanceUpgradeTimer.json",
-    "evmBytecodeHash": "0x26d4b4cc5bd61997446458419a722f4ed74083bc1cc58362edbda40e6a48c77e",
+    "evmBytecodeHash": "0x7feabcebaf66c7fab297216f67b51edacc50c4b5a5f8f917b1b965f738400cc8",
     "evmBytecodePath": "/l1-contracts/out/GovernanceUpgradeTimer.sol/GovernanceUpgradeTimer.json",
-    "evmDeployedBytecodeHash": "0x3d884e6542d9d5fa051f9d4401798af23aff74ea234868b1396aa7b7454baee5"
+    "evmDeployedBytecodeHash": "0x387c853ba15cd7135aabb095330ad603dad08728fcc0ce45767b57aedb5ace4e"
   },
   {
     "contractName": "l1-contracts/L1AssetRouter",
-    "zkBytecodeHash": "0x010008374d4f9ea9e5eeb3acedc36ee40f74b76b53fc4c00f420feb6860d71bf",
+    "zkBytecodeHash": "0x010008372a52382395246b65e1c72dce86b902b4dea4c42efd9e2ed3befd9166",
     "zkBytecodePath": "/l1-contracts/zkout/L1AssetRouter.sol/L1AssetRouter.json",
-    "evmBytecodeHash": "0x82cbb68550aff429a3eb643f76b6553c1f0d3c60d55fb0c7d11dfd3172ac12ff",
+    "evmBytecodeHash": "0xdda10ea9690965537ae700bb2a95c8e4e4d47c97d4688819f276e6a2bcc34462",
     "evmBytecodePath": "/l1-contracts/out/L1AssetRouter.sol/L1AssetRouter.json",
-    "evmDeployedBytecodeHash": "0xc99f95ae2d3ca1029e0c3f3eaba5e0062c5d91b0aaaa9cac12ac647fdf563088"
+    "evmDeployedBytecodeHash": "0x3fd93de9c844fe8c6f248c57014900a81a6f854586cbc251700b1c084c414b23"
   },
   {
     "contractName": "l1-contracts/L1ERC20Bridge",
-    "zkBytecodeHash": "0x010002e98b3ebf314903fa87905b01bc6e5dffb59a41b68e743df09916845f7b",
+    "zkBytecodeHash": "0x010002e91da85998faabc9a38f25bcbed0439ede8030a8ea2874cdd5301510c5",
     "zkBytecodePath": "/l1-contracts/zkout/L1ERC20Bridge.sol/L1ERC20Bridge.json",
-    "evmBytecodeHash": "0x708af6bfdf8be7321bd62f331ada80e0cfc6233b9ab9410113869d6d1b9957ef",
+    "evmBytecodeHash": "0xc452adcc2ebc25df3e6f27f0c009d76d2fad478ad1d0e67ed99ff76e205eedda",
     "evmBytecodePath": "/l1-contracts/out/L1ERC20Bridge.sol/L1ERC20Bridge.json",
-    "evmDeployedBytecodeHash": "0x73230d48d3d522880871490a54bcd5803b1958725980245fc4469d64b9f24891"
+    "evmDeployedBytecodeHash": "0x927765e4450badf0a885b19bdd399585abf6e017f74b8c0e0388da87b530b17b"
   },
   {
     "contractName": "l1-contracts/L1GenesisUpgrade",
-    "zkBytecodeHash": "0x010006c5884cf207cfdbe9de3909b5726431ffac7216150d9505f315dedd4b36",
+    "zkBytecodeHash": "0x010006c5dd3d3275859a479c20de1690f374c748b5c6cb9bb7fad3e4522b7c45",
     "zkBytecodePath": "/l1-contracts/zkout/L1GenesisUpgrade.sol/L1GenesisUpgrade.json",
-    "evmBytecodeHash": "0xbd4bb65d0f79b0d74fd1b39d100303ccecf10e09c668b3d7cf4c72da086e9664",
+    "evmBytecodeHash": "0x0ec0bbaceacca7b3f24587f246c0b5baa6911b607df76479a0706e9b3451bdef",
     "evmBytecodePath": "/l1-contracts/out/L1GenesisUpgrade.sol/L1GenesisUpgrade.json",
-    "evmDeployedBytecodeHash": "0xec5e1ed308f0bc1b577e6a851371e9035fce075e710777bae8c0cd26a97dabc3"
+    "evmDeployedBytecodeHash": "0xeaea340f8c16a714da0162007cae7ed9fb1fdd12322ac5fb9802f5ac367eaa81"
   },
   {
     "contractName": "l1-contracts/L1NativeTokenVault",
-    "zkBytecodeHash": "0x01000989a1d047bae3c4624c2d7b374f8bfedf2abd0fe87cf6d5b644757bc876",
+    "zkBytecodeHash": "0x01000989eee39dc842246fab836075146ba17bafe4673e8397aaac257966b9ba",
     "zkBytecodePath": "/l1-contracts/zkout/L1NativeTokenVault.sol/L1NativeTokenVault.json",
-    "evmBytecodeHash": "0x4f53bf92df1590927d1e849a59be54277324c189cabb975947f55874b9f50e5d",
+    "evmBytecodeHash": "0x3ed095bd4e5ec468bca27759ae3391ba677bf882edb902f1d783a529905873e1",
     "evmBytecodePath": "/l1-contracts/out/L1NativeTokenVault.sol/L1NativeTokenVault.json",
-    "evmDeployedBytecodeHash": "0xf52b627964e4edd5bf4ad851b6ebf3b08bccaa7ac47634c54bd57bb923541028"
+    "evmDeployedBytecodeHash": "0xe7a8ddb50a88b9c9954ab81e99b14a3cb0363de6f9f1c9e56f4edebf1b1449ab"
   },
   {
     "contractName": "l1-contracts/L1Nullifier",
-    "zkBytecodeHash": "0x01000659b92e962d1065547c060364fea760347bfea65f8d4af85bde0e8c11ce",
+    "zkBytecodeHash": "0x010006592327fb0ffdc79da67df723e15c119a64df2e82e03ab761d5d7bb0902",
     "zkBytecodePath": "/l1-contracts/zkout/L1Nullifier.sol/L1Nullifier.json",
-    "evmBytecodeHash": "0x853188c4425140ae67f9d4bef72c5d9cdf24fbd9ed915bb76ea5cf55b1aba86e",
+    "evmBytecodeHash": "0x33082ef7596f90006b37ab0fb4b22b7a060f4babb878daa7b5c91d662bbe550f",
     "evmBytecodePath": "/l1-contracts/out/L1Nullifier.sol/L1Nullifier.json",
-    "evmDeployedBytecodeHash": "0x3c0c69b0033ebf79d11a2a14044355d0f98773a17999ed99c58b6d7eb0ef0203"
+    "evmDeployedBytecodeHash": "0xd592c2751ce4def60dac5267976f5f2cd98d681ccd4103e08eddb771c1f038e4"
   },
   {
     "contractName": "l1-contracts/L1VerifierFflonk",
     "zkBytecodeHash": "0x010009bfd544c0fafedf518944bc814a06b28bbb88224aed8d74d19cec3d982b",
     "zkBytecodePath": "/l1-contracts/zkout/L1VerifierFflonk.sol/L1VerifierFflonk.json",
-    "evmBytecodeHash": "0xc8472dbb6768bdd2ff66db95af75471c879cdf266866491f1261fb038eea4f65",
+    "evmBytecodeHash": "0xe426d2c374bec47131bec1fa5600572c58d757da5703ddd8f9b7b3a156174273",
     "evmBytecodePath": "/l1-contracts/out/L1VerifierFflonk.sol/L1VerifierFflonk.json",
-    "evmDeployedBytecodeHash": "0x7a90ab51401789d938cba9746a9ce346eb83f07c28d73a6a64ae8170879045e0"
+    "evmDeployedBytecodeHash": "0x1f4d9e6ffd53a2ed040b4662ab1fc5f7d46b4e86633eac1c388da6cbc385441a"
   },
   {
     "contractName": "l1-contracts/L1VerifierPlonk",
     "zkBytecodeHash": "0x01000dbbcf7703d7db99c4007645f2761f7a9d65bff63fedc98ab48ebf49ec68",
     "zkBytecodePath": "/l1-contracts/zkout/L1VerifierPlonk.sol/L1VerifierPlonk.json",
-    "evmBytecodeHash": "0xe5bc313c647e4e09df97fc65ab976c8269978ee3006b490ea4e17c88fee4053a",
+    "evmBytecodeHash": "0x5530d608ab404a08df88c58ba682b7e9b66b692497ddb7e5b7e1a5279d6de3c2",
     "evmBytecodePath": "/l1-contracts/out/L1VerifierPlonk.sol/L1VerifierPlonk.json",
-    "evmDeployedBytecodeHash": "0x9e2d982d812614e9315c854d9bf7b13a28d71f43609ac5af9cb79c8485ee5b43"
+    "evmDeployedBytecodeHash": "0x63f5ca70246327998dc88bc56a177cdacb9bac28b668e8e9710bcee68517da5d"
   },
   {
     "contractName": "l1-contracts/L2AdminFactory",
-    "zkBytecodeHash": "0x010000bb0cd7b22e93abc3ac6e7a3b87b960aa0e0afe7e3e40522ae61f4ef17d",
+    "zkBytecodeHash": "0x010000bbb07bb3f5387dc5c7aee0a47fe141952fb2c34732bda27aed342728d1",
     "zkBytecodePath": "/l1-contracts/zkout/L2AdminFactory.sol/L2AdminFactory.json",
-    "evmBytecodeHash": "0xa0a7ce5f88b000cfa6ad6aae5284bc84c572cca59e320913d6cf0ee4f5d78d8e",
+    "evmBytecodeHash": "0x4cd9b03e9e72cddb21b73e7dc76002466e5c6caf856173b1f589f8d1fa54eaa4",
     "evmBytecodePath": "/l1-contracts/out/L2AdminFactory.sol/L2AdminFactory.json",
-    "evmDeployedBytecodeHash": "0x6fb20ba4e21f62880ab60d6d4d5cca5a7b78cab4d3669b5400dad1d2380749d1"
+    "evmDeployedBytecodeHash": "0x21c51ebd471fd55e98e119235598b46c78d5e1cbcf3d2447363765967e72b86f"
   },
   {
     "contractName": "l1-contracts/L2AssetRouter",
-    "zkBytecodeHash": "0x010005312039098877a4754a4ab7ea354aeeefdab32e1e11e9cbb462f2e64e0e",
+    "zkBytecodeHash": "0x01000531e4474195b403859f14f5d48ebc1985c1db9a3296ce6194b0461702d2",
     "zkBytecodePath": "/l1-contracts/zkout/L2AssetRouter.sol/L2AssetRouter.json",
-    "evmBytecodeHash": "0xfa04609f958e827fe225ff3b132c5cf1f74b075bb8f2bc8bcc9a354d842debdf",
+    "evmBytecodeHash": "0x11936adc95eeab8f66bd20998839f31b0f9ad2afce95c107b682e26c02a4d417",
     "evmBytecodePath": "/l1-contracts/out/L2AssetRouter.sol/L2AssetRouter.json",
-    "evmDeployedBytecodeHash": "0x44b137bd450f79d10c29c272b62413c075d3100ceb1095b5ddc68457ebf9900a"
+    "evmDeployedBytecodeHash": "0x14ce576b1b542e7ab2cb7bc25a5974d174cb7958824a7012e49aaef4a7ebe711"
   },
   {
     "contractName": "l1-contracts/L2ContractHelper",
-    "zkBytecodeHash": "0x0100000768110dc36572eef1e251ec4989ae2a2a3da452a14c953f675bf8438e",
+    "zkBytecodeHash": "0x010000071f459e38447fccb548eae5d6eec26fddc1ff2b6e9318397a02825fcd",
     "zkBytecodePath": "/l1-contracts/zkout/L2ContractHelper.sol/L2ContractHelper.json",
-    "evmBytecodeHash": "0x3b85514ac88855d90529bec162c28e43441600738b1bd20678ca5321890e3231",
+    "evmBytecodeHash": "0x0cf442608d5b45bae0647d47f7da03b6e4b9c4e0d8341834e745377bde498922",
     "evmBytecodePath": "/l1-contracts/out/L2ContractHelper.sol/L2ContractHelper.json",
-    "evmDeployedBytecodeHash": "0x5621ccdd5e0e45fd3e8ea3a435832de619a137bfbdab3bfd2d02399103a87f5d"
+    "evmDeployedBytecodeHash": "0x599598414c9e3e95fd0fb6695e23030c6da76819c670159373eca3ce358d69d6"
   },
   {
     "contractName": "l1-contracts/L2MessageVerification",
-    "zkBytecodeHash": "0x010001599f465b4e59fe8264622c28065138ba9146ea1d8194fffa6c8cf652d2",
+    "zkBytecodeHash": "0x01000159a46015f09471f022f2ae9bc6f1214ab48b9b9322365d1460d7e3b25f",
     "zkBytecodePath": "/l1-contracts/zkout/L2MessageVerification.sol/L2MessageVerification.json",
-    "evmBytecodeHash": "0xc4b99467a6f246ee0acb242de2b9735fc71bc2d17952773864d844f27488aada",
+    "evmBytecodeHash": "0xcbf04067126ca1ba71c1de269f9f3780657f6dda12708fa58bb5bf062247a39f",
     "evmBytecodePath": "/l1-contracts/out/L2MessageVerification.sol/L2MessageVerification.json",
-    "evmDeployedBytecodeHash": "0xc2bd0ee7c55255f73649bb40d4bc5e78748f9ef682d384aae6fc9e3886baf64a"
+    "evmDeployedBytecodeHash": "0xbab7d9f97d6c5c57b8b53306130f7fb94efe8b35320c968daa76f4a1d3139e09"
   },
   {
     "contractName": "l1-contracts/L2NativeTokenVault",
-    "zkBytecodeHash": "0x0100084fb0fcb2248aca9be1d9dae2175723f5bab3cd2fceea0cdd6dc4ead8ef",
+    "zkBytecodeHash": "0x0100084fa2eb3ff890d24ac75cdc559a6ca96246e5b4a36e27c0b11218329230",
     "zkBytecodePath": "/l1-contracts/zkout/L2NativeTokenVault.sol/L2NativeTokenVault.json",
-    "evmBytecodeHash": "0xbce9a006e9e116a55881a1a6a181880da3ac2cb0ce6d274b00271e4d6268b64d",
+    "evmBytecodeHash": "0x15249ad86e2d701be6891f390cb6b7c642914c79c4c97088cc3fd8e3d8815d1e",
     "evmBytecodePath": "/l1-contracts/out/L2NativeTokenVault.sol/L2NativeTokenVault.json",
-    "evmDeployedBytecodeHash": "0x3de139afb8cedf376287ca1418db079118ca705f302502fc069c2ce75c872815"
+    "evmDeployedBytecodeHash": "0x0b92dd9c02453b97e53c167f17c9a7f1cd011cf1a81cf31b9b1629c6c567622d"
   },
   {
     "contractName": "l1-contracts/L2ProxyAdminDeployer",
     "zkBytecodeHash": "0x0100005fcb83d64a2c142996104330e7ce72ae4c2828fa8305d2524cd457e9a5",
     "zkBytecodePath": "/l1-contracts/zkout/L2ProxyAdminDeployer.sol/L2ProxyAdminDeployer.json",
-    "evmBytecodeHash": "0x3d7ac817bf44b7213b2f6672d1eec308f7534b9ee707839b297a34c637a818ee",
+    "evmBytecodeHash": "0x1e8f5d06fdb324849b9c6bfb4ef083d65cc219d3c28d6d0720bfe9e49a799e38",
     "evmBytecodePath": "/l1-contracts/out/L2ProxyAdminDeployer.sol/L2ProxyAdminDeployer.json",
-    "evmDeployedBytecodeHash": "0x017e0a802b14c0f5070490f38b3a6dae7311de0350d9469b0251ae89a3cd9145"
+    "evmDeployedBytecodeHash": "0xfff52b67c457cd8e8ad8ae16d0d39044ed69b0f8fdf102bd83301713658420ac"
   },
   {
     "contractName": "l1-contracts/L2SharedBridgeLegacy",
-    "zkBytecodeHash": "0x01000195febda094464da95c219a8a49e04f8874eebf3df4bc7eef73c182f2eb",
+    "zkBytecodeHash": "0x01000195395fc4a1a15cf84f6b8a2db9920f7b75996794c5830c15334226c52c",
     "zkBytecodePath": "/l1-contracts/zkout/L2SharedBridgeLegacy.sol/L2SharedBridgeLegacy.json",
-    "evmBytecodeHash": "0xb4ee560a9d15b9579ca8de97d1b6330467abb3bf9258e655a79b5f7bd28bad12",
+    "evmBytecodeHash": "0x4959ad7b3b08aedab73f68ce1549b26e003732e92592b307b20489b6756b4ccb",
     "evmBytecodePath": "/l1-contracts/out/L2SharedBridgeLegacy.sol/L2SharedBridgeLegacy.json",
-    "evmDeployedBytecodeHash": "0x9385a5c8dcdaa3c2c3d71bbf6a0866a87eb15413cce1926da1c29274b6642a9b"
+    "evmDeployedBytecodeHash": "0x81084bc7128c8d82826c491b997d2c13afd2b1c6d6d0a0ed50926a922077ed6f"
   },
   {
     "contractName": "l1-contracts/L2VerifierFflonk",
     "zkBytecodeHash": "0x010009ed63bf50172f3e96e673d22a571f642f1fb4d03d46d6393deabe770eb6",
     "zkBytecodePath": "/l1-contracts/zkout/L2VerifierFflonk.sol/L2VerifierFflonk.json",
-    "evmBytecodeHash": "0x0889848661601a2535c5ba7e10e722d5276d65c75016a503cbca51db04e6d14c",
+    "evmBytecodeHash": "0x00e904fdb27b0babd63ae0358cfb6f0725b159f083a871a329fe95ceaa04b858",
     "evmBytecodePath": "/l1-contracts/out/L2VerifierFflonk.sol/L2VerifierFflonk.json",
-    "evmDeployedBytecodeHash": "0xda91cabde56063fe5faf06667ba1d070be6a39e5677a9fa015eafc137113ba27"
+    "evmDeployedBytecodeHash": "0x9627de65d3a9f6c25716a15f5ec73e45132d60ab9114b895cd2673f2bb376433"
   },
   {
     "contractName": "l1-contracts/L2VerifierPlonk",
     "zkBytecodeHash": "0x01000e176f9efebfe1b3a193ba398eb2b09e2290768e2bea53201177f2cc45b4",
     "zkBytecodePath": "/l1-contracts/zkout/L2VerifierPlonk.sol/L2VerifierPlonk.json",
-    "evmBytecodeHash": "0x17c988ee73be6b005565c350724354a42cec2e398a5eae022d9e92a9712d4409",
+    "evmBytecodeHash": "0xbec1a485562e9615ea9a322b6105d8ebfe2aeb58f111cc085191ee9adbf2b15c",
     "evmBytecodePath": "/l1-contracts/out/L2VerifierPlonk.sol/L2VerifierPlonk.json",
-    "evmDeployedBytecodeHash": "0x5e7c84743330846d1d3142aea3bfea483a186e7df20c4c192f4b2035499da965"
+    "evmDeployedBytecodeHash": "0x9643514599b7f38d2812c2ba757597e32400abdf1d38cd22770c339b151f613e"
   },
   {
     "contractName": "l1-contracts/L2WrappedBaseToken",
-    "zkBytecodeHash": "0x01000341553ad0a53ecbc340a2cdedf7a7eeb23a40dab92d45c57c482147d542",
+    "zkBytecodeHash": "0x01000341c5d203db49cb291d1da683e6627424be8876ae51cfe4f0310d918a42",
     "zkBytecodePath": "/l1-contracts/zkout/L2WrappedBaseToken.sol/L2WrappedBaseToken.json",
-    "evmBytecodeHash": "0xe205867e95682a9a39c3b5fe5ab04dba2d547ad72cf23c75733d45c3ff2b1069",
+    "evmBytecodeHash": "0xcd0e85b964bb852b36c3a8e81349778fa4d35efef8e7b0bb2540881dfa700bd9",
     "evmBytecodePath": "/l1-contracts/out/L2WrappedBaseToken.sol/L2WrappedBaseToken.json",
-    "evmDeployedBytecodeHash": "0xe57382a7f52c2dac822d26f3ce1df45a7eee815ba8b532ba49ca01d61fb1406c"
+    "evmDeployedBytecodeHash": "0xc5358a844549b5b315d4534d0daa62c5b95dd550fa388654998d10dc13bcf30f"
   },
   {
     "contractName": "l1-contracts/L2WrappedBaseTokenStore",
-    "zkBytecodeHash": "0x010000a9da7be905b492a63410923aed89df5a937e0ade7c59172b21753ca697",
+    "zkBytecodeHash": "0x010000a90ed2f4427c6ed16c50ef545d7fec827074f34838be29af98811f9780",
     "zkBytecodePath": "/l1-contracts/zkout/L2WrappedBaseTokenStore.sol/L2WrappedBaseTokenStore.json",
-    "evmBytecodeHash": "0x9caf2dc833deff68d7df5223e72df1768f58df47f08be46c09aeb6b80e4a0f16",
+    "evmBytecodeHash": "0x10ac794e4f83d6101601a4566c74a56266b1921366c2a81e8ef0caada663d04a",
     "evmBytecodePath": "/l1-contracts/out/L2WrappedBaseTokenStore.sol/L2WrappedBaseTokenStore.json",
-    "evmDeployedBytecodeHash": "0x66cf846d2bf74657aaef63f5cab9c83920fe064e22a0be1d8f961cf5230c5d65"
+    "evmDeployedBytecodeHash": "0x17304d1bdd04eaf0329b0c3932912d40f31a8dfb2938ce37b3af14d7f97f300b"
   },
   {
     "contractName": "l1-contracts/LibMap",
     "zkBytecodeHash": "0x01000007c9d4634530675b17346b57327af5c6f4ee376f121d51ab7b0a2a2111",
     "zkBytecodePath": "/l1-contracts/zkout/LibMap.sol/LibMap.json",
-    "evmBytecodeHash": "0xd675a82c93214994e704e9ca6cb42be1ef15e05f08b62105b94591c1451c16f9",
+    "evmBytecodeHash": "0xf42e70eebfbf2ed5a48f9ea7fe219ecddb9141ccec22a2f45ef157f040ed069c",
     "evmBytecodePath": "/l1-contracts/out/LibMap.sol/LibMap.json",
-    "evmDeployedBytecodeHash": "0x5e2fe29366bb5dddde2f3fc4252b29aefc397a93b54fa2e5f4d70da6819c3976"
+    "evmDeployedBytecodeHash": "0xb04da1fa9abde93053529e51c9d95ca7fd5cd8750ddc95196dd35d767e351e3f"
   },
   {
     "contractName": "l1-contracts/MailboxFacet",
-    "zkBytecodeHash": "0x0100063130b7d5b5f8487587d2ce8c89d9e925d2d5a5db42fdbcdac6857b2310",
+    "zkBytecodeHash": "0x010006852c3eb23cfd667a7f7704166e1621a8451a51d8e29ce7ec96ec9b4cd3",
     "zkBytecodePath": "/l1-contracts/zkout/Mailbox.sol/MailboxFacet.json",
-    "evmBytecodeHash": "0x9206b56869e7610e9e50e60fb4b3cafce696db97f74f31d7f2d307832d5124a0",
+    "evmBytecodeHash": "0x3c3f8eaad19bf8802aebe81e5b57c4ad9f4203713e58a506467e81a98e0d6c12",
     "evmBytecodePath": "/l1-contracts/out/Mailbox.sol/MailboxFacet.json",
-    "evmDeployedBytecodeHash": "0x4c0300f5c28f52282b95bd463c001bc9ef4f478bc23161955a3ee5e3d701275b"
+    "evmDeployedBytecodeHash": "0xd78d024ef460aa0fdf5e61b00ff91f592698e8bae6c90d238d68a2386cc195d3"
   },
   {
     "contractName": "l1-contracts/Math",
     "zkBytecodeHash": "0x0100000784fa40c1f5aa5ee8bd526141395649512aad43de97ea24e2129e4aa6",
     "zkBytecodePath": "/l1-contracts/zkout/Math.sol/Math.json",
-    "evmBytecodeHash": "0xeb3cd324348d499b5e6de60073b4f19e827e0d107d4022be3771b23b52c0664a",
+    "evmBytecodeHash": "0xabecd4724f22900dc525e9a4daaf64a96a95d47e9b0dec07274596849f100b2f",
     "evmBytecodePath": "/l1-contracts/out/Math.sol/Math.json",
-    "evmDeployedBytecodeHash": "0xab9c090573375499650fb22d219649a1ef03eff2c05294f3930ab20eae5c1230"
+    "evmDeployedBytecodeHash": "0x611ebc15d83cab0253f8563ca3e8fa2fa06f9cde479d2488be2587c77f2957c2"
   },
   {
     "contractName": "l1-contracts/MathUpgradeable",
     "zkBytecodeHash": "0x01000007d5aec9b0ffc3be29e7464aa6833f48bbb44d6485e811e281d6949713",
     "zkBytecodePath": "/l1-contracts/zkout/MathUpgradeable.sol/MathUpgradeable.json",
-    "evmBytecodeHash": "0xf3bf3a6d5324771cba823f95550c6a9eca4ac5d91f3ca7a8797ca4d6f86709cb",
+    "evmBytecodeHash": "0xe5867878d597542e10c27fb14302bdd38082656f7e59b77687c35a830942023d",
     "evmBytecodePath": "/l1-contracts/out/MathUpgradeable.sol/MathUpgradeable.json",
-    "evmDeployedBytecodeHash": "0x20f7236bd2051084ff472a2dab7230610a1689a79aca2f9108632fe557b6cb35"
+    "evmDeployedBytecodeHash": "0xcc623e83cffb8625f737ecafc3090c939d55c567a45dcdeddb547deb1d312445"
   },
   {
     "contractName": "l1-contracts/Merkle",
-    "zkBytecodeHash": "0x010000071d6627e00f5c999145074a0709abfaec638ea5051b29a5cb1ffc0687",
+    "zkBytecodeHash": "0x01000007a7c4faae4909735589d7589bdcde0db310be5d398289663d00fc1292",
     "zkBytecodePath": "/l1-contracts/zkout/Merkle.sol/Merkle.json",
-    "evmBytecodeHash": "0x77c77bb5f9449f9885c832d8eb0446ce3bca97e5df9e106d35ec340d931c8714",
+    "evmBytecodeHash": "0x9371ed9380e621cf49c44fbbdfd7a3b5150f505c9a65594f29df218554d70fcc",
     "evmBytecodePath": "/l1-contracts/out/Merkle.sol/Merkle.json",
-    "evmDeployedBytecodeHash": "0x713ebe733650ce6ae893fa5b9669295755dd3d7953fff29440d3a56c97a5642f"
+    "evmDeployedBytecodeHash": "0xb76e38b5fa6dc05249ce833d476b0219e8e6a403b9f68fc03ecff79a7ff96bf7"
   },
   {
     "contractName": "l1-contracts/MessageHashing",
-    "zkBytecodeHash": "0x010000079a305ce4f1acfd6335db50aabbcfdd8e3e33fb52b07de7c321d47013",
+    "zkBytecodeHash": "0x01000007894dfc017838d39678efa5be694f287f7084344421f5f87510ab773f",
     "zkBytecodePath": "/l1-contracts/zkout/MessageHashing.sol/MessageHashing.json",
-    "evmBytecodeHash": "0xdf0ab35d7ea64d1ae6fa3f0b7799ab3fef3c7c5af6cacf9e1dd93e16fda936fb",
+    "evmBytecodeHash": "0x90fb5a6dabef914ef4c5b464e840a581a47cb3495093559067b9a7e41beb49c4",
     "evmBytecodePath": "/l1-contracts/out/MessageHashing.sol/MessageHashing.json",
-    "evmDeployedBytecodeHash": "0x9a6d8f59073ea762f6178ab9327655d569cc2077d8edae59665e12763b6035a1"
+    "evmDeployedBytecodeHash": "0x9718805c5fc92072936b31a61ca2778250bf2150ac423f7f92df3532803c14cb"
   },
   {
     "contractName": "l1-contracts/MessageRoot",
-    "zkBytecodeHash": "0x010003e54cf56d329be0c829566a3e7e79aa0ae135fb5f452ec3c199d6af4b9b",
+    "zkBytecodeHash": "0x010003a9fb498113ea723c63d5acabeeea30c568277cb6337cf5626ec62abad8",
     "zkBytecodePath": "/l1-contracts/zkout/MessageRoot.sol/MessageRoot.json",
-    "evmBytecodeHash": "0xb2977b85155cb0d070198c747177858f1371d8fdcd0d487b2dc450fc9005021c",
+    "evmBytecodeHash": "0x3806aca993c52cb978dae299148ca5ca8464a7b59bef654944dc495c2ac7d1f1",
     "evmBytecodePath": "/l1-contracts/out/MessageRoot.sol/MessageRoot.json",
-    "evmDeployedBytecodeHash": "0xea1a13eddf2d163f2d122a16bf655a7ebf4a50f6826fa329e2d1765f5b26872e"
+    "evmDeployedBytecodeHash": "0x703b1ec992be3264bf14e860cddf96d958b250a99247b581e693be6b052a91f8"
   },
   {
     "contractName": "l1-contracts/PermanentRestriction",
-    "zkBytecodeHash": "0x0100031132827bab8ab45922044a4abb2a04a9e17a6e3c554e7ea6b051ff8c88",
+    "zkBytecodeHash": "0x01000311d0643aa02d45700767198c9467e01605184bc888dacabaa83c1bc4a2",
     "zkBytecodePath": "/l1-contracts/zkout/PermanentRestriction.sol/PermanentRestriction.json",
-    "evmBytecodeHash": "0xe58b35e8d48fdf95d4607f37f743aa5f35096f4db006e42fcc4ad6117be4bb81",
+    "evmBytecodeHash": "0xe83352da4da0edf041f87167f3b2a3d4e34ec24aa6cf40fc6cd6e84b82f1fe2f",
     "evmBytecodePath": "/l1-contracts/out/PermanentRestriction.sol/PermanentRestriction.json",
-    "evmDeployedBytecodeHash": "0xb3ccf7fbe3ee6678ef2970eb543a6a5682d3842b6bff4fae984c5317042c0479"
+    "evmDeployedBytecodeHash": "0xac88df6b8547aeaa2a39ed86876f92a2469118e77aca5b662fb4791c0024ff19"
   },
   {
     "contractName": "l1-contracts/PriorityQueue",
-    "zkBytecodeHash": "0x010000071958ae6193acd246d77dd6881c6c4b2b389e4ff957ce8afa022d68dd",
+    "zkBytecodeHash": "0x01000007b8d18e35d3ff35935dbdd032b2cad24bf50912974c6962db0661769c",
     "zkBytecodePath": "/l1-contracts/zkout/PriorityQueue.sol/PriorityQueue.json",
-    "evmBytecodeHash": "0x9863016593dee9ce8505c6459cd4bdd6e23d0f4f5a92e4068ffeb229705c1cdd",
+    "evmBytecodeHash": "0x82b826047c55d1f0e29b63c41bf07659a7bf6212bf6a68d350849247bc32407a",
     "evmBytecodePath": "/l1-contracts/out/PriorityQueue.sol/PriorityQueue.json",
-    "evmDeployedBytecodeHash": "0x4815db925b1ef14e524c60b71af81c61216a7f9d02a7bd16ff99b9da009bf554"
+    "evmDeployedBytecodeHash": "0x49d651be036488fbc34ddfe8e5562bd3ac0b4b9460442c4bcc6636f3ace23a1a"
   },
   {
     "contractName": "l1-contracts/PriorityTree",
-    "zkBytecodeHash": "0x01000007737ef0abac02a57deece17062f4c7ac2b4838e279d3fb616045dac83",
+    "zkBytecodeHash": "0x01000007aeaf7b3b44ec679845950c38ddce6de69498b932d5f0aaa3384ad041",
     "zkBytecodePath": "/l1-contracts/zkout/PriorityTree.sol/PriorityTree.json",
-    "evmBytecodeHash": "0x617f235e6eded731ce9a332fa506532f91a5d7ece663bfb15c3d26cd3dc17a17",
+    "evmBytecodeHash": "0x5be76f637144f21e870032baf6ca3cdb610e624b844f0a5277b64ddc8d8e5882",
     "evmBytecodePath": "/l1-contracts/out/PriorityTree.sol/PriorityTree.json",
-    "evmDeployedBytecodeHash": "0x929bc6987e01016df830aa2bce0f308bdf38eaafcf9eaf19dbf72a4dd6c2b42a"
+    "evmDeployedBytecodeHash": "0xac8c0b5ce4e220b9039793b109f530dcce973d377b0ccbdcb2150db1a07b7ae1"
   },
   {
     "contractName": "l1-contracts/ProxyAdmin",
     "zkBytecodeHash": "0x010000e18d0788d925e16659993ff65cb636c3ed1fd5b90115ee07382b3ce24f",
     "zkBytecodePath": "/l1-contracts/zkout/ProxyAdmin.sol/ProxyAdmin.json",
-    "evmBytecodeHash": "0xae804cba018bd20f1433163bdb40280e81dd2b07ea50524148886c3682abb0a2",
+    "evmBytecodeHash": "0xcff4661a94eb7c3f61715f683aeacf0ba7a67f132bcc7bfe85886a9633abd5c7",
     "evmBytecodePath": "/l1-contracts/out/ProxyAdmin.sol/ProxyAdmin.json",
-    "evmDeployedBytecodeHash": "0x14ab4271cecf41fd1de3364dcfb049553af19593cac645b24ca375c52a9c50ff"
+    "evmDeployedBytecodeHash": "0x3e24f5627da795c9c92719f33975de5a51026252289f4884c9e1ff3c6d7737e6"
   },
   {
     "contractName": "l1-contracts/RelayedSLDAValidator",
-    "zkBytecodeHash": "0x010000fd10f1e9a372cf56a9a77b1efaccae5281366c81dc404440a6eeef30b8",
+    "zkBytecodeHash": "0x010000fdfd9bb94f11f7e05f15695792b0e83c5a959aec296e6b972cdeceb6cc",
     "zkBytecodePath": "/l1-contracts/zkout/RelayedSLDAValidator.sol/RelayedSLDAValidator.json",
-    "evmBytecodeHash": "0x5d23d78164090fd9d0093c8002876a6991ddfba451684ec931939014d9f6c830",
+    "evmBytecodeHash": "0xcac013245ec7be98c26e0b03cf45275cd52bebf62a176f4f22e89e7638972a74",
     "evmBytecodePath": "/l1-contracts/out/RelayedSLDAValidator.sol/RelayedSLDAValidator.json",
-    "evmDeployedBytecodeHash": "0xc810680302c2f1c6877c5fa745138176ee17672549e843b583eebf1b23961f40"
+    "evmDeployedBytecodeHash": "0xbdb381a9407950daaeb1ff781d7e2855880b241b43d2497ab58955383658b276"
   },
   {
     "contractName": "l1-contracts/RestrictionValidator",
-    "zkBytecodeHash": "0x0100000776a408e3116e9c16110a5c91001b040b26b82e81b72edd7cdbe9c4a9",
+    "zkBytecodeHash": "0x01000007d1376362470aa34a8b6e01ec56736a13e4e4bf5d722dd63dd3685359",
     "zkBytecodePath": "/l1-contracts/zkout/RestrictionValidator.sol/RestrictionValidator.json",
-    "evmBytecodeHash": "0x3cecaf8dc65907c854b434131e71101db92cedb8e8c960416209a03bce0b42d6",
+    "evmBytecodeHash": "0xc4e6a8600e95931994c69e2d35a0c7d34201d15402032e3d23955c97923bee86",
     "evmBytecodePath": "/l1-contracts/out/RestrictionValidator.sol/RestrictionValidator.json",
-    "evmDeployedBytecodeHash": "0x50059f062753c7decf858d333bf5f62844bf4f252c52cb793b03798023a38ca6"
+    "evmDeployedBytecodeHash": "0x5d1fcdcb3c09bf6a61fb4e564a3efda3aac24a76797e80e454daa53a7a849b54"
   },
   {
     "contractName": "l1-contracts/RevertReceiveAccount",
     "zkBytecodeHash": "0x0100001b8591fba336df6685cf15a8f823a0111d0a6370e9f695abd1bd23cf3f",
     "zkBytecodePath": "/l1-contracts/zkout/RevertReceiveAccount.sol/RevertReceiveAccount.json",
-    "evmBytecodeHash": "0x2267239699453c5998d497bbc39e1b64b2c22cf3ad69326b3b5929a27971e12f",
+    "evmBytecodeHash": "0x1466d202351a4de66b9d8cc46bb974319c8a7094529f403cb4258fcb3be84fdd",
     "evmBytecodePath": "/l1-contracts/out/RevertReceiveAccount.sol/RevertReceiveAccount.json",
-    "evmDeployedBytecodeHash": "0xc900e4080679f84148d32383c2aefce71aaa6ce63504ace61595b5c1b9b0f215"
+    "evmDeployedBytecodeHash": "0x8d3cf4c920fb12e19f149c622ef8e007cb7e2e8edb4f263e38e849e8decb8306"
   },
   {
     "contractName": "l1-contracts/RevertTransferERC20",
     "zkBytecodeHash": "0x0100017b9a39434f86ab39017bcc0fd821445875a6a1aa93ac7a3aef1b7347c7",
     "zkBytecodePath": "/l1-contracts/zkout/RevertTransferERC20.sol/RevertTransferERC20.json",
-    "evmBytecodeHash": "0x398006d07ea9f30a7a7e4fd11eedb254c33957985bedd401b098817d6b72c728",
+    "evmBytecodeHash": "0xbcb1344f61cc43da0dd723b8564eff8567f0ebeaaa04a494f6cc39fd694d6f88",
     "evmBytecodePath": "/l1-contracts/out/RevertTransferERC20.sol/RevertTransferERC20.json",
-    "evmDeployedBytecodeHash": "0xb4afdd7a35adcf6994891369dddefcc5569651f61fa3c20b2da2fb61e59e1252"
+    "evmDeployedBytecodeHash": "0x8e5e41e7bca05882d9294f226218802839ac87805414de8755c8276f03a3d8fe"
   },
   {
     "contractName": "l1-contracts/RollupDAManager",
-    "zkBytecodeHash": "0x0100007111b1817680b0fb2ed41571fb93651bb05a12f3d4816266bdede03381",
+    "zkBytecodeHash": "0x01000071da5054220410ac5963d1a515cf0aa6644fdf4fe0fdd11bc9047ce361",
     "zkBytecodePath": "/l1-contracts/zkout/RollupDAManager.sol/RollupDAManager.json",
-    "evmBytecodeHash": "0x6e482ffae4498e34212f5ed9a807dbe278e704cf0c04ca9c9aa783e73c2e9821",
+    "evmBytecodeHash": "0x3000f89452688a51cbc31e5210438ed360db8e85aa48bde3de03bbb2f595f0f5",
     "evmBytecodePath": "/l1-contracts/out/RollupDAManager.sol/RollupDAManager.json",
-    "evmDeployedBytecodeHash": "0xbe78f34bcc117aa59d5dd46d10d7d3d00b1897b85a039994f64da96d9426fb59"
+    "evmDeployedBytecodeHash": "0xa45ea2f9300712c83c223df708948f2a14183e8deffdcca855129e9f3a555658"
   },
   {
     "contractName": "l1-contracts/SafeCast",
     "zkBytecodeHash": "0x0100000730acac4ef083a37d6ab89aa36cd9963db4e489879b78fd75f23430a5",
     "zkBytecodePath": "/l1-contracts/zkout/SafeCast.sol/SafeCast.json",
-    "evmBytecodeHash": "0x0d98b2d8357ede11d1b03981df84d785b0f6957480c138a0b25297fd14ffbe5b",
+    "evmBytecodeHash": "0x18ce7c92839015c0653f11dce67bb559b1a10d186326e44bad345f319c582726",
     "evmBytecodePath": "/l1-contracts/out/SafeCast.sol/SafeCast.json",
-    "evmDeployedBytecodeHash": "0x7cd91ac9a40112d901069cd69384d85540e951b9ee336f34a85ef6ad12ff03d1"
+    "evmDeployedBytecodeHash": "0xbc9c9e4dd8ff0a3c8b1fec852cfb84633a4d5a2e6093272da08b730f70670a34"
   },
   {
     "contractName": "l1-contracts/SafeERC20",
     "zkBytecodeHash": "0x010000073b40f6657214c1c08498da4c6044e841db780ec53dcc6e1319ce4ccb",
     "zkBytecodePath": "/l1-contracts/zkout/SafeERC20.sol/SafeERC20.json",
-    "evmBytecodeHash": "0x8bcaaae3edcd704336fb87ff526323636ab7c153592a0804f8b65156f3cbdd73",
+    "evmBytecodeHash": "0x427416bb09180bc71f57d2ca252780a6a1c6c26d12c23f91ab48b97f051451f3",
     "evmBytecodePath": "/l1-contracts/out/SafeERC20.sol/SafeERC20.json",
-    "evmDeployedBytecodeHash": "0x37bb79938d832f604f20542497f60f8cc41f46a0525d837460755f975bd26202"
+    "evmDeployedBytecodeHash": "0x8b357b830dd84ee5367d1bb5863cc5e318ad94a48a09fe299d21ab2e9663756c"
   },
   {
     "contractName": "l1-contracts/SemVer",
     "zkBytecodeHash": "0x0100000733c2d2368df4bff2f15475d1cfc5db39cbe975f364b403b0932b99a0",
     "zkBytecodePath": "/l1-contracts/zkout/SemVer.sol/SemVer.json",
-    "evmBytecodeHash": "0x69b82664ac0eff045d6ca1e34974387a3a856a46578b1fa6dafd2ac3020e613c",
+    "evmBytecodeHash": "0xf6b9a8cb67c916247994d61ee0ddc9064ce9a5073c1f5b14a4e5b918b81730da",
     "evmBytecodePath": "/l1-contracts/out/SemVer.sol/SemVer.json",
-    "evmDeployedBytecodeHash": "0xe1f70baa7b9a10beea537323699161a613a10cfd2f5abdccf7eb34e7e2b5eb51"
+    "evmDeployedBytecodeHash": "0x872c057264b391237586b3152744946135afc9357cb585d60ce16bcffe291827"
   },
   {
     "contractName": "l1-contracts/ServerNotifier",
-    "zkBytecodeHash": "0x010000f125f46d636c1e35d36f57b082031717e9815862ac43aa6f940c12cb19",
+    "zkBytecodeHash": "0x010000f1fbce838b64f8cb0333458b170d9a8ff735b5aa7560df73cfeac4ee6e",
     "zkBytecodePath": "/l1-contracts/zkout/ServerNotifier.sol/ServerNotifier.json",
-    "evmBytecodeHash": "0xbf0e4d53cd7380f52ca731b582fcbddfe058bea4dc04a15fd4f4c90dd3f69f39",
+    "evmBytecodeHash": "0x90f9e9963e97e3994144f1fd22efc4d81c53d71f0b95ffa2dea6369e0d13ac6c",
     "evmBytecodePath": "/l1-contracts/out/ServerNotifier.sol/ServerNotifier.json",
-    "evmDeployedBytecodeHash": "0x3b29dca1e2354253b6d525170095ecb77648c72935d922229c240c5da8b20d7f"
+    "evmDeployedBytecodeHash": "0x1a9c82b33bbb769106e5adbc01cac8a7e9521007e7f4468fe3640c4d7f97701f"
   },
   {
     "contractName": "l1-contracts/SignedMath",
     "zkBytecodeHash": "0x010000073b4ff9ba2f6ae737833f673602e0c344bb2ef794f5303b4edb03c959",
     "zkBytecodePath": "/l1-contracts/zkout/SignedMath.sol/SignedMath.json",
-    "evmBytecodeHash": "0xd1539f05abc9be582f7fd40681d23cf512e79a64c3d1a631f9edfe38780747a7",
+    "evmBytecodeHash": "0xc1697ec30f209b3fd78dbe721ca72086165e825943802dbbaacaf7103bbef3d5",
     "evmBytecodePath": "/l1-contracts/out/SignedMath.sol/SignedMath.json",
-    "evmDeployedBytecodeHash": "0x59c1227d9c5cf1f3564cafc87031f44398aa3879bc42585902586cc9c4b0cbb1"
+    "evmDeployedBytecodeHash": "0x43ccc464694a3eb51d85c2324a28d3bf8096466aeaf1fe46f6ace7b0440c8333"
   },
   {
     "contractName": "l1-contracts/SignedMathUpgradeable",
     "zkBytecodeHash": "0x01000007e11221e38bbf4cc6f25d26978bb65379e7c9bb0773f04bf4291bc30f",
     "zkBytecodePath": "/l1-contracts/zkout/SignedMathUpgradeable.sol/SignedMathUpgradeable.json",
-    "evmBytecodeHash": "0x4a6177ee9326e3f8062a17735efeecafd301cc501c24196d1cb43221eb4bc67a",
+    "evmBytecodeHash": "0x590555c7c737f5e32be721580e6d340ae9445c4f8a5402ffe56565f2063d5afb",
     "evmBytecodePath": "/l1-contracts/out/SignedMathUpgradeable.sol/SignedMathUpgradeable.json",
-    "evmDeployedBytecodeHash": "0x103a3cc591ce8bd1bbd30680ef2096bd064eba508a86f3018087d8f4f2ee177a"
+    "evmDeployedBytecodeHash": "0x78448d911703548f02d8da8d063fe41682804d70753ddb7e7bd8f86778b66c8e"
   },
   {
     "contractName": "l1-contracts/StorageSlot",
     "zkBytecodeHash": "0x01000007abfdd8447cec54942b782815aaa2999cbd1fcf9e4805abdd0acbd8bd",
     "zkBytecodePath": "/l1-contracts/zkout/StorageSlot.sol/StorageSlot.json",
-    "evmBytecodeHash": "0x563777cf67b8585398325d4f327ced08dc0a76bedb7c8a04ec3f5ac05389d4ba",
+    "evmBytecodeHash": "0xbca91662636473a6a8e538d89ba3baf26db7628553488443694b7f5b6e04d512",
     "evmBytecodePath": "/l1-contracts/out/StorageSlot.sol/StorageSlot.json",
-    "evmDeployedBytecodeHash": "0x0c20f504d9e212a6d88524a7361c25412473a127992b8611ddc311dc6d6adcb6"
+    "evmDeployedBytecodeHash": "0x4a65750cfc79105328fbf2b750d4e003f40e120c277889d2b39cb290e3e5f989"
   },
   {
     "contractName": "l1-contracts/Strings",
     "zkBytecodeHash": "0x010000075a354ac6a9ece550e8d3e7379e78946a4b0fcadea45df8f4e500a4b7",
     "zkBytecodePath": "/l1-contracts/zkout/Strings.sol/Strings.json",
-    "evmBytecodeHash": "0x58c632496fb4e72f86cbd208c70e9613accfcd28adf4d7744ee7165bde1fb9fc",
+    "evmBytecodeHash": "0x412606d5c679964706daf50310dda3e430d56a4df79ceeb51db481f37621fbc8",
     "evmBytecodePath": "/l1-contracts/out/Strings.sol/Strings.json",
-    "evmDeployedBytecodeHash": "0x83ef366ca7c636a1360ca8ac33cf80e4bedc8bfaa62f4397064751b005d22b33"
+    "evmDeployedBytecodeHash": "0x01e4b490436d976b06d6f44bfb6bc9540b123804902db42a34cd96cf2388e6e2"
   },
   {
     "contractName": "l1-contracts/StringsUpgradeable",
     "zkBytecodeHash": "0x01000007584a040e5c5918b86d8f91401f32a9412673bc604492a5181e38cc25",
     "zkBytecodePath": "/l1-contracts/zkout/StringsUpgradeable.sol/StringsUpgradeable.json",
-    "evmBytecodeHash": "0x34cb6de5b5aa20f3f4f6ccd48308fdb86e53e2684513d7a51b6f4224e7d1fc7f",
+    "evmBytecodeHash": "0x218e0e1c8d4acec8a335ee8a4fb05d4212396e68c07adb339c7c8e944b549992",
     "evmBytecodePath": "/l1-contracts/out/StringsUpgradeable.sol/StringsUpgradeable.json",
-    "evmDeployedBytecodeHash": "0xef6f42791be03f203def1f5cae725ac78bc2ee8cc919539b2a241dc593440355"
+    "evmDeployedBytecodeHash": "0x2f1ac38e3bbfa20ef26a62de54b0ef757b1089a15373302603287708ff0e0a52"
   },
   {
     "contractName": "l1-contracts/SystemContractsCaller",
-    "zkBytecodeHash": "0x01000007a18bb1022c9edc34f8cbdb0be2ae3b25eb36aac3ca6031e4e97c8b1b",
+    "zkBytecodeHash": "0x010000076c42310b7d443e2cc6d3ae3b94546f7ed6b71fa2c5165038671c32b9",
     "zkBytecodePath": "/l1-contracts/zkout/SystemContractsCaller.sol/SystemContractsCaller.json",
-    "evmBytecodeHash": "0x1690fca63e79c88ceb933b76eae2c6ef901f53e6e47839ee1644d504292e292a",
+    "evmBytecodeHash": "0xcd8d97177ac5dd06b91cc32bfea029f0196b4539cfc2bbf2872a1655dd2ced1b",
     "evmBytecodePath": "/l1-contracts/out/SystemContractsCaller.sol/SystemContractsCaller.json",
-    "evmDeployedBytecodeHash": "0xf964064c2b99efed3baecaa6d8cbefd9463e5cb7575c36f241b0935efa7341bb"
+    "evmDeployedBytecodeHash": "0xe4d8ff93043081afd4d7579d004afae4f51c77fa37925fe40c4dcaaaf2169f06"
   },
   {
     "contractName": "l1-contracts/Utils",
-    "zkBytecodeHash": "0x010000072b447561373673192607f23e070f61f6d1178dc6d5eb548e50ef1b04",
+    "zkBytecodeHash": "0x01000007368f2801453fefda587c4540678ca5ca893c6136ff444abaf251e6ff",
     "zkBytecodePath": "/l1-contracts/zkout/SystemContractsCaller.sol/Utils.json",
-    "evmBytecodeHash": "0xbd2de090b6ac9b225c93e38fa975d75caeaa4883146d13a87356aac249acba36",
+    "evmBytecodeHash": "0xa79be8e2f6a0a9bf6faa3e58c17dae526809d25071b75811efe68b510de2ab20",
     "evmBytecodePath": "/l1-contracts/out/SystemContractsCaller.sol/Utils.json",
-    "evmDeployedBytecodeHash": "0x7593d593ac0d3fb55703c92a6b1e8cd9ef8d2bdd6d4c92628fd3e6c4ce04e7a9"
+    "evmDeployedBytecodeHash": "0x5d73306df1ce2532a59572167718869500f585ef9e4e105a5e55b9068b1c8510"
   },
   {
     "contractName": "l1-contracts/TestnetVerifier",
-    "zkBytecodeHash": "0x010000dd242304c0e8f5b5c89f1593e3d6a6a6b8d4cbf62c52f74b758924eac7",
+    "zkBytecodeHash": "0x010000ddf470162a6935c7eac8438786b706ada5d43d4cb8ecac627277a87347",
     "zkBytecodePath": "/l1-contracts/zkout/TestnetVerifier.sol/TestnetVerifier.json",
-    "evmBytecodeHash": "0x9b3c1d780f6d86afa2d859eeba87a3ae2438dcac7c261fcfcebf71303f511b64",
+    "evmBytecodeHash": "0x5aebdef7a50b02f4c57e594e737a0561a555927de15c9977489a3c66ee8b392b",
     "evmBytecodePath": "/l1-contracts/out/TestnetVerifier.sol/TestnetVerifier.json",
-    "evmDeployedBytecodeHash": "0x7e18303285fa1eebe7abd2e7b69b9ade3f5d67eb868966ee3e53ac8fba26be97"
+    "evmDeployedBytecodeHash": "0x4c26736f9499792f27eea49593107bf6992ee704d0da19a40ed263ddc54939dc"
   },
   {
     "contractName": "l1-contracts/TransactionValidator",
-    "zkBytecodeHash": "0x01000007044379ac7a203350dc07d684ef6c599236120e38334ff0ecf5e6353e",
+    "zkBytecodeHash": "0x010000072798d4ba201e8e894a4d26d2d91263af03dbad6bd54ce17781cd361f",
     "zkBytecodePath": "/l1-contracts/zkout/TransactionValidator.sol/TransactionValidator.json",
-    "evmBytecodeHash": "0x9b8bc10a3049f0737d1d60391a1cf3e81e477c52b3e5f1793888d12a5ab015a2",
+    "evmBytecodeHash": "0xb51b23d3fc07c1739d827cbef2a78a55afff4d756218287cdf31bbdaf882aa54",
     "evmBytecodePath": "/l1-contracts/out/TransactionValidator.sol/TransactionValidator.json",
-    "evmDeployedBytecodeHash": "0xf2c55afced069897977ef6f9d8ed1ab9cf92691b73397a5db7f8c042b14f767b"
+    "evmDeployedBytecodeHash": "0x859154f4a725411dab361623391a04f6f958b94baaec694b51d5ad7feff61f25"
   },
   {
     "contractName": "l1-contracts/TransitionaryOwner",
     "zkBytecodeHash": "0x0100005bd2f3ba147ba7ae7b091665249e47524c2c777a5eef48df88474f0837",
     "zkBytecodePath": "/l1-contracts/zkout/TransitionaryOwner.sol/TransitionaryOwner.json",
-    "evmBytecodeHash": "0x0b0e968e8b3a3499d6a64465c65caf0e2ee58f0d9822c6a61555d0b4c87e3867",
+    "evmBytecodeHash": "0x12b21be6f196c241127d5d6a6ff0b3c8a3d342bcc02f3a7203334ef80d51c163",
     "evmBytecodePath": "/l1-contracts/out/TransitionaryOwner.sol/TransitionaryOwner.json",
-    "evmDeployedBytecodeHash": "0xe8e47e802c9f28bc2c2a33e861e00a3d3a77690ec78ec0387f77e90f04e8d949"
+    "evmDeployedBytecodeHash": "0xd8afac6a15f6ccf1af9f16691962bb4e2f607a59ecc8ed4b38e50057ab6aff14"
   },
   {
     "contractName": "l1-contracts/TransparentUpgradeableProxy",
     "zkBytecodeHash": "0x01000149593c20ec28bef707d918a4f963887591dbe8278c730e860abf0fdb64",
     "zkBytecodePath": "/l1-contracts/zkout/TransparentUpgradeableProxy.sol/TransparentUpgradeableProxy.json",
-    "evmBytecodeHash": "0xeff8a1d98c67d773530551ca091731243869cec1e637b9e35a773dc9ee1ec3d3",
+    "evmBytecodeHash": "0x2968a66d95853b3000038817479fa832c8effb3fbf20b9810dd5e4a76428be42",
     "evmBytecodePath": "/l1-contracts/out/TransparentUpgradeableProxy.sol/TransparentUpgradeableProxy.json",
-    "evmDeployedBytecodeHash": "0x233c67ec54c6d38b0fc1b57546483b2849e61308832443513d521c4188ff63d7"
+    "evmDeployedBytecodeHash": "0x6c1c45e934973af0dc99ace579876b8416e146c47b560c4798524d5f168ea4d9"
   },
   {
     "contractName": "l1-contracts/UncheckedMath",
     "zkBytecodeHash": "0x010000077758666a5353fc097b50d4715d4d63bdcfd0fc93ca7a9dae308c8f15",
     "zkBytecodePath": "/l1-contracts/zkout/UncheckedMath.sol/UncheckedMath.json",
-    "evmBytecodeHash": "0x359f599125d8648c07d921f1635f93139d35dd81f1f0fe1dcb7b79863e331d3e",
+    "evmBytecodeHash": "0x58cf4e3b450ee1d3d557e6c8207a0e3a43df513b698f6211e144afab0d121c3b",
     "evmBytecodePath": "/l1-contracts/out/UncheckedMath.sol/UncheckedMath.json",
-    "evmDeployedBytecodeHash": "0x0a9eb0d661a8d20af1a906d357fc60ff7f6347fa367cf9d7c17f3494d5fdfd89"
+    "evmDeployedBytecodeHash": "0xbfad91382de49e4a0ed602098052ec279d91413a6fbf47c001bc11d7cc75d7c9"
   },
   {
     "contractName": "l1-contracts/UnsafeBytes",
     "zkBytecodeHash": "0x0100000705aab131e66b26d5976a28c7f8616e43bbaa8d162c637f6f412c8259",
     "zkBytecodePath": "/l1-contracts/zkout/UnsafeBytes.sol/UnsafeBytes.json",
-    "evmBytecodeHash": "0x0e43251a01dea60598d935f22a05c7b5afc2e769f049d035d8cfe36ab6f88e6a",
+    "evmBytecodeHash": "0x483c1d91c8e0707a330652c606cf1171bb49ed22e49ea6c82b77f5da51cb77dc",
     "evmBytecodePath": "/l1-contracts/out/UnsafeBytes.sol/UnsafeBytes.json",
-    "evmDeployedBytecodeHash": "0x97b15b9cf3a912e69c3f08a5c2dbe0ec352ba2283f230b17e39c2eaa0a8244ca"
+    "evmDeployedBytecodeHash": "0xa2fb6760e5b4ee157f46a76e3c6101b0548bd089d2096b6e1a122bc1b3d8c225"
   },
   {
     "contractName": "l1-contracts/UpgradeStageValidator",
-    "zkBytecodeHash": "0x010000a3771562551046c5ffd58184a752b58cdff8366bbb1b477ace3f2d247c",
+    "zkBytecodeHash": "0x010000a3a94a5659552166c246fb47e0415878551c6cfab620787b7789925e41",
     "zkBytecodePath": "/l1-contracts/zkout/UpgradeStageValidator.sol/UpgradeStageValidator.json",
-    "evmBytecodeHash": "0xc27494e319ff13b0d7baba8d5e1c9568da88514426320a8a9afaed0aba5a6cf4",
+    "evmBytecodeHash": "0xf824b761ce2c078a11f125048e65146ad2b828cebec1e8b9b40ec86cbc669894",
     "evmBytecodePath": "/l1-contracts/out/UpgradeStageValidator.sol/UpgradeStageValidator.json",
-    "evmDeployedBytecodeHash": "0x57062ed9ed37a2bb4226119238995351946ed4bdfce228bc947df50165945ce2"
+    "evmDeployedBytecodeHash": "0xf4d23044481ece3365ba5fe51dd72cee073bb5e36fc41885ea09cb90fa0f2003"
   },
   {
     "contractName": "l1-contracts/UpgradeableBeacon",
     "zkBytecodeHash": "0x010000674dd9c2b44a5c02408bda04df734b258d1c6ee9e07f5a6904a13d27fc",
     "zkBytecodePath": "/l1-contracts/zkout/UpgradeableBeacon.sol/UpgradeableBeacon.json",
-    "evmBytecodeHash": "0x16e9b6d2d2ff2d4f09e041993b5bb29902e10dc154491fac8e1dcd8cd0faf50e",
+    "evmBytecodeHash": "0x6ca8ae9937fd9a2a30a3069882596cfe4d8b8b8936de942364ea5256a848979e",
     "evmBytecodePath": "/l1-contracts/out/UpgradeableBeacon.sol/UpgradeableBeacon.json",
-    "evmDeployedBytecodeHash": "0xba4bfb9d8fdb5e5690b9c2e10d68acdd886790840a3da73771993f5ddd9cf23f"
+    "evmDeployedBytecodeHash": "0x44f3eb40382ddca04d81519a7f2c6adb0b0e9abfc0e42921d0611f20c08b3c3b"
   },
   {
     "contractName": "l1-contracts/ValidatorTimelock",
-    "zkBytecodeHash": "0x010001fbf08f314f406426ca6f3b91a7aefba718585d9121072652529254dbdc",
+    "zkBytecodeHash": "0x010001fb19676479c5df32ecd90706dc9d87efe892a9af64ca4181ee8177a856",
     "zkBytecodePath": "/l1-contracts/zkout/ValidatorTimelock.sol/ValidatorTimelock.json",
-    "evmBytecodeHash": "0x5b4d25fa35ef75b1fa954e75ee00a4ed1f2f9c507484d0f3dd9ec63dc0fd2711",
+    "evmBytecodeHash": "0x9f2d434ab6faddfd0683384ed253a82d9ceb469b318310a3970c0ce968697eee",
     "evmBytecodePath": "/l1-contracts/out/ValidatorTimelock.sol/ValidatorTimelock.json",
-    "evmDeployedBytecodeHash": "0x0dc74c2cff4313434fd0b4c86c423393ad3f756c364dad8f307313148741f723"
+    "evmDeployedBytecodeHash": "0xbd67463f50e4db17305f98f8b7d2c73b993f3b94d3605be20f8d81562a0a8e59"
   },
   {
     "contractName": "l1-contracts/ValidiumL1DAValidator",
-    "zkBytecodeHash": "0x01000033e116188e528e1c13b086e6ed8e41915871976258efc2bf9fd67536f5",
+    "zkBytecodeHash": "0x010000330e0557e02bf220ade3abab8754cdf81e4ff8050d7c5a86920b22e125",
     "zkBytecodePath": "/l1-contracts/zkout/ValidiumL1DAValidator.sol/ValidiumL1DAValidator.json",
-    "evmBytecodeHash": "0x0ce7b837f9e7208bccde2a05117964f893e2db806cb60994f31a02b030debbc8",
+    "evmBytecodeHash": "0xef170b7ce281ec1170affaf771bc5546b640ddde06a5aab66ec847df71e280ec",
     "evmBytecodePath": "/l1-contracts/out/ValidiumL1DAValidator.sol/ValidiumL1DAValidator.json",
-    "evmDeployedBytecodeHash": "0x4bb4a64ea60cc9b01102ad85f40e4dc04d632499c93bd19c2d5dcfc28767c5e1"
+    "evmDeployedBytecodeHash": "0x688602ca12ca3103cc98c13065825a6eba475ad4a99f2404c3e35f44438a9a7e"
   },
   {
     "contractName": "l1-contracts/ZKChainBase",
-    "zkBytecodeHash": "0x010000076008613c5252921df8c3e2eb86ca99048509845493be3186e94adf08",
+    "zkBytecodeHash": "0x01000007331cfff5a9b9dba0e823c3d8465854429d678145b4d87156e7042e83",
     "zkBytecodePath": "/l1-contracts/zkout/ZKChainBase.sol/ZKChainBase.json",
-    "evmBytecodeHash": "0xc3cab08fc10c7bf8bb91c1d112fe38590b41ccc5dc6db4fa282c01f974e89cff",
+    "evmBytecodeHash": "0xc794cb504638ee110e3bb063a8122515d2a1f59a10c3989c2e60ae9ab8d47a61",
     "evmBytecodePath": "/l1-contracts/out/ZKChainBase.sol/ZKChainBase.json",
-    "evmDeployedBytecodeHash": "0x094f5428da63b905d2c9d26ba505129bc00e1da8d288856e40420c0dca9a9a12"
+    "evmDeployedBytecodeHash": "0x1a9bacc38f3a8bfb87177167953c6eec18350cd8d5ba8aa827107a770d07e309"
   },
   {
     "contractName": "l1-contracts/Create2AndTransfer",
-    "evmBytecodeHash": "0x221befb9f9899292243c989af6b79b7299bbbb9960121ea2cde5b0850cc38b12",
+    "evmBytecodeHash": "0x0cd925c191f3eaee3c6ac695f34e5707d6c5a9bafce07a32a903a8c54e5473d3",
     "evmBytecodePath": "/l1-contracts/out/Create2AndTransfer.sol/Create2AndTransfer.json",
-    "evmDeployedBytecodeHash": "0x87c81e913d79f8ab2775997bf2d2a921264e252c59f6654cb42b21b382b9602f",
+    "evmDeployedBytecodeHash": "0xfd58a3b64f6ca67cf4024c9712166aac44e42aec82a240aec2b261ed7292351e",
     "zkBytecodeHash": null,
     "zkBytecodePath": null
   },
   {
     "contractName": "l1-contracts/MockERC20",
-    "evmBytecodeHash": "0x7655faf6d29697c964847c601edba441fd8c7b88693359cb23b3e927b0a1dcee",
+    "evmBytecodeHash": "0x37fc1ad092b0fad92a33be8e307f29887acbf7b02e16b023f8cadca1cc061914",
     "evmBytecodePath": "/l1-contracts/out/MockERC20.sol/MockERC20.json",
-    "evmDeployedBytecodeHash": "0x4fabd8ce36623371e635db21f76b1b7fd0b6d359baae2ae0d909650f9513450a",
+    "evmDeployedBytecodeHash": "0x5dec419ab92f28941f369cc96b0ec458c38cec1dd4ebcbc30f9ba1c26fb5bc41",
     "zkBytecodeHash": null,
     "zkBytecodePath": null
   },
   {
     "contractName": "l1-contracts/MockERC721",
-    "evmBytecodeHash": "0x314fceef34e8be18d58cd1303a5d88d25d51e236c254fbbf6932037de2c645e0",
+    "evmBytecodeHash": "0x0439592b99bedb6a531a6d1618af9f7d95241a319a56f7a6416446931e48e287",
     "evmBytecodePath": "/l1-contracts/out/MockERC721.sol/MockERC721.json",
-    "evmDeployedBytecodeHash": "0x9925d7834373021358516939dd1b34727550181871786e2ce207e64f714304c7",
+    "evmDeployedBytecodeHash": "0x73bb8fa64576597d3dc6b58ef2d0741bc8d8330801489283adff298dfaecedfa",
     "zkBytecodeHash": null,
     "zkBytecodePath": null
   },
   {
     "contractName": "l1-contracts/stdError",
-    "evmBytecodeHash": "0xc665c6f2163557700dc7cd809615cf2fcf70af3400a150cb9f68fbb8daa643e2",
+    "evmBytecodeHash": "0x6881dfdd4d4fa00c5adf0fdb51653e4285caeb3ee0de7744e154ea4bcf2e894a",
     "evmBytecodePath": "/l1-contracts/out/StdError.sol/stdError.json",
-    "evmDeployedBytecodeHash": "0xae396a9f2444f6ca903c33b92aeabe1a6e8f5d74a30ccf57fb9730890b8c353a",
+    "evmDeployedBytecodeHash": "0x3b480904fca1744b27926545b233b35b783f7b18a779f247fc95c6330c4f0195",
     "zkBytecodeHash": null,
     "zkBytecodePath": null
   },
   {
     "contractName": "l1-contracts/stdJson",
-    "evmBytecodeHash": "0x128c681644804cc473fa44e37b6805e18426a1f19df9b10ca04cec9a77828063",
+    "evmBytecodeHash": "0x59d9a9bc57015d0eeb083be4ba677a0299817f2cc86587c01e0f00aa75a81dc7",
     "evmBytecodePath": "/l1-contracts/out/StdJson.sol/stdJson.json",
-    "evmDeployedBytecodeHash": "0x157d3028bcfb2056e0acf0a0f0fa6abf6194df78cb93eb740b6bdf6950b14da3",
+    "evmDeployedBytecodeHash": "0xe3fdaee91a01048774f59d69d35c504c19dc0714cfa064aa7bbf4d052f632b23",
     "zkBytecodeHash": null,
     "zkBytecodePath": null
   },
   {
     "contractName": "l1-contracts/stdMath",
-    "evmBytecodeHash": "0xda78553c78a5f4d3bcd8bf198b63e9e5fba3b22efc22ba73f31e5e19476d0aa6",
+    "evmBytecodeHash": "0x1bc3a38d4d14b3e12d3d73924b1533376ad578c6c66444db8da7c39c15d06f6e",
     "evmBytecodePath": "/l1-contracts/out/StdMath.sol/stdMath.json",
-    "evmDeployedBytecodeHash": "0x4ceda3e6f661699d507e56828120123765e74d00dada868fd2f3be962286970d",
+    "evmDeployedBytecodeHash": "0x2d8c18628b8c4dd5bf65911bc0ca5961f4d3de4a790a083f1a3182a3280e02f8",
     "zkBytecodeHash": null,
     "zkBytecodePath": null
   },
   {
     "contractName": "l1-contracts/stdStorage",
-    "evmBytecodeHash": "0xcff31252e0beabecef78071fa2c2a8fffe7c363e4985f26ec16fa1c94b58c58d",
+    "evmBytecodeHash": "0xb9837fdd3bed0a3bf1b7988ab6347d04eaa27e0a476bb9a6acd3995d9967b1dd",
     "evmBytecodePath": "/l1-contracts/out/StdStorage.sol/stdStorage.json",
-    "evmDeployedBytecodeHash": "0xf10b687825e4eaf0a5ac72ab238cfdbb16383a8282f3325730b1833c18f86d8e",
+    "evmDeployedBytecodeHash": "0x4863ad2376c3bd7427890fa06a17d7ac7959d083e926776625ab1e9add42637e",
     "zkBytecodeHash": null,
     "zkBytecodePath": null
   },
   {
     "contractName": "l1-contracts/stdStorageSafe",
-    "evmBytecodeHash": "0x24689c96609e938d757cb923dc9f36521f9ae646045b97e4cabfc480b700dc3f",
+    "evmBytecodeHash": "0x6cc439e86cc81de617552d75533bf63c15187e8a9340d76813ce13f5d184389e",
     "evmBytecodePath": "/l1-contracts/out/StdStorage.sol/stdStorageSafe.json",
-    "evmDeployedBytecodeHash": "0xfa69cba4ebff5308c0ccbf1ed3aa745b11bfca5c44fe8d9096b160a6261f94c5",
+    "evmDeployedBytecodeHash": "0x6a6d5d1ce45760a3af5ec98acd40cbb9be8d2bccf232630642a3869898ba78cf",
     "zkBytecodeHash": null,
     "zkBytecodePath": null
   },
   {
     "contractName": "l1-contracts/StdStyle",
-    "evmBytecodeHash": "0xa18cfe8510b6cd2782723670defea98e1f7bf4281e05b96d2f16345fea7d2571",
+    "evmBytecodeHash": "0x6c325f31fc430fe6c67b77d4cde53ee935bd53c22789710b21c6decea9dd41c9",
     "evmBytecodePath": "/l1-contracts/out/StdStyle.sol/StdStyle.json",
-    "evmDeployedBytecodeHash": "0x0b58b56c31275d5687cab5a436b28b4b28df34c96cb7b397dab08455e9236683",
+    "evmDeployedBytecodeHash": "0xd1aff65b18548436bf2b88655baeae23a5cd8faa7a75f3b6ecca131ff98a2c87",
     "zkBytecodeHash": null,
     "zkBytecodePath": null
   },
   {
     "contractName": "l1-contracts/stdToml",
-    "evmBytecodeHash": "0xf37ed78c6523dc2eeb14b08d14db17297d989f55c8d0f5c2b839f7c58bf1600b",
+    "evmBytecodeHash": "0xd927f7ee93c505ba5fb1766421d748ce85772c18f9671c99712defa9f345b823",
     "evmBytecodePath": "/l1-contracts/out/StdToml.sol/stdToml.json",
-    "evmDeployedBytecodeHash": "0x01df83c9391711397de29395ec967d86df717e915075676fddc40227dfc2904d",
+    "evmDeployedBytecodeHash": "0x1786adeb7db46c6c4cb03d0c1b3b6017596d4b9e53248958d6edaf6decccfab1",
     "zkBytecodeHash": null,
     "zkBytecodePath": null
   },
   {
     "contractName": "l1-contracts/console",
-    "evmBytecodeHash": "0x8da2e310f9af76f053e3ba5c51cd5256644ed4866a8db5eac9e213062cf94048",
+    "evmBytecodeHash": "0xc780f879e48427c68ba6316301e2617139017fbb5b34a3bffd0132efc7489787",
     "evmBytecodePath": "/l1-contracts/out/console.sol/console.json",
-    "evmDeployedBytecodeHash": "0x33a8b941b30c3b3b1aae733dd00d4dbb8fc11c6871ab9f8947ba937ba222a883",
+    "evmDeployedBytecodeHash": "0x73493cb773f4af27abaa701af95d54334068f815c65f6ecfe65a5452b4613172",
     "zkBytecodeHash": null,
     "zkBytecodePath": null
   },
   {
     "contractName": "l1-contracts/safeconsole",
-    "evmBytecodeHash": "0x8d4a6c561bee25898bd6a5ba365c5eedf9e0a56fc74dea5486c64a59496431f3",
+    "evmBytecodeHash": "0x71cba256e5175678f0997dff38b86c99bb38a5e502d04846b025ebacb413ff5b",
     "evmBytecodePath": "/l1-contracts/out/safeconsole.sol/safeconsole.json",
-    "evmDeployedBytecodeHash": "0xe8fbe25dd4a1388b6b3556d52ad8ac9ef7b61f03d1c64371803c3338e725c71e",
+    "evmDeployedBytecodeHash": "0x11892e7c8a9fe6031f5b839068603141246a182dee302032beb2e7d8580dcae9",
     "zkBytecodeHash": null,
     "zkBytecodePath": null
   },
@@ -1738,7 +1746,7 @@
   {
     "contractName": "Bootloader",
     "zkBytecodePath": "/system-contracts/zkout/bootloader_test.yul/Bootloader.json",
-    "zkBytecodeHash": "0x010004133522d1933f2161a6dab347ea5afbfa19068a84c95ee5b1637fd863a2",
+    "zkBytecodeHash": "0x010004137863681b736a24748dca9bb6523562fcc5f36e55db72b213d14939d4",
     "evmBytecodePath": null,
     "evmBytecodeHash": null,
     "evmDeployedBytecodeHash": null
@@ -1754,7 +1762,7 @@
   {
     "contractName": "Bootloader",
     "zkBytecodePath": "/system-contracts/zkout/fee_estimate.yul/Bootloader.json",
-    "zkBytecodeHash": "0x010008e7307e11ead68f2cc251202724991514d0339105270d42ad6810c4bb3b",
+    "zkBytecodeHash": "0x010009c9092da281c9fb83cad02d4ca7fa6acf90dbb85fc879707a2f75def80b",
     "evmBytecodePath": null,
     "evmBytecodeHash": null,
     "evmDeployedBytecodeHash": null
@@ -1762,7 +1770,7 @@
   {
     "contractName": "Bootloader",
     "zkBytecodePath": "/system-contracts/zkout/gas_test.yul/Bootloader.json",
-    "zkBytecodeHash": "0x01000853ac39b8cd30fe3487716d8bfbd4194bfada28ada2409970b9aa850ba7",
+    "zkBytecodeHash": "0x0100093398fbe99841edeadfa94f62bd23b5f04cfbcb456275eba8f9d140c4ed",
     "evmBytecodePath": null,
     "evmBytecodeHash": null,
     "evmDeployedBytecodeHash": null
@@ -1770,7 +1778,7 @@
   {
     "contractName": "Bootloader",
     "zkBytecodePath": "/system-contracts/zkout/playground_batch.yul/Bootloader.json",
-    "zkBytecodeHash": "0x010008ed7bb367c8f28cc76217487a848c18d07090428d45467eb89bfc55b28b",
+    "zkBytecodeHash": "0x010009cfccc0f41aa05ca27f5163a284cd6a99d5e776d19d98266bcfad9cc7e8",
     "evmBytecodePath": null,
     "evmBytecodeHash": null,
     "evmDeployedBytecodeHash": null
@@ -1778,7 +1786,7 @@
   {
     "contractName": "Bootloader",
     "zkBytecodePath": "/system-contracts/zkout/proved_batch.yul/Bootloader.json",
-    "zkBytecodeHash": "0x0100086360ea7c87d9f20a2d94ed2dc1027570540308bfb1ba023e089cdd76f3",
+    "zkBytecodeHash": "0x01000943eba71a51146ee25e80df16183a5cf416c13e3bd116563cde4c5d02bd",
     "evmBytecodePath": null,
     "evmBytecodeHash": null,
     "evmDeployedBytecodeHash": null

--- a/recompute_hashes.sh
+++ b/recompute_hashes.sh
@@ -1,6 +1,8 @@
 # Script to recompile and recreate the hashes for the contracts.
 # source ./recompute_hashes.sh
 
+set -e
+
 # Expected Foundry version and commit
 EXPECTED_VERSION="0.0.2"
 EXPECTED_COMMIT="27360d4c8"
@@ -25,25 +27,28 @@ if [ "$INSTALLED_VERSION" != "$EXPECTED_VERSION" ] || [ "$INSTALLED_COMMIT" != "
   exit 1
 fi
 
+if [ "$(git rev-parse --show-toplevel)" != "$PWD" ]; then
+  echo "error: must be run at the root of matter-labs/era-contracts repository" >&2
+  exit 1
+fi
+
 # Update submodules (just in case)
 git submodule update --init --recursive
 
+yarn
 
 # Cleanup everything and recompile
-pushd da-contracts && \
-forge clean && popd && \
-pushd l1-contracts && \
-yarn clean && forge clean && popd && \
-pushd l2-contracts && \
-yarn clean && forge clean && popd && \
-pushd system-contracts && \
-yarn clean && forge clean && popd && \
-pushd da-contracts && \
-yarn build:foundry && popd && \
-pushd l1-contracts && \
-yarn build:foundry && popd && \
-pushd l2-contracts && \
-yarn build:foundry && popd && \
-pushd system-contracts && \
-yarn build:foundry && popd && \
+forge clean --root da-contracts
+yarn --cwd l1-contracts clean
+forge clean --root l1-contracts
+yarn --cwd l2-contracts clean
+forge clean --root l2-contracts
+yarn --cwd system-contracts clean
+forge clean --root system-contracts
+
+yarn --cwd da-contracts build:foundry
+yarn --cwd l1-contracts build:foundry
+yarn --cwd l2-contracts build:foundry
+yarn --cwd system-contracts build:foundry
+
 yarn calculate-hashes:fix


### PR DESCRIPTION
## What ❔

The `recompute_hashes.sh` fails with the following error:

```
...
Cloning into '/Users/nikitastupin/github.com/matter-labs/era-contracts/lib/openzeppelin-contracts-v4/lib/forge-std/lib/ds-test'...
Submodule path 'lib/openzeppelin-contracts-v4/lib/forge-std/lib/ds-test': checked out '6da7dd8f7395f83e1fb6fa88a64ba9a030f85d4f'
./recompute_hashes.sh: line 33: pushd: da-contracts: No such file or directory
```

I've refactored the script and now it works.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
