### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/docs/settlement_contracts/data_availability/standard_pubdata_format.md
+++ b/docs/settlement_contracts/data_availability/standard_pubdata_format.md
@@ -229,7 +229,7 @@ Note, that values like `initial_value`, `address` and `key` are not used in the 
 #### **L2**
 
 1. The operator provides both full `stateDiffs` (i.e. the array of the structs above) and the compressed state diffs (i.e. the array which contains the state diffs, compressed by the algorithm explained [below](#state-diff-compression-format)).
-2. The L2DAValidator must verify that the compressed version is consistent with the original stateDiffs and send the the _hash_ of the original state diff to its L1 counterpart. It will also include the compressed state diffs into the totalPubdata to be published onto L1.
+2. The L2DAValidator must verify that the compressed version is consistent with the original stateDiffs and send the _hash_ of the original state diff to its L1 counterpart. It will also include the compressed state diffs into the totalPubdata to be published onto L1.
 
 #### **L1**
 

--- a/docs/settlement_contracts/priority_queue/processing_of_l1-l2_txs.md
+++ b/docs/settlement_contracts/priority_queue/processing_of_l1-l2_txs.md
@@ -93,6 +93,6 @@ In the current system though having such logic would be dangerous and would allo
 
 The most important caveat of this malicious upgrade is that it may change implementation of the `Keccak256` precompile to return any values that the operator needs.
 
-- When the`priorityOperationsRollingHash` will be updated, instead of the “correct” rolling hash of the priority transactions, the one which would appear with the correct topmost priority operation is returned. The operator can’t amend the behaviour of `numberOfPriorityTransactions`, but it won’t help much, since the the `priorityOperationsRollingHash` will match on L1 on the execution step.
+- When the`priorityOperationsRollingHash` will be updated, instead of the “correct” rolling hash of the priority transactions, the one which would appear with the correct topmost priority operation is returned. The operator can’t amend the behaviour of `numberOfPriorityTransactions`, but it won’t help much, since the `priorityOperationsRollingHash` will match on L1 on the execution step.
 
 That’s why the concept of the upgrade transaction is needed: this is the only transaction that can initiate transactions out of the kernel space and thus change bytecodes of system contracts. That’s why it must be the first one and that’s why bootloader [emits](../../../system-contracts/bootloader/bootloader.yul#L603) its hash via a system L2→L1 log before actually processing it.

--- a/l1-contracts/contracts/bridge/ntv/INativeTokenVault.sol
+++ b/l1-contracts/contracts/bridge/ntv/INativeTokenVault.sol
@@ -33,7 +33,7 @@ interface INativeTokenVault {
     /// @dev This function is used to ensure that the token is registered with the NTV.
     function ensureTokenIsRegistered(address _nativeToken) external returns (bytes32);
 
-    /// @notice Used to get the the ERC20 data for a token
+    /// @notice Used to get the ERC20 data for a token
     function getERC20Getters(address _token, uint256 _originChainId) external view returns (bytes memory);
 
     /// @notice Used to get the token address of an assetId

--- a/l1-contracts/contracts/state-transition/libraries/BatchDecoder.sol
+++ b/l1-contracts/contracts/state-transition/libraries/BatchDecoder.sol
@@ -86,7 +86,7 @@ library BatchDecoder {
     /// @notice Decodes proof data from a calldata byte array into the previous batch, an array of proved batches, and a proof array.
     /// @param _proofData The calldata byte array containing the data for proving batches.
     /// @return prevBatch The batch information before the batches to be verified.
-    /// @return provedBatches An array containing the the batches to be verified.
+    /// @return provedBatches An array containing the batches to be verified.
     /// @return proof An array containing the proof for the verifier.
     function _decodeProofData(
         bytes calldata _proofData
@@ -117,7 +117,7 @@ library BatchDecoder {
     /// @param _processBatchFrom The expected batch number of the first batch in the array.
     /// @param _processBatchTo The expected batch number of the last batch in the array.
     /// @return prevBatch The batch information before the batches to be verified.
-    /// @return provedBatches An array containing the the batches to be verified.
+    /// @return provedBatches An array containing the batches to be verified.
     /// @return proof An array containing the proof for the verifier.
     function decodeAndCheckProofData(
         bytes calldata _proofData,

--- a/system-contracts/bootloader/bootloader.yul
+++ b/system-contracts/bootloader/bootloader.yul
@@ -72,7 +72,7 @@ object "Bootloader" {
             }
 
             /// @dev Calculates the gas per pubdata based on the pubdata price provided by the operator
-            /// as well the the fixed baseFee.
+            /// as well the fixed baseFee.
             function gasPerPubdataFromBaseFee(baseFee, pubdataPrice) -> ret {
                 ret := ceilDiv(pubdataPrice, baseFee)
             }

--- a/system-contracts/contracts/SystemContext.sol
+++ b/system-contracts/contracts/SystemContext.sol
@@ -104,7 +104,7 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, SystemContra
         origin = _newOrigin;
     }
 
-    /// @notice Set the the current gas price.
+    /// @notice Set the current gas price.
     /// @param _gasPrice The new tx gasPrice.
     function setGasPrice(uint256 _gasPrice) external onlyCallFromBootloader {
         gasPrice = _gasPrice;


### PR DESCRIPTION
## What ❔

remove redundant words in comment

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
