### PR TITLE
Fix wrong file path in generate-bootloader-artifacts script

### DIFF
--- a/system-contracts/scripts/generate-bootloader-artifacts.ts
+++ b/system-contracts/scripts/generate-bootloader-artifacts.ts
@@ -4,7 +4,7 @@ import { ethers } from "ethers";
 
 const OUTPUT_DIR = "bootloader/artifacts";
 
-const ARTIFACT_PATH = "zkout/{file}/contracts-preprocessed/bootloader/{file}.json";
+const ARTIFACT_PATH = "zkout/{file}/Bootloader.json";
 
 const bootloaderArtifacts = ["fee_estimate.yul", "gas_test.yul", "playground_batch.yul", "proved_batch.yul"];
 


### PR DESCRIPTION
## What ❔

File path was incorrect.

Changed line 7 in the scripts/generate-bootloader-artifacts.ts from

```
const ARTIFACT_PATH = "zkout/{file}/contracts-preprocessed/bootloader/{file}.json";
```

to

```
const ARTIFACT_PATH = "zkout/{file}/Bootloader.json";
```

## Why ❔

- reported [here](https://github.com/zkSync-Community-Hub/zksync-developers/discussions/1074)
- Fixes the script

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
