### PR TITLE
chore: upload error signatures when `--fix`ing

### DIFF
--- a/l1-contracts/scripts/errors-lint.ts
+++ b/l1-contracts/scripts/errors-lint.ts
@@ -2,6 +2,76 @@ import { Command } from "commander";
 import * as fs from "fs";
 import * as path from "path";
 import { ethers } from "ethers";
+import * as https from "https";
+
+// Helper function to query the signature database
+async function querySignatureDatabase(signature: string): Promise<any> {
+  const url = `https://www.4byte.directory/api/v1/signatures/?text_signature=${encodeURIComponent(
+    signature
+  )}&_=${Date.now()}`; // add a timestamp to avoid caching
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, (res) => {
+        let data = "";
+        res.on("data", (chunk) => {
+          data += chunk;
+        });
+        res.on("end", () => {
+          try {
+            resolve(JSON.parse(data));
+          } catch (e) {
+            reject(new Error(`Failed to parse response from signature database: ${data}`));
+          }
+        });
+      })
+      .on("error", (err) => {
+        reject(new Error(`Error querying signature database: ${err.message}`));
+      });
+  });
+}
+
+// Helper function to submit a signature to the database
+async function submitSignatureToDatabase(signature: string): Promise<void> {
+  const postData = JSON.stringify({
+    text_signature: signature
+  });
+
+  const options = {
+    hostname: "www.4byte.directory",
+    path: "/api/v1/signatures/",
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(postData)
+    }
+  };
+
+  return new Promise((resolve, reject) => {
+    const req = https.request(options, (res) => {
+      let responseBody = "";
+      res.on("data", (chunk) => (responseBody += chunk));
+
+      res.on("end", () => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          console.log(`Signature "${signature}" submitted successfully.`);
+          resolve();
+        } else if (res.statusCode === 400 && responseBody.includes("already exists")) {
+          console.log(`Signature "${signature}" already exists in the database (race condition?). Treating as success.`);
+          resolve();
+        } else {
+          reject(new Error(`Failed to submit signature "${signature}". Status: ${res.statusCode}, Body: ${responseBody}`));
+        }
+      });
+    });
+
+    req.on("error", (e) => {
+      reject(new Error(`Error submitting signature "${signature}": ${e.message}`));
+    });
+
+    req.write(postData);
+    req.end();
+  });
+}
 
 // Constant arrays
 const CONTRACTS_DIRECTORIES = {
@@ -83,7 +153,7 @@ function sortErrorBlocks(lines: string[]): string[] {
 }
 
 // Process a file: handle selector insertion, multiline parsing, and sorting
-function processFile(filePath: string, fix: boolean, collectedErrors: Map<string, [string, string]>): boolean {
+async function processFile(filePath: string, fix: boolean, collectedErrors: Map<string, [string, string]>): Promise<boolean> {
   const content = fs.readFileSync(filePath, "utf8");
 
   // Find all enum definitions in the file
@@ -139,6 +209,16 @@ function processFile(filePath: string, fix: boolean, collectedErrors: Map<string
         if (prev && prev.trim().startsWith("//")) output[output.length - 1] = comment;
         else output.push(comment);
         modified = true;
+      }
+
+      // Submit signature to https://www4byte.directory/ if --fix is provided
+      if (fix) {
+        const dbResult = await querySignatureDatabase(sig);
+        if (dbResult.count === 0) {
+          await submitSignatureToDatabase(sig);
+        } else {
+          console.log(`Signature "${sig}" already exists in the database.`);
+        }
       }
 
       // Push block
@@ -198,7 +278,7 @@ async function main() {
     const usedErrors = new Set<string>();
     for (const customErrorFile of errorsPaths) {
       const absolutePath = path.resolve(contractsPath + "/" + customErrorFile);
-      const result = processFile(absolutePath, options.fix, declaredErrors);
+      const result = await processFile(absolutePath, options.fix, declaredErrors);
       if (result && options.check) hasErrors = true;
     }
     if (options.check && hasErrors) {


### PR DESCRIPTION
## What ❔

Uploads error signatures to https://www.4byte.directory/ when running `yarn errors-lint --fix` inside `l1-contracts`. Note that the presence of signatures in this database is **not** checked as part of CI as it can be quite slow (~3 minutes) to iterate through all errors. This directory is used by our own [anvil-zksync](https://github.com/matter-labs/anvil-zksync) as well as other third parties when decoding errors, hopefully making debugging tasks easier for all.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
