### PR TITLE
fix: return result from createEVM flow

### DIFF
--- a/system-contracts/contracts/DefaultAccountNoSecurity.sol
+++ b/system-contracts/contracts/DefaultAccountNoSecurity.sol
@@ -171,13 +171,12 @@ contract DefaultAccountNoSecurity is IAccount {
             if (_transaction.txType != EIP_712_TX_TYPE && _transaction.txType != L1_TO_L2_TX_TYPE) {
                 if (_transaction.reserved[1] == 1) {
                     // Note, that createEVM can only be called with "isSystem" flag.
-                    SystemContractsCaller.systemCallWithPropagatedRevert(
+                    return SystemContractsCaller.systemCallWithPropagatedRevert(
                         gas,
                         address(DEPLOYER_SYSTEM_CONTRACT),
                         value,
                         abi.encodeCall(DEPLOYER_SYSTEM_CONTRACT.createEVM, (data))
                     );
-                    return bytes("");
                 }
             }
         }


### PR DESCRIPTION
## What ❔

Return result from createEVM flow fort `DefaultAccountNoSecurity`.

## Why ❔

The function expects a return value unlike in `DefaultAccount`, which is available to us.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
