### PR TITLE
chore: Add reverts for deprecated batch functions.

### DIFF
--- a/AllContractsHashes.json
+++ b/AllContractsHashes.json
@@ -1,7 +1,7 @@
 [
   {
     "contractName": "system-contracts/AccountCodeStorage",
-    "zkBytecodeHash": "0x010000750f70b1e4efd4c2bb3989b5894e73669b04ff4e9e17165f617512ff32",
+    "zkBytecodeHash": "0x010000754c8f8cd6bcd79e0cdae1c13ca049254450038c8b67eaf137136c06ab",
     "zkBytecodePath": "/system-contracts/zkout/AccountCodeStorage.sol/AccountCodeStorage.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -25,7 +25,7 @@
   },
   {
     "contractName": "system-contracts/BootloaderUtilities",
-    "zkBytecodeHash": "0x010009257791341de9feeaa774ae065bd3eb1831676706afdac510b18088298b",
+    "zkBytecodeHash": "0x01000925e9f58314719129c8a138a5c3885031b12448988027a4c4bbe2fd05d9",
     "zkBytecodePath": "/system-contracts/zkout/BootloaderUtilities.sol/BootloaderUtilities.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -33,7 +33,7 @@
   },
   {
     "contractName": "system-contracts/ComplexUpgrader",
-    "zkBytecodeHash": "0x010000a9f876e1f57ff78df3aac2bc1f95d07068922b02928f68782173f808dd",
+    "zkBytecodeHash": "0x010000a959f3a2b9b50060453ca67e9d2bbb63bcf9a5582b2bb4a39e3d1a9199",
     "zkBytecodePath": "/system-contracts/zkout/ComplexUpgrader.sol/ComplexUpgrader.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -41,7 +41,7 @@
   },
   {
     "contractName": "system-contracts/Compressor",
-    "zkBytecodeHash": "0x01000139489303ba7938dd20c8d317ef43caa2b6ad075de35b7b2199414f3cf9",
+    "zkBytecodeHash": "0x010001398fc33d8047a1a47277f29c80a5192a0e3d32f64c88324355b7e1c8e9",
     "zkBytecodePath": "/system-contracts/zkout/Compressor.sol/Compressor.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -49,7 +49,7 @@
   },
   {
     "contractName": "system-contracts/ContractDeployer",
-    "zkBytecodeHash": "0x010006ab15a3cab90be8e05bbe0a039a2c16bdec4cedf907a75a62b8d88814f8",
+    "zkBytecodeHash": "0x010006ab27bdff31f27b56423934e3bbc33942c421c839953c50243f0c44b070",
     "zkBytecodePath": "/system-contracts/zkout/ContractDeployer.sol/ContractDeployer.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -57,7 +57,7 @@
   },
   {
     "contractName": "system-contracts/Create2Factory",
-    "zkBytecodeHash": "0x0100003f63b147ce81dc95c9f89a91feff9802009aa1bbd91d6f192f9977adb7",
+    "zkBytecodeHash": "0x0100003fbcdeb6b1bd180622fb0f3a128ca861b1ad5e1943e3704f030f431521",
     "zkBytecodePath": "/system-contracts/zkout/Create2Factory.sol/Create2Factory.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -65,7 +65,7 @@
   },
   {
     "contractName": "system-contracts/DefaultAccount",
-    "zkBytecodeHash": "0x010005f734dec9a66e4471535311709ef26982c3546408de7c25d41a9d4ed09d",
+    "zkBytecodeHash": "0x010005f75e21458bccc980152cfbd540cf223b5f474cacc5db53a091587f637e",
     "zkBytecodePath": "/system-contracts/zkout/DefaultAccount.sol/DefaultAccount.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -137,7 +137,7 @@
   },
   {
     "contractName": "system-contracts/EfficientCall",
-    "zkBytecodeHash": "0x010000071795b1af19998d60c6e40047434361c41892bab462d80ca8ddd92dc5",
+    "zkBytecodeHash": "0x01000007cfe3affa0469091445d604893c5ad70e20b3960d176ca6423de89e21",
     "zkBytecodePath": "/system-contracts/zkout/EfficientCall.sol/EfficientCall.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -153,7 +153,7 @@
   },
   {
     "contractName": "system-contracts/EvmHashesStorage",
-    "zkBytecodeHash": "0x01000017daa45fb5ccf1bb514e079614428a337b71522e1ecd5b250e65a84733",
+    "zkBytecodeHash": "0x010000173a7c7f2744e51cbc54a6a05370b3b6a6011645e39c1826cdd6c95d96",
     "zkBytecodePath": "/system-contracts/zkout/EvmHashesStorage.sol/EvmHashesStorage.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -161,7 +161,7 @@
   },
   {
     "contractName": "system-contracts/EvmPredeploysManager",
-    "zkBytecodeHash": "0x01000111489b40393c76dd3c494f3b01a9884d5c0e65968dde53779ef6a5007a",
+    "zkBytecodeHash": "0x010001110803602109fb300a7c5ce668550088f13c3759a97eec787f6660ae73",
     "zkBytecodePath": "/system-contracts/zkout/EvmPredeploysManager.sol/EvmPredeploysManager.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -169,7 +169,7 @@
   },
   {
     "contractName": "system-contracts/ImmutableSimulator",
-    "zkBytecodeHash": "0x010000333c690f2891124528fb9317217c69550d1134275e531b9d4fcd9fe0df",
+    "zkBytecodeHash": "0x01000033d9d7239d4250d1e59383b1960b2a93fb5824ced1df2dba0b1c5dca07",
     "zkBytecodePath": "/system-contracts/zkout/ImmutableSimulator.sol/ImmutableSimulator.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -177,7 +177,7 @@
   },
   {
     "contractName": "system-contracts/KnownCodesStorage",
-    "zkBytecodeHash": "0x010000c961d90dd8d5af5fddd0bade361a4e9ad9f565a8342ac57a616c24e4cb",
+    "zkBytecodeHash": "0x010000c9171d70c19a853417946b9b7418fbbd1fc4204c0315175d85842a19c0",
     "zkBytecodePath": "/system-contracts/zkout/KnownCodesStorage.sol/KnownCodesStorage.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -185,7 +185,7 @@
   },
   {
     "contractName": "system-contracts/L1Messenger",
-    "zkBytecodeHash": "0x010001cbc0d3e61f29e413b1b2804687dcbd45f842a6a6a6f39532d94a7defe6",
+    "zkBytecodeHash": "0x010001cbdbe437edbee47bc63e6780489f8dca3cdbcbdb5a260634d49829e41b",
     "zkBytecodePath": "/system-contracts/zkout/L1Messenger.sol/L1Messenger.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -193,7 +193,7 @@
   },
   {
     "contractName": "system-contracts/L2BaseToken",
-    "zkBytecodeHash": "0x010000ed9c7f49f404ac483f64661fa500ac424399403f465ce68131b7538124",
+    "zkBytecodeHash": "0x010000ed4fce7182bdbe235dc467e04842109d26e567c76ad2b87708c8cca772",
     "zkBytecodePath": "/system-contracts/zkout/L2BaseToken.sol/L2BaseToken.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -201,7 +201,7 @@
   },
   {
     "contractName": "system-contracts/L2GenesisForceDeploymentsHelper",
-    "zkBytecodeHash": "0x0100000781f55e1cfed5a2e2f95209dd44b1c3a9b9acb35a10308bd376d7d6e8",
+    "zkBytecodeHash": "0x0100000770b48693764ff847391de76d8ae1b03265c638ad589128eae710fbf3",
     "zkBytecodePath": "/system-contracts/zkout/L2GenesisForceDeploymentsHelper.sol/L2GenesisForceDeploymentsHelper.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -209,7 +209,7 @@
   },
   {
     "contractName": "system-contracts/L2GenesisUpgrade",
-    "zkBytecodeHash": "0x010001e1135c019ac0ac6ad7e209bdb8072e48ce3f7210c03d37d31c5bff9e7b",
+    "zkBytecodeHash": "0x010001e1f98172b88de5b8bb7423256bd475bd18e6202e04f4acdd3ddae1424d",
     "zkBytecodePath": "/system-contracts/zkout/L2GenesisUpgrade.sol/L2GenesisUpgrade.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -217,7 +217,7 @@
   },
   {
     "contractName": "system-contracts/L2InteropRootStorage",
-    "zkBytecodeHash": "0x01000049c8f6c58942b2af5a831f0524ce845013e36f3dee0c2bd6eba8765dcc",
+    "zkBytecodeHash": "0x01000049c7dcb249c1cb6045fc09ac3374bab2f505ae44f76d6209df8fdb6ddc",
     "zkBytecodePath": "/system-contracts/zkout/L2InteropRootStorage.sol/L2InteropRootStorage.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -225,7 +225,7 @@
   },
   {
     "contractName": "system-contracts/L2UpgradeUtils",
-    "zkBytecodeHash": "0x0100000738d8346aed882fdc82d9c3769a1c12abe6b9b2e3076ff55c7aee9f19",
+    "zkBytecodeHash": "0x01000007530cf90e5371d99e9f15f6ffcf4b647d6488e3feff7b2aec8465f698",
     "zkBytecodePath": "/system-contracts/zkout/L2UpgradeUtils.sol/L2UpgradeUtils.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -233,7 +233,7 @@
   },
   {
     "contractName": "system-contracts/L2V29Upgrade",
-    "zkBytecodeHash": "0x010003532289a3a04d7c4f9b285cca451e6b00847f0a2140346bdc3a21ad48a5",
+    "zkBytecodeHash": "0x01000353e7b6c3af58b2e57e6a58cf7f498ad44721f57075dda954ed01d99c25",
     "zkBytecodePath": "/system-contracts/zkout/L2V29Upgrade.sol/L2V29Upgrade.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -249,7 +249,7 @@
   },
   {
     "contractName": "system-contracts/MsgValueSimulator",
-    "zkBytecodeHash": "0x0100005733d4154317fed7fe01a319b35921ba38224e720b8af0d3dd2bc5bb5d",
+    "zkBytecodeHash": "0x01000057f2501514d0a32765435cd9be455d99b7b4141655c8524123a5155635",
     "zkBytecodePath": "/system-contracts/zkout/MsgValueSimulator.sol/MsgValueSimulator.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -257,7 +257,7 @@
   },
   {
     "contractName": "system-contracts/NonceHolder",
-    "zkBytecodeHash": "0x010000d90eaf8c2379e61b01db642bbab6c8bfa2f00698354826acfc07c88cad",
+    "zkBytecodeHash": "0x010000d963e706faa3f74fc7f7195b1f7b42df568f63a2bbfe351fced574d3ae",
     "zkBytecodePath": "/system-contracts/zkout/NonceHolder.sol/NonceHolder.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -273,7 +273,7 @@
   },
   {
     "contractName": "system-contracts/PubdataChunkPublisher",
-    "zkBytecodeHash": "0x01000073c30eeb7211a111dd8447eb05f569b06c4179463d82636e432fc46848",
+    "zkBytecodeHash": "0x010000731262d424cbb398d1a81e99d5a1de14616c319f4ff43017303739e107",
     "zkBytecodePath": "/system-contracts/zkout/PubdataChunkPublisher.sol/PubdataChunkPublisher.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -313,7 +313,7 @@
   },
   {
     "contractName": "system-contracts/SystemCaller",
-    "zkBytecodeHash": "0x0100004dc7b441fd054d9a4d8351175b430485a0a58331eb1d8463b6e760be69",
+    "zkBytecodeHash": "0x0100004d18b5e25b98e2c0d82df27113b4272b04ac064b75c247e1d70beab006",
     "zkBytecodePath": "/system-contracts/zkout/SystemCaller.sol/SystemCaller.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -321,7 +321,7 @@
   },
   {
     "contractName": "system-contracts/SystemContext",
-    "zkBytecodeHash": "0x0100016da0d54d11a3559c7436136aac0651838e095ba20c1a390d3e5a15e409",
+    "zkBytecodeHash": "0x01000173ab332922f55650431853cef043a8c27715be96fb2755ba61e02a713b",
     "zkBytecodePath": "/system-contracts/zkout/SystemContext.sol/SystemContext.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -329,7 +329,7 @@
   },
   {
     "contractName": "system-contracts/SystemContractHelper",
-    "zkBytecodeHash": "0x0100000716c8757f14e97cdb75217137caae9e1766c8b60aabb02e55b2161b2f",
+    "zkBytecodeHash": "0x0100000794efe3c92da194104c76c227017a787ec16010adb88e93da3deae78e",
     "zkBytecodePath": "/system-contracts/zkout/SystemContractHelper.sol/SystemContractHelper.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -337,7 +337,7 @@
   },
   {
     "contractName": "system-contracts/SystemContractsCaller",
-    "zkBytecodeHash": "0x01000007ccc14be9be8f60e193aeb6f6c3b91e413342dc3b4c4778b92bd6b23b",
+    "zkBytecodeHash": "0x0100000719f62c770ef04f0ed9dbc613232abccbcc6abd9095aa290186ff7a74",
     "zkBytecodePath": "/system-contracts/zkout/SystemContractsCaller.sol/SystemContractsCaller.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -345,7 +345,7 @@
   },
   {
     "contractName": "system-contracts/TransactionHelper",
-    "zkBytecodeHash": "0x010000070f42ab7aa25c7a674d80cc0289b4487054a32adff56f4aff4b7dee84",
+    "zkBytecodeHash": "0x0100000757b2ca6dc63a22c104886746dedd40666027f4e171a8db318a50df38",
     "zkBytecodePath": "/system-contracts/zkout/TransactionHelper.sol/TransactionHelper.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -377,7 +377,7 @@
   },
   {
     "contractName": "system-contracts/Utils",
-    "zkBytecodeHash": "0x0100000778eb2540daca940eed9c6d667ba7da5d30b20e3418561a1efae3f7ba",
+    "zkBytecodeHash": "0x01000007fa5e9ceec5798adf4817cedac8536118c564b151f4dbdbd13fe92568",
     "zkBytecodePath": "/system-contracts/zkout/Utils.sol/Utils.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,

--- a/system-contracts/contracts/SystemContext.sol
+++ b/system-contracts/contracts/SystemContext.sol
@@ -7,7 +7,7 @@ import {SystemContractBase} from "./abstract/SystemContractBase.sol";
 import {ISystemContextDeprecated} from "./interfaces/ISystemContextDeprecated.sol";
 import {SystemContractHelper} from "./libraries/SystemContractHelper.sol";
 import {BOOTLOADER_FORMAL_ADDRESS, COMPLEX_UPGRADER_CONTRACT, SystemLogKey} from "./Constants.sol";
-import {CannotInitializeFirstVirtualBlock, CannotReuseL2BlockNumberFromPreviousBatch, CurrentBatchNumberMustBeGreaterThanZero, InconsistentNewBatchTimestamp, IncorrectL2BlockHash, IncorrectSameL2BlockPrevBlockHash, IncorrectSameL2BlockTimestamp, IncorrectVirtualBlockInsideMiniblock, InvalidNewL2BlockNumber, L2BlockAndBatchTimestampMismatch, L2BlockNumberZero, NoVirtualBlocks, NonMonotonicL2BlockTimestamp, PreviousL2BlockHashIsIncorrect, ProvidedBatchNumberIsNotCorrect, TimestampsShouldBeIncremental, UpgradeTransactionMustBeFirst} from "contracts/SystemContractErrors.sol";
+import {CannotInitializeFirstVirtualBlock, CannotReuseL2BlockNumberFromPreviousBatch, CurrentBatchNumberMustBeGreaterThanZero, DeprecatedFunction, InconsistentNewBatchTimestamp, IncorrectL2BlockHash, IncorrectSameL2BlockPrevBlockHash, IncorrectSameL2BlockTimestamp, IncorrectVirtualBlockInsideMiniblock, InvalidNewL2BlockNumber, L2BlockAndBatchTimestampMismatch, L2BlockNumberZero, NoVirtualBlocks, NonMonotonicL2BlockTimestamp, PreviousL2BlockHashIsIncorrect, ProvidedBatchNumberIsNotCorrect, TimestampsShouldBeIncremental, UpgradeTransactionMustBeFirst} from "contracts/SystemContractErrors.sol";
 
 /**
  * @author Matter Labs
@@ -416,7 +416,7 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, SystemContra
     /// @notice Publishes L2->L1 logs needed to verify the validity of this batch on L1.
     /// @dev Should be called at the end of the current batch.
     function publishTimestampDataToL1() external onlyCallFromBootloader {
-        (uint128 currentBatchNumber, uint128 currentBatchTimestamp) = getBatchNumberAndTimestamp();
+        (uint128 currentBatchNumber, uint128 currentBatchTimestamp) = _getBatchNumberAndTimestamp();
         (, uint128 currentL2BlockTimestamp) = getL2BlockNumberAndTimestamp();
 
         // The structure of the "setNewBatch" implies that currentBatchNumber > 0, but we still double check it
@@ -458,7 +458,7 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, SystemContra
         uint128 _expectedNewNumber,
         uint256 _baseFee
     ) external onlyCallFromBootloader {
-        (uint128 previousBatchNumber, uint128 previousBatchTimestamp) = getBatchNumberAndTimestamp();
+        (uint128 previousBatchNumber, uint128 previousBatchTimestamp) = _getBatchNumberAndTimestamp();
         if (_newTimestamp <= previousBatchTimestamp) {
             revert TimestampsShouldBeIncremental(_newTimestamp, previousBatchTimestamp);
         }
@@ -499,6 +499,14 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, SystemContra
         txNumberInBlock = 0;
     }
 
+    /// @notice Returns the current batch's number and timestamp.
+    /// @return batchNumber and batchTimestamp tuple of the current batch's number and the current batch's timestamp
+    function _getBatchNumberAndTimestamp() internal view returns (uint128 batchNumber, uint128 batchTimestamp) {
+        BlockInfo memory batchInfo = currentBatchInfo;
+        batchNumber = batchInfo.number;
+        batchTimestamp = batchInfo.timestamp;
+    }
+
     /*//////////////////////////////////////////////////////////////
                         DEPRECATED METHODS
     //////////////////////////////////////////////////////////////*/
@@ -508,44 +516,41 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, SystemContra
     /// @return hash The hash of the batch.
     /// @dev Deprecated to make publicly accessible methods compatible with planned releases.
     /// @dev Please use the block function `getBlockHashEVM` if needed.
-    /// @dev The function body will be replaced with revert in the next release.
+    /// @dev The function will be completely removed in the next release.
     function getBatchHash(uint256 _batchNumber) external view returns (bytes32 hash) {
-        hash = batchHashes[_batchNumber];
+        revert DeprecatedFunction(this.getBatchHash.selector);
     }
 
     /// @notice Returns the current batch's number and timestamp.
     /// @return batchNumber and batchTimestamp tuple of the current batch's number and the current batch's timestamp
     /// @dev Deprecated for external usage to make publicly accessible methods compatible with planned releases.
     /// @dev Please use the block function `getL2BlockNumberAndTimestamp` if needed.
-    /// @dev The function body will be replaced with revert in the next release.
-    function getBatchNumberAndTimestamp() public view returns (uint128 batchNumber, uint128 batchTimestamp) {
-        BlockInfo memory batchInfo = currentBatchInfo;
-        batchNumber = batchInfo.number;
-        batchTimestamp = batchInfo.timestamp;
+    /// @dev The function will be completely removed in the next release.
+    function getBatchNumberAndTimestamp() external view returns (uint128 batchNumber, uint128 batchTimestamp) {
+        revert DeprecatedFunction(this.getBatchNumberAndTimestamp.selector);
     }
 
     /// @notice Returns the current batch's number and timestamp.
     /// @dev Deprecated for external usage to make publicly accessible methods compatible with planned releases.
     /// @dev Please use the block function `getL2BlockNumberAndTimestamp` if needed.
-    /// @dev The function body will be replaced with revert in the next release.
+    /// @dev The function will be completely removed in the next release.
     function currentBlockInfo() external view returns (uint256 blockInfo) {
-        (uint128 blockNumber, uint128 blockTimestamp) = getBatchNumberAndTimestamp();
-        blockInfo = (uint256(blockNumber) << 128) | uint256(blockTimestamp);
+        revert DeprecatedFunction(this.currentBlockInfo.selector);
     }
 
     /// @notice Returns the current batch's number and timestamp.
     /// @dev Deprecated to make publicly accessible methods compatible with planned releases.
     /// @dev Please use the block function `getL2BlockNumberAndTimestamp` if needed.
-    /// @dev The function body will be replaced with revert in the next release.
+    /// @dev The function will be completely removed in the next release.
     function getBlockNumberAndTimestamp() external view returns (uint256 blockNumber, uint256 blockTimestamp) {
-        (blockNumber, blockTimestamp) = getBatchNumberAndTimestamp();
+        revert DeprecatedFunction(this.getBlockNumberAndTimestamp.selector);
     }
 
     /// @notice Returns the hash of the given batch.
     /// @dev Deprecated to make publicly accessible methods compatible with planned releases.
     /// @dev Please use the block function `getBlockHashEVM` if needed.
-    /// @dev The function body will be replaced with revert in the next release.
+    /// @dev The function will be completely removed in the next release.
     function blockHash(uint256 _blockNumber) external view returns (bytes32 hash) {
-        hash = batchHashes[_blockNumber];
+        revert DeprecatedFunction(this.blockHash.selector);
     }
 }

--- a/system-contracts/contracts/SystemContractErrors.sol
+++ b/system-contracts/contracts/SystemContractErrors.sol
@@ -30,6 +30,8 @@ error CompressorEnumIndexNotEqual(uint256 expected, uint256 actual);
 error CompressorInitialWritesProcessedNotEqual(uint256 expected, uint256 actual);
 // 0x6ad429e8
 error CurrentBatchNumberMustBeGreaterThanZero();
+// 0x01e6c91e
+error DeprecatedFunction(bytes4 selector);
 // 0x9be48d8d
 error DerivedKeyNotEqualToCompressedValue(bytes32 expected, bytes32 provided);
 // 0xe223db5e


### PR DESCRIPTION
## What ❔

We are deprecating batch methods in preparation for ZKsync OS. There will be no concept of batches, so it's better to guard users from using batch-like interfaces. 
A plan to transition smoothly consists of 3 steps:
1. Mark relevant functions as deprecated, but leave them accessible. v29
2. Replace relevant functions' bodies with reverts. v30
3. Delete functions from codebase if they are not being used by us, otherwise leave them as internal functions. v31

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
