### PR TITLE
fix: Create contract artifacts and add them to releases

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -69,14 +69,14 @@ jobs:
           tar -czvf l2-contracts.tar.gz ./l2-contracts
           tar -czvf system-contracts.tar.gz ./system-contracts
 
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ steps.init.outputs.release_tag }}
-          fail_on_unmatched_files: true
-          target_commitish: ${{ inputs.commit }}
-          body: ""
-          files: |
-            l1-contracts.tar.gz
-            l2-contracts.tar.gz
-            system-contracts.tar.gz
+      #- name: Release
+      #  uses: softprops/action-gh-release@v1
+      #  with:
+      #    tag_name: ${{ steps.init.outputs.release_tag }}
+      #    fail_on_unmatched_files: true
+      #    target_commitish: ${{ inputs.commit }}
+      #    body: ""
+      #    files: |
+      #      l1-contracts.tar.gz
+      #      l2-contracts.tar.gz
+      #      system-contracts.tar.gz

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -3,15 +3,12 @@ name: Build and release(manual)
 on:
   workflow_dispatch:
     inputs:
+      # TODO: rename from commit to tag.
       commit:
         type: string
-        description: SHA commit for build
-        required: false
-      prefix:
-        type: string
-        description: Prefix for release name
-        required: false
-        default: manual
+        description: tag/branch/commit to build from
+        required: true
+
 
 permissions:
   contents: write
@@ -45,7 +42,6 @@ jobs:
         id: init
         run: |
           yarn
-          echo "release_tag=${{ inputs.prefix }}-${{ inputs.commit }}" >> $GITHUB_OUTPUT
 
       - name: Build l1 contracts
         working-directory: l1-contracts
@@ -69,14 +65,12 @@ jobs:
           tar -czvf l2-contracts.tar.gz ./l2-contracts
           tar -czvf system-contracts.tar.gz ./system-contracts
 
-      #- name: Release
-      #  uses: softprops/action-gh-release@v1
-      #  with:
-      #    tag_name: ${{ steps.init.outputs.release_tag }}
-      #    fail_on_unmatched_files: true
-      #    target_commitish: ${{ inputs.commit }}
-      #    body: ""
-      #    files: |
-      #      l1-contracts.tar.gz
-      #      l2-contracts.tar.gz
-      #      system-contracts.tar.gz
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ input.commit }}
+          fail_on_unmatched_files: true
+          files: |
+            l1-contracts.tar.gz
+            l2-contracts.tar.gz
+            system-contracts.tar.gz

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,4 +1,4 @@
-name: Build and release(manual)
+name: Build and release(manual & tags)
 
 on:
   workflow_dispatch:
@@ -7,6 +7,10 @@ on:
         type: string
         description: tag to build from
         required: true
+  create:
+    tags:
+      - "v*"      # for main releases
+      - "zkos*"   # for zk releases
 
 
 permissions:
@@ -17,10 +21,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+      - name: Resolve tag
+        id: vars
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "TAG=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            # For push/create on a tag, github.ref looks like 'refs/tags/<tag>'
+            echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          fi
+          echo "Resolved TAG=${{ steps.vars.outputs.TAG }}"
+
       - name: Checkout the repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ steps.vars.outputs.TAG }}
           submodules: recursive
 
       - name: Install foundry-zksync
@@ -67,7 +83,7 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ inputs.tag }}
+          tag_name: ${{ steps.vars.outputs.TAG }}
           fail_on_unmatched_files: true
           files: |
             l1-contracts.tar.gz

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -3,10 +3,9 @@ name: Build and release(manual)
 on:
   workflow_dispatch:
     inputs:
-      # TODO: rename from commit to tag.
-      commit:
+      tag:
         type: string
-        description: tag/branch/commit to build from
+        description: tag to build from
         required: true
 
 
@@ -21,7 +20,7 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.commit }}
+          ref: ${{ inputs.tag }}
           submodules: recursive
 
       - name: Install foundry-zksync
@@ -68,7 +67,7 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ inputs.commit }}
+          tag_name: ${{ inputs.tag }}
           fail_on_unmatched_files: true
           files: |
             l1-contracts.tar.gz

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -9,9 +9,8 @@ on:
         required: true
   create:
     tags:
-      - "v*"      # for main releases
-      - "zkos*"   # for zk releases
-
+      - "v*" # for main releases
+      - "zkos*" # for zk releases
 
 permissions:
   contents: write
@@ -21,7 +20,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
       - name: Resolve tag
         id: vars
         run: |

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ input.commit }}
+          tag_name: ${{ inputs.commit }}
           fail_on_unmatched_files: true
           files: |
             l1-contracts.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ l1-contracts/test/foundry/l1/integration/deploy-scripts/script-config/config-dep
 l1-contracts/test/foundry/integration/deploy-scripts/script-out/*
 l1-contracts/test/foundry/l1/integration/upgrade-envs/script-out/*.toml
 l1-contracts/zkout/*
+.lycheecache

--- a/_typos.toml
+++ b/_typos.toml
@@ -16,6 +16,8 @@ extend-exclude = [
     "*.json",
     "*.lock",
     ".git/",
+    # Typo inside (unaccessible vs inaccessible) fix before v30.
+    "/system-contracts/contracts/abstract/SystemContractBase.sol",
     "SECURITY.md"
 ]
 

--- a/docs/evm_emulation/technical_overview.md
+++ b/docs/evm_emulation/technical_overview.md
@@ -44,7 +44,7 @@ Additionally EVM contracts can be deployed from EraVM environment using **system
 - `createEVM` - `CREATE`-like behavior
 - `create2EVM` - `CREATE2`-like behavior
 
-They use the same address derivation schemes as corresponding EVM opcodes. To derive the deployed contract’s address for EOAs we use the main nonce for this operation, while for contracts we use their deployment nonce. You can read more about the two types of nonces in the [NonceHolder system contract’s documentation](https://docs.zksync.io/build/developer-reference/era-contracts/system-contracts#nonceholder).
+They use the same address derivation schemes as corresponding EVM opcodes. To derive the deployed contract’s address for EOAs we use the main nonce for this operation, while for contracts we use their deployment nonce. You can read more about the two types of nonces in the [NonceHolder system contract’s documentation](https://docs.zksync.io/zksync-protocol/contracts/system-contracts#nonceholder).
 
 ❗ Note, that these two functions are not used (and can’t be used!) from the EVM environment. EVM smart contracts can’t perform **system** calls. EVM opcodes `CREATE` and `CREATE2` should be used instead.
 


### PR DESCRIPTION
## What ❔

* compile contracts and add them to releases
* This will happen either manually, or on tag creation.

## Why ❔

* Allows zksync-era CI to run a little bit faster (as it doesn't have to recompile everything - and this is its current bevaviour).