### PR TITLE
fix: Fix a nasty typo in l2-contracts CI

### DIFF
--- a/.github/workflows/l2-contracts-ci.yaml
+++ b/.github/workflows/l2-contracts-ci.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: yarn
 
-    # In the future, we should simply take the artifacts that are built by l1-contracts.
+      # In the future, we should simply take the artifacts that are built by l1-contracts.
       - name: Build l1 contracts
         working-directory: l1-contracts
         run: |


### PR DESCRIPTION
## What ❔

* we were storing artifacts under a wrong name (l1 instead of l2), which might have caused sometimes the allcontract hashes CI to fail.
* Both L1 & L2 are building contracts (we should combine it into one flow in the future) - but they do it slightly different. This resulted in L2 artifacts sometimes overwriting l1 artifacts.
