### PR TITLE
Restrict workflow permissions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-# What ❔
+## What ❔
 
 <!-- What are the changes this PR brings about? -->
 <!-- Example: This PR adds a PR template to the repo. -->

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -13,6 +13,9 @@ on:
         required: false
         default: manual
 
+permissions:
+  contents: write
+
 jobs:
   build-contracts:
     runs-on: ubuntu-latest

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -11,6 +11,9 @@ name: Codespell
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   # TODO: fix codespell CI
   # codespell:

--- a/.github/workflows/invariant-tests.yaml
+++ b/.github/workflows/invariant-tests.yaml
@@ -5,7 +5,8 @@ on:
     - cron: "00 01 * * *"
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   define-matrix:

--- a/.github/workflows/l1-contracts-ci.yaml
+++ b/.github/workflows/l1-contracts-ci.yaml
@@ -3,10 +3,8 @@ name: L1 contracts CI
 on:
   pull_request:
 
-# We need this permissions for this CI to work with external contributions
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   build:
@@ -286,6 +284,9 @@ jobs:
         working-directory: l1-contracts
     needs: [build, lint]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout the repository

--- a/.github/workflows/l2-contracts-ci.yaml
+++ b/.github/workflows/l2-contracts-ci.yaml
@@ -3,6 +3,9 @@ name: L2 contracts CI
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/nodejs-license.yaml
+++ b/.github/workflows/nodejs-license.yaml
@@ -23,6 +23,9 @@ env:
   # It has to be one line, there must be no space between packages.
   EXCLUDE_PACKAGES: testrpc@0.0.1;uuid@2.0.1;era-contracts@0.1.0;
 
+permissions:
+  contents: read
+
 jobs:
   generate-matrix:
     name: Lists modules

--- a/.github/workflows/secrets_scanner.yaml
+++ b/.github/workflows/secrets_scanner.yaml
@@ -1,5 +1,9 @@
 name: Leaked Secrets Scan
 on: [pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   TruffleHog:
     runs-on: ubuntu-latest

--- a/.github/workflows/slither.yaml
+++ b/.github/workflows/slither.yaml
@@ -2,6 +2,9 @@ name: Slither scanner
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   slither:
     name: Slither check

--- a/.github/workflows/system-contracts-ci.yaml
+++ b/.github/workflows/system-contracts-ci.yaml
@@ -3,6 +3,9 @@ name: System contracts CI
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What ❔

- Harden the security of our workflows by restricting the workflow permissions according to the principle of least privilege. Reported by the [CodeQL scanning](https://github.com/matter-labs/era-contracts/security/code-scanning).
- Fix the pull request template formatting.

## Why ❔

To minimize the impact of compromised workflows/actions/dependencies.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
