### PR TITLE
feat: weaken timestamp restriction in `_ensureBatchConsistentWithL2Block`

### DIFF
--- a/AllContractsHashes.json
+++ b/AllContractsHashes.json
@@ -321,7 +321,7 @@
   },
   {
     "contractName": "system-contracts/SystemContext",
-    "zkBytecodeHash": "0x0100016dc606066be5cad36c2c8e263904e42db8cf7786f3354faa43e183815d",
+    "zkBytecodeHash": "0x0100016d8931c2d3a12e1c362adfbb5195b3b422131c7078cbf841bab40697f9",
     "zkBytecodePath": "/system-contracts/zkout/SystemContext.sol/SystemContext.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,

--- a/system-contracts/contracts/SystemContext.sol
+++ b/system-contracts/contracts/SystemContext.sol
@@ -449,11 +449,11 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, SystemContra
         );
     }
 
-    /// @notice Ensures that the timestamp of the batch is greater than the timestamp of the last L2 block.
+    /// @notice Ensures that the timestamp of the batch is greater than or equal to the timestamp of the last L2 block.
     /// @param _newTimestamp The timestamp of the new batch.
     function _ensureBatchConsistentWithL2Block(uint128 _newTimestamp) internal view {
         uint128 currentBlockTimestamp = currentL2BlockInfo.timestamp;
-        if (_newTimestamp <= currentBlockTimestamp) {
+        if (_newTimestamp < currentBlockTimestamp) {
             revert InconsistentNewBatchTimestamp(_newTimestamp, currentBlockTimestamp);
         }
     }

--- a/system-contracts/test/SystemContext.spec.ts
+++ b/system-contracts/test/SystemContext.spec.ts
@@ -377,6 +377,8 @@ describe("SystemContext tests", () => {
     });
   });
 
+  // One more describe section for `setNewBatch` tests. These tests require at least one `setL2Block` invocation before them.
+  // They should go after `setL2Block` section since tests from there rely on the fact that function `setL2Block` is not called before.
   describe("setNewBatch after setL2Block", async () => {
     it("should revert InconsistentNewBatchTimestamp", async () => {
       const batchData = await systemContext.getBatchNumberAndTimestamp();


### PR DESCRIPTION
## What ❔

Given that l2 blocks can now have same timestamps, it doesn't make any sense to require the timestamp of the batch to be greater than the timestamp of the last L2 block. Change to only require `new_batch.timestamp >= prev_block.timestamp` 

## Why ❔

See above

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
