### PR TITLE
feat(eigenda): EigenDA M1

### DIFF
--- a/da-contracts/contracts/da-layers/eigenda/EigenDAL1DAValidator.sol
+++ b/da-contracts/contracts/da-layers/eigenda/EigenDAL1DAValidator.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.28;
+
+import {IL1DAValidator, L1DAValidatorOutput} from "../../IL1DAValidator.sol";
+import {OperatorDAInputTooSmall} from "../../DAContractsErrors.sol";
+
+interface IRiscZeroVerifier {
+    function verify(bytes calldata seal, bytes32 imageId, bytes32 journalDigest) external view;
+}
+
+struct Journal {
+    bytes32 eigenDAHash; // The hash of the EigenDA data calculated by the Risc0 guest
+    bytes env_commitment; // The abi-encoded steel commitment
+    bytes proof; // The KZG Proof for proof of equivalence
+}
+
+struct EigenDAInclusionData {
+    bytes seal;
+    bytes32 imageId;
+    bytes journal;
+}
+
+contract EigenDAL1DAValidator is IL1DAValidator {
+    error InvalidValidatorOutputHash();
+    error ProofNotVerified();
+
+    IRiscZeroVerifier public risc0Verifier;
+
+    constructor(address risc0VerifierAddress) {
+        risc0Verifier = IRiscZeroVerifier(risc0VerifierAddress);
+    }
+
+    /// Verifies a zk proof of an eth-call to https://github.com/Layr-Labs/eigenda/blob/805492f803416c258b8aa7dff90c7d5cc4b750bd/contracts/src/periphery/cert/interfaces/IEigenDACertVerifierBase.sol#L8
+    /// It is only compatible with EigenDACertV3 https://github.com/Layr-Labs/eigenda/blob/805492f803416c258b8aa7dff90c7d5cc4b750bd/contracts/src/periphery/cert/EigenDACertTypes.sol#L11
+    function checkDA(
+        uint256, // _chainId
+        uint256, // _batchNumber,
+        bytes32 l2DAValidatorOutputHash, // keccak(stateDiffHash, eigenDAHash) Calculated on EigenDAL2DAValidator and passed through L2->L1 Logs
+        bytes calldata operatorDAInput, // stateDiffHash + inclusion_data (abi encoded EigenDAInclusionData)
+        uint256 maxBlobsSupported
+    ) external override returns (L1DAValidatorOutput memory output) {
+        if (operatorDAInput.length < 32) {
+            revert OperatorDAInputTooSmall(operatorDAInput.length, 32);
+        }
+        output.stateDiffHash = bytes32(operatorDAInput[:32]);
+
+        // Decode the inclusion data from the operatorDAInput
+        EigenDAInclusionData memory inclusionData = abi.decode(operatorDAInput[32:], (EigenDAInclusionData));
+
+        // Decode the journal (public outputs)
+        Journal memory journal = abi.decode(inclusionData.journal, (Journal));
+
+        // Verify the risczero proof
+        risc0Verifier.verify(inclusionData.seal, inclusionData.imageId, sha256(inclusionData.journal));
+
+        // Check that the eigenDAHash from the Inclusion Data (originally calculated on Risc0 guest) is correct
+        if (l2DAValidatorOutputHash != keccak256(abi.encodePacked(output.stateDiffHash, journal.eigenDAHash)))
+            revert InvalidValidatorOutputHash();
+
+        output.blobsLinearHashes = new bytes32[](maxBlobsSupported);
+        output.blobsOpeningCommitments = new bytes32[](maxBlobsSupported);
+    }
+}

--- a/l1-contracts/deploy-scripts/ContractsBytecodesLib.sol
+++ b/l1-contracts/deploy-scripts/ContractsBytecodesLib.sol
@@ -25,7 +25,7 @@ library ContractsBytecodesLib {
         }
     }
     function getCreationCodeEVM(string memory contractIdentifier) internal view returns (bytes memory) {
-        string[3] memory DA_CONTRACT_IDENTIFIERS = ["RollupL1DAValidator", "AvailL1DAValidator", "DummyAvailBridge"];
+        string[4] memory DA_CONTRACT_IDENTIFIERS = ["RollupL1DAValidator", "AvailL1DAValidator", "DummyAvailBridge", "EigenDAL1DAValidator"];
 
         uint256 DA_CONTRACT_IDENTIFIERS_LENGTH = DA_CONTRACT_IDENTIFIERS.length;
         for (uint i = 0; i < DA_CONTRACT_IDENTIFIERS_LENGTH; i++) {
@@ -84,13 +84,14 @@ library ContractsBytecodesLib {
             "L1V29Upgrade"
         ];
 
-        string[6] memory L2_GENERIC_CONTRACT_IDENTIFIERS = [
+        string[7] memory L2_GENERIC_CONTRACT_IDENTIFIERS = [
             "ForceDeployUpgrader",
             "RollupL2DAValidator",
             "ConsensusRegistry",
             "AvailL2DAValidator",
             "ValidiumL2DAValidator",
-            "TimestampAsserter"
+            "TimestampAsserter",
+            "EigenDAL2DAValidator"
         ];
 
         string[3] memory SYSTEM_CONTRACT_IDENTIFIERS = [

--- a/l1-contracts/deploy-scripts/ContractsBytecodesLib.sol
+++ b/l1-contracts/deploy-scripts/ContractsBytecodesLib.sol
@@ -25,7 +25,12 @@ library ContractsBytecodesLib {
         }
     }
     function getCreationCodeEVM(string memory contractIdentifier) internal view returns (bytes memory) {
-        string[4] memory DA_CONTRACT_IDENTIFIERS = ["RollupL1DAValidator", "AvailL1DAValidator", "DummyAvailBridge", "EigenDAL1DAValidator"];
+        string[4] memory DA_CONTRACT_IDENTIFIERS = [
+            "RollupL1DAValidator",
+            "AvailL1DAValidator",
+            "DummyAvailBridge",
+            "EigenDAL1DAValidator"
+        ];
 
         uint256 DA_CONTRACT_IDENTIFIERS_LENGTH = DA_CONTRACT_IDENTIFIERS.length;
         for (uint i = 0; i < DA_CONTRACT_IDENTIFIERS_LENGTH; i++) {

--- a/l1-contracts/deploy-scripts/DeployL1.s.sol
+++ b/l1-contracts/deploy-scripts/DeployL1.s.sol
@@ -239,6 +239,15 @@ contract DeployL1Script is Script, DeployUtils {
         } else {
             addresses.daAddresses.availL1DAValidator = config.contracts.availL1DAValidator;
         }
+        if (config.contracts.eigenDAL1DAValidator == address(0)) {
+            if (config.contracts.eigenDARiscZeroVerifier == address(0)) {
+                console.log("EigenDARiscZeroVerifier not deployed, do not use for production");
+                }
+            addresses.daAddresses.eigenDARiscZeroVerifier = config.contracts.eigenDARiscZeroVerifier;
+            addresses.daAddresses.eigenDAL1DAValidator = deploySimpleContract("EigenDAL1DAValidator", false);
+        } else {
+            addresses.daAddresses.eigenDAL1DAValidator = config.contracts.eigenDAL1DAValidator;
+        }
         vm.startBroadcast(msg.sender);
         IRollupDAManager rollupDAManager = IRollupDAManager(addresses.daAddresses.rollupDAManager);
         rollupDAManager.updateDAPair(
@@ -534,6 +543,18 @@ contract DeployL1Script is Script, DeployUtils {
             addresses.daAddresses.availL1DAValidator
         );
 
+        vm.serializeAddress(
+            "deployed_addresses",
+            "eigenda_l1_validator_addr",
+            addresses.daAddresses.eigenDAL1DAValidator
+        );
+
+        vm.serializeAddress(
+            "deployed_addresses",
+            "eigenda_risc_zero_verifier_addr",
+            addresses.daAddresses.eigenDARiscZeroVerifier
+        );
+
         string memory deployedAddresses = vm.serializeAddress(
             "deployed_addresses",
             "native_token_vault_addr",
@@ -559,6 +580,7 @@ contract DeployL1Script is Script, DeployUtils {
             getL2ValidatorAddress("ValidiumL2DAValidator")
         );
         vm.serializeAddress("root", "expected_avail_l2_da_validator_addr", getL2ValidatorAddress("AvailL2DAValidator"));
+        vm.serializeAddress("root", "expected_eigenda_l2_validator_addr", getL2ValidatorAddress("EigenDAL2DAValidator"));
         string memory toml = vm.serializeAddress("root", "owner_address", config.ownerAddress);
 
         vm.writeToml(toml, outputPath);

--- a/l1-contracts/deploy-scripts/DeployL1.s.sol
+++ b/l1-contracts/deploy-scripts/DeployL1.s.sol
@@ -242,7 +242,7 @@ contract DeployL1Script is Script, DeployUtils {
         if (config.contracts.eigenDAL1DAValidator == address(0)) {
             if (config.contracts.eigenDARiscZeroVerifier == address(0)) {
                 console.log("EigenDARiscZeroVerifier not deployed, do not use for production");
-                }
+            }
             addresses.daAddresses.eigenDARiscZeroVerifier = config.contracts.eigenDARiscZeroVerifier;
             addresses.daAddresses.eigenDAL1DAValidator = deploySimpleContract("EigenDAL1DAValidator", false);
         } else {
@@ -580,7 +580,11 @@ contract DeployL1Script is Script, DeployUtils {
             getL2ValidatorAddress("ValidiumL2DAValidator")
         );
         vm.serializeAddress("root", "expected_avail_l2_da_validator_addr", getL2ValidatorAddress("AvailL2DAValidator"));
-        vm.serializeAddress("root", "expected_eigenda_l2_validator_addr", getL2ValidatorAddress("EigenDAL2DAValidator"));
+        vm.serializeAddress(
+            "root",
+            "expected_eigenda_l2_validator_addr",
+            getL2ValidatorAddress("EigenDAL2DAValidator")
+        );
         string memory toml = vm.serializeAddress("root", "owner_address", config.ownerAddress);
 
         vm.writeToml(toml, outputPath);

--- a/l1-contracts/deploy-scripts/DeployL2Contracts.sol
+++ b/l1-contracts/deploy-scripts/DeployL2Contracts.sol
@@ -178,7 +178,7 @@ contract DeployL2Script is Script {
         } else if (config.validatorType == DAValidatorType.Avail) {
             bytecode = ContractsBytecodesLib.getCreationCode("AvailL2DAValidator");
         } else if (config.validatorType == DAValidatorType.EigenDA) {
-            bytecode = L2ContractsBytecodesLib.getCreationCode("EigenDAL2DAValidator");
+            bytecode = ContractsBytecodesLib.getCreationCode("EigenDAL2DAValidator");
         } else {
             revert("Invalid DA validator type");
         }

--- a/l1-contracts/deploy-scripts/DeployL2Contracts.sol
+++ b/l1-contracts/deploy-scripts/DeployL2Contracts.sol
@@ -24,7 +24,8 @@ contract DeployL2Script is Script {
     enum DAValidatorType {
         Rollup,
         NoDA,
-        Avail
+        Avail,
+        EigenDA
     }
 
     // solhint-disable-next-line gas-struct-packing
@@ -151,7 +152,7 @@ contract DeployL2Script is Script {
         config.eraChainId = toml.readUint("$.era_chain_id");
 
         uint256 validatorTypeUint = toml.readUint("$.da_validator_type");
-        require(validatorTypeUint < 3, "Invalid DA validator type");
+        require(validatorTypeUint < 4, "Invalid DA validator type");
         config.validatorType = DAValidatorType(validatorTypeUint);
     }
 
@@ -176,6 +177,8 @@ contract DeployL2Script is Script {
             bytecode = ContractsBytecodesLib.getCreationCode("ValidiumL2DAValidator");
         } else if (config.validatorType == DAValidatorType.Avail) {
             bytecode = ContractsBytecodesLib.getCreationCode("AvailL2DAValidator");
+        } else if (config.validatorType == DAValidatorType.EigenDA) {
+            bytecode = L2ContractsBytecodesLib.getCreationCode("EigenDAL2DAValidator");
         } else {
             revert("Invalid DA validator type");
         }

--- a/l1-contracts/deploy-scripts/DeployUtils.s.sol
+++ b/l1-contracts/deploy-scripts/DeployUtils.s.sol
@@ -42,6 +42,8 @@ struct DataAvailabilityDeployedAddresses {
     address noDAValidiumL1DAValidator;
     address availBridge;
     address availL1DAValidator;
+    address eigenDAL1DAValidator;
+    address eigenDARiscZeroVerifier;
 }
 
 // solhint-disable-next-line gas-struct-packing
@@ -107,6 +109,8 @@ struct ContractsConfig {
     bytes32 defaultAAHash;
     bytes32 evmEmulatorHash;
     address availL1DAValidator;
+    address eigenDAL1DAValidator;
+    address eigenDARiscZeroVerifier;
 }
 
 struct TokensConfig {
@@ -183,6 +187,13 @@ abstract contract DeployUtils is Create2FactoryUtils {
 
         if (vm.keyExistsToml(toml, "$.contracts.avail_l1_da_validator")) {
             config.contracts.availL1DAValidator = toml.readAddress("$.contracts.avail_l1_da_validator");
+        }
+        if (vm.keyExistsToml(toml, "$.contracts.eigenda_l1_validator")) {
+            config.contracts.eigenDAL1DAValidator = toml.readAddress("$.contracts.eigenda_l1_validator");
+        }
+
+        if (vm.keyExistsToml(toml, "$.contracts.eigenda_risc_zero_verifier_addr")) {
+            config.contracts.eigenDARiscZeroVerifier = toml.readAddress("$.contracts.eigenda_risc_zero_verifier_addr");
         }
 
         config.tokens.tokenWethAddress = toml.readAddress("$.tokens.token_weth_address");
@@ -408,6 +419,8 @@ abstract contract DeployUtils is Create2FactoryUtils {
             return abi.encode(addresses.daAddresses.availBridge);
         } else if (compareStrings(contractName, "DummyAvailBridge")) {
             return abi.encode();
+        } else if (compareStrings(contractName, "EigenDAL1DAValidator")) {
+            return abi.encode(addresses.daAddresses.eigenDARiscZeroVerifier);
         } else if (compareStrings(contractName, "Verifier")) {
             return abi.encode(addresses.stateTransition.verifierFflonk, addresses.stateTransition.verifierPlonk);
         } else if (compareStrings(contractName, "VerifierFflonk")) {

--- a/l2-contracts/contracts/data-availability/EigenDAL2DAValidator.sol
+++ b/l2-contracts/contracts/data-availability/EigenDAL2DAValidator.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.28;
+
+import {IL2DAValidator} from "../interfaces/IL2DAValidator.sol";
+
+import {StateDiffL2DAValidator} from "./StateDiffL2DAValidator.sol";
+
+/// EigenDA L2 DA validator. It will create a commitment to the pubdata that can later be verified during settlement.
+contract EigenDAL2DAValidator is IL2DAValidator, StateDiffL2DAValidator {
+    function validatePubdata(
+        // The rolling hash of the user L2->L1 logs.
+        bytes32,
+        // The root hash of the user L2->L1 logs.
+        bytes32,
+        // The chained hash of the L2->L1 messages
+        bytes32 _chainedMessagesHash,
+        // The chained hash of uncompressed bytecodes sent to L1
+        bytes32 _chainedBytecodesHash,
+        // Operator data, that is related to the DA itself
+        bytes calldata _totalL2ToL1PubdataAndStateDiffs
+    ) external returns (bytes32 outputHash) {
+        (bytes32 stateDiffHash, bytes calldata _fullPubdata, ) = _produceStateDiffPubdata(
+            _chainedMessagesHash,
+            _chainedBytecodesHash,
+            _totalL2ToL1PubdataAndStateDiffs
+        );
+
+        bytes32 fullPubdataHash = keccak256(_fullPubdata);
+        outputHash = keccak256(abi.encodePacked(stateDiffHash, fullPubdataHash));
+    }
+}


### PR DESCRIPTION
# What ❔
This PR adds contracts for EigenDA M1
Replaces old [PR](https://github.com/matter-labs/era-contracts/pull/1405) due to change in branch destination
## `EigenDAL1DAValidator`
 
It receives the inclusion data, with the following format

```rust
struct EigenDAInclusionData {
    bytes seal;
    bytes32 imageId;
    bytes32 journalDigest;
    bytes32 eigenDAHash;
}
```

It uses a risc zero verifier to verify that the proof generated in the sidecar is correct.
It also compares the hash calculated in the sidecar against the one passed through `L2->L1 Logs`

## `EigenDAL2DAValidator`

It calculates the `fullPubdataHash` that will be sent through `L2->L1 Logs`

Related to: https://github.com/matter-labs/zksync-era/pull/4232
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
