### PR TITLE
fix: createEVM call for DefaultAccountNoSecurity

### DIFF
--- a/system-contracts/contracts/DefaultAccountNoSecurity.sol
+++ b/system-contracts/contracts/DefaultAccountNoSecurity.sol
@@ -153,6 +153,20 @@ contract DefaultAccountNoSecurity is IAccount {
         bytes calldata data = _transaction.data;
         uint32 gas = Utils.safeCastToU32(gasleft());
 
+        if (to == address(0)) {
+            if (_transaction.txType != EIP_712_TX_TYPE && _transaction.txType != L1_TO_L2_TX_TYPE) {
+                if (_transaction.reserved[1] == 1) {
+                    // Note, that createEVM can only be called with "isSystem" flag.
+                    return SystemContractsCaller.systemCallWithPropagatedRevert(
+                        gas,
+                        address(DEPLOYER_SYSTEM_CONTRACT),
+                        value,
+                        abi.encodeCall(DEPLOYER_SYSTEM_CONTRACT.createEVM, (data))
+                    );
+                }
+            }
+        }
+
         // Note, that the deployment method from the deployer contract can only be called with a "systemCall" flag.
         bool isSystemCall;
         if (to == address(DEPLOYER_SYSTEM_CONTRACT) && data.length >= 4) {


### PR DESCRIPTION
## What ❔

Ports `createEVM` logic from `DefaultAccount::executeTransaction` to `DefaultAccountNoSecurity::executeTransaction`.

## Why ❔

EVM interpreter create would fail if using `DefaultAccountNoSecurity` due to the missing dispatch.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
