### PR TITLE
initial impl of system proxies

### DIFF
--- a/l1-contracts/contracts/common/L1ContractErrors.sol
+++ b/l1-contracts/contracts/common/L1ContractErrors.sol
@@ -376,6 +376,14 @@ error ZeroChainId();
 error ZeroGasPriceL1TxZKSyncOS();
 // 0x601b6882
 error ZKChainLimitReached();
+// 
+error ConstructorsNotSupported();
+
+error SystemContractProxyInitialized();
+
+error ZKSyncOSNotForceDeployForExistingContract(address);
+
+error UnsupportedUpgradeType();
 
 enum SharedBridgeKey {
     PostUpgradeFirstBatch,

--- a/l1-contracts/contracts/common/l2-helpers/L2ContractAddresses.sol
+++ b/l1-contracts/contracts/common/l2-helpers/L2ContractAddresses.sol
@@ -97,3 +97,6 @@ address constant L2_CHAIN_ASSET_HANDLER_ADDR = address(USER_CONTRACTS_OFFSET + 0
 /// @dev Besides separation of concerns, we need it as a separate contract to ensure that L2NativeTokenVaultZKOS
 /// does not have to include BridgedStandardERC20 and UpgradeableBeacon and so can fit into the code size limit.
 address constant L2_NTV_BEACON_DEPLOYER_ADDR = address(USER_CONTRACTS_OFFSET + 0x0b);
+
+// TODO: this address will collide with the other new draft-v30 addresses, need to select a different one.
+address constant L2_SYSTEM_CONTRACT_PROXY_ADMIN_ADDR = address(USER_CONTRACTS_OFFSET + 0x0c);

--- a/l1-contracts/contracts/l2-upgrades/ISystemContractProxy.sol
+++ b/l1-contracts/contracts/l2-upgrades/ISystemContractProxy.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.28;
+
+interface ISystemContractProxy {
+    /// @notice Force initializes the admin of the proxy.
+    /// @dev Note, that since constructors are not supported, the
+    /// initially stored value for the admin is zero and L2_COMPLEX_UPGRADER_ADDR is allowed
+    /// to update the admin to the real admin.
+    /// Once it's changed, it will return the stored admin. The TransparentUpgradeableProxy
+    /// ensures that the stored admin can never be set to zero address (without a buggy implementation).
+    function forceInitAdmin(address _newAdmin) external;
+}

--- a/l1-contracts/contracts/l2-upgrades/L2ComplexUpgrader.sol
+++ b/l1-contracts/contracts/l2-upgrades/L2ComplexUpgrader.sol
@@ -3,7 +3,7 @@
 pragma solidity 0.8.28;
 
 import {IL2ContractDeployer} from "../common/interfaces/IL2ContractDeployer.sol";
-import {L2_DEPLOYER_SYSTEM_CONTRACT_ADDR, L2_FORCE_DEPLOYER_ADDR} from "../common/l2-helpers/L2ContractAddresses.sol";
+import {L2_DEPLOYER_SYSTEM_CONTRACT_ADDR, L2_FORCE_DEPLOYER_ADDR, L2_COMPLEX_UPGRADER_ADDR} from "../common/l2-helpers/L2ContractAddresses.sol";
 import {AddressHasNoCode, Unauthorized} from "../common/L1ContractErrors.sol";
 
 import {IComplexUpgrader} from "../state-transition/l2-deps/IComplexUpgrader.sol";
@@ -19,9 +19,8 @@ import {L2GenesisForceDeploymentsHelper} from "./L2GenesisForceDeploymentsHelper
 contract L2ComplexUpgrader is IComplexUpgrader {
     /// @notice Ensures that only the `FORCE_DEPLOYER` can call the function.
     /// @dev Note that it is vital to put this modifier at the start of *each* function,
-    /// since even temporary anauthorized access can be dangerous.
+    /// since even temporary unauthorized access can be dangerous.
     modifier onlyForceDeployer() {
-        // Note, that it is not
         if (msg.sender != L2_FORCE_DEPLOYER_ADDR) {
             revert Unauthorized(msg.sender);
         }
@@ -55,14 +54,14 @@ contract L2ComplexUpgrader is IComplexUpgrader {
     /// @param _delegateTo the address of the contract to which the calls will be delegated
     /// @param _calldata the calldata to be delegate called in the `_delegateTo` contract
     function forceDeployAndUpgradeUniversal(
-        UniversalForceDeploymentInfo[] calldata _forceDeployments,
+        UniversalContractUpgradeInfo[] calldata _forceDeployments,
         address _delegateTo,
         bytes calldata _calldata
     ) external payable onlyForceDeployer {
         // solhint-disable-next-line gas-length-in-loops
         for (uint256 i = 0; i < _forceDeployments.length; ++i) {
-            L2GenesisForceDeploymentsHelper.forceDeployOnAddress(
-                _forceDeployments[i].isZKsyncOS,
+            L2GenesisForceDeploymentsHelper.conductContractUpgrade(
+                _forceDeployments[i].upgradeType,
                 _forceDeployments[i].deployedBytecodeInfo,
                 _forceDeployments[i].newAddress
             );

--- a/l1-contracts/contracts/l2-upgrades/L2GenesisForceDeploymentsHelper.sol
+++ b/l1-contracts/contracts/l2-upgrades/L2GenesisForceDeploymentsHelper.sol
@@ -2,20 +2,20 @@
 
 pragma solidity 0.8.28;
 
-import {L2_ASSET_ROUTER_ADDR, L2_BRIDGEHUB_ADDR, L2_CHAIN_ASSET_HANDLER_ADDR, L2_DEPLOYER_SYSTEM_CONTRACT_ADDR, L2_MESSAGE_ROOT_ADDR, L2_NATIVE_TOKEN_VAULT_ADDR, L2_NTV_BEACON_DEPLOYER_ADDR, L2_WRAPPED_BASE_TOKEN_IMPL_ADDR} from "../common/l2-helpers/L2ContractAddresses.sol";
+import {L2_ASSET_ROUTER_ADDR, L2_BRIDGEHUB_ADDR, L2_CHAIN_ASSET_HANDLER_ADDR, L2_DEPLOYER_SYSTEM_CONTRACT_ADDR, L2_MESSAGE_ROOT_ADDR, L2_NATIVE_TOKEN_VAULT_ADDR, L2_NTV_BEACON_DEPLOYER_ADDR, L2_WRAPPED_BASE_TOKEN_IMPL_ADDR, L2_SYSTEM_CONTRACT_PROXY_ADMIN_ADDR} from "../common/l2-helpers/L2ContractAddresses.sol";
 import {IL2ContractDeployer} from "../common/interfaces/IL2ContractDeployer.sol";
 import {FixedForceDeploymentsData, ZKChainSpecificForceDeploymentsData} from "../state-transition/l2-deps/IL2GenesisUpgrade.sol";
 import {IL2WrappedBaseToken} from "../bridge/interfaces/IL2WrappedBaseToken.sol";
-
+import {SystemContractProxy} from "./SystemContractProxy.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts-v4/proxy/transparent/TransparentUpgradeableProxy.sol";
-
+import {SystemContractProxyAdmin} from "./SystemContractProxyAdmin.sol";
 import {IZKOSContractDeployer} from "./IZKOSContractDeployer.sol";
 import {L2NativeTokenVault} from "../bridge/ntv/L2NativeTokenVault.sol";
 import {L2MessageRoot} from "../bridgehub/L2MessageRoot.sol";
 import {L2Bridgehub} from "../bridgehub/L2Bridgehub.sol";
 import {L2AssetRouter} from "../bridge/asset-router/L2AssetRouter.sol";
 import {L2ChainAssetHandler} from "../bridgehub/L2ChainAssetHandler.sol";
-import {DeployFailed} from "../common/L1ContractErrors.sol";
+import {DeployFailed, UnsupportedUpgradeType, ZKSyncOSNotForceDeployForExistingContract} from "../common/L1ContractErrors.sol";
 
 import {L2NativeTokenVaultZKOS} from "../bridge/ntv/L2NativeTokenVaultZKOS.sol";
 
@@ -23,6 +23,9 @@ import {ICTMDeploymentTracker} from "../bridgehub/ICTMDeploymentTracker.sol";
 import {IMessageRoot} from "../bridgehub/IMessageRoot.sol";
 
 import {UpgradeableBeaconDeployer} from "../bridge/ntv/UpgradeableBeaconDeployer.sol";
+import {ISystemContractProxy} from "./ISystemContractProxy.sol";
+import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts-v4/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {IComplexUpgrader} from "../state-transition/l2-deps/IComplexUpgrader.sol";
 
 /// @title L2GenesisForceDeploymentsHelper
 /// @author Matter Labs
@@ -44,7 +47,7 @@ library L2GenesisForceDeploymentsHelper {
         IL2ContractDeployer(L2_DEPLOYER_SYSTEM_CONTRACT_ADDR).forceDeployOnAddresses(forceDeployments);
     }
 
-    function forceDeployZKsyncOS(bytes memory _bytecodeInfo, address _newAddress) internal {
+    function unsafeForceDeployZKSyncOS(bytes memory _bytecodeInfo, address _newAddress) internal {
         (bytes32 bytecodeHash, uint32 bytecodeLength, bytes32 observableBytecodeHash) = abi.decode(
             _bytecodeInfo,
             (bytes32, uint32, bytes32)
@@ -62,15 +65,47 @@ library L2GenesisForceDeploymentsHelper {
         }
     }
 
+    function forceDeployOnAddressZKSyncOS(bytes memory _bytecodeInfo, address _newAddress) internal {
+        require(_newAddress.code.length == 0, ZKSyncOSNotForceDeployForExistingContract(_newAddress));
+        unsafeForceDeployZKSyncOS(_bytecodeInfo, _newAddress);
+    }
+
+    function updateZKSyncOSContract(bytes memory _bytecodeInfo, address _newAddress) internal {
+        (bytes memory bytecodeInfo, bytes memory bytecodeInfoSystemProxy) = abi.decode(
+            (_bytecodeInfo),
+            (bytes, bytes)
+        );
+
+        // The address to force deploy the implementation to.
+        address implAddress = address(uint160(uint256(keccak256(bytecodeInfo))));
+        forceDeployOnAddressZKSyncOS(bytecodeInfo, implAddress);
+
+        // If the address does not have any bytecode, we expect that it is a proxy
+        if (_newAddress.code.length == 0) {
+            forceDeployOnAddressZKSyncOS(bytecodeInfoSystemProxy, _newAddress);
+            ISystemContractProxy(_newAddress).forceInitAdmin(L2_SYSTEM_CONTRACT_PROXY_ADMIN_ADDR);
+        }
+
+        // Now we need to update the implementation address in the proxy.
+        SystemContractProxyAdmin(L2_SYSTEM_CONTRACT_PROXY_ADMIN_ADDR).upgrade(
+            ITransparentUpgradeableProxy(_newAddress),
+            implAddress
+        );
+    }
+
     /// @notice Unified function to force deploy contracts based on whether it's ZKSyncOS or Era.
-    /// @param _isZKsyncOS Whether the deployment is for ZKSyncOS or Era.
+    /// @param _upgradeType The upgrade type to use.
     /// @param _bytecodeInfo The bytecode information for deployment.
     /// @param _newAddress The address where the contract should be deployed.
-    function forceDeployOnAddress(bool _isZKsyncOS, bytes memory _bytecodeInfo, address _newAddress) internal {
-        if (_isZKsyncOS) {
-            forceDeployZKsyncOS(_bytecodeInfo, _newAddress);
-        } else {
+    function conductContractUpgrade(IComplexUpgrader.ContractUpgradeType _upgradeType, bytes memory _bytecodeInfo, address _newAddress) internal {
+        if (_upgradeType == IComplexUpgrader.ContractUpgradeType.ZKsyncOSUnsafeForceDeployment) {
+            unsafeForceDeployZKSyncOS(_bytecodeInfo, _newAddress);
+        } else if (_upgradeType == IComplexUpgrader.ContractUpgradeType.ZKsyncOSSystemProxyUpgrade) {
+            updateZKSyncOSContract(_bytecodeInfo, _newAddress);
+        } else if (_upgradeType == IComplexUpgrader.ContractUpgradeType.EraForceDeployment) {
             forceDeployEra(_bytecodeInfo, _newAddress);
+        } else {
+            revert UnsupportedUpgradeType();
         }
     }
 
@@ -97,8 +132,21 @@ library L2GenesisForceDeploymentsHelper {
             (ZKChainSpecificForceDeploymentsData)
         );
 
-        forceDeployOnAddress(
-            _isZKsyncOS,
+        IComplexUpgrader.ContractUpgradeType expectedUpgradeType = _isZKsyncOS
+            ? IComplexUpgrader.ContractUpgradeType.ZKsyncOSSystemProxyUpgrade
+            : IComplexUpgrader.ContractUpgradeType.EraForceDeployment;
+
+        // For Era chains, the SystemContractProxyAdmin is never used during deployment, this line is just to 
+        // ensure consistency.
+        // For ZKSyncOS chains, we expect that both the contract and the owner has been populated at the time of the genesis.
+        // These are not predeployed only for legacy chains. For them, special logic (not covered here) would be used to ensure
+        // that they have this contract is predeployed and the owner is set correctly.
+        if (SystemContractProxyAdmin(L2_SYSTEM_CONTRACT_PROXY_ADMIN_ADDR).owner() != address(this)) {
+            SystemContractProxyAdmin(L2_SYSTEM_CONTRACT_PROXY_ADMIN_ADDR).forceSetOwner(address(this));
+        }
+
+        conductContractUpgrade(
+            expectedUpgradeType,
             fixedForceDeploymentsData.messageRootBytecodeInfo,
             address(L2_MESSAGE_ROOT_ADDR)
         );
@@ -108,7 +156,7 @@ library L2GenesisForceDeploymentsHelper {
             L2MessageRoot(L2_MESSAGE_ROOT_ADDR).initL2(fixedForceDeploymentsData.l1ChainId);
         }
 
-        forceDeployOnAddress(_isZKsyncOS, fixedForceDeploymentsData.bridgehubBytecodeInfo, address(L2_BRIDGEHUB_ADDR));
+        conductContractUpgrade(expectedUpgradeType, fixedForceDeploymentsData.bridgehubBytecodeInfo, address(L2_BRIDGEHUB_ADDR));
         if (_isGenesisUpgrade) {
             L2Bridgehub(L2_BRIDGEHUB_ADDR).initL2(
                 fixedForceDeploymentsData.l1ChainId,
@@ -128,8 +176,8 @@ library L2GenesisForceDeploymentsHelper {
             ? address(0)
             : L2AssetRouter(L2_ASSET_ROUTER_ADDR).L2_LEGACY_SHARED_BRIDGE();
 
-        forceDeployOnAddress(
-            _isZKsyncOS,
+        conductContractUpgrade(
+            expectedUpgradeType,
             fixedForceDeploymentsData.l2AssetRouterBytecodeInfo,
             address(L2_ASSET_ROUTER_ADDR)
         );
@@ -172,7 +220,7 @@ library L2GenesisForceDeploymentsHelper {
         });
 
         // Now initializing the upgradeable token beacon
-        forceDeployOnAddress(_isZKsyncOS, fixedForceDeploymentsData.l2NtvBytecodeInfo, L2_NATIVE_TOKEN_VAULT_ADDR);
+        conductContractUpgrade(expectedUpgradeType, fixedForceDeploymentsData.l2NtvBytecodeInfo, L2_NATIVE_TOKEN_VAULT_ADDR);
 
         if (_isGenesisUpgrade) {
             address deployedTokenBeacon;
@@ -181,8 +229,8 @@ library L2GenesisForceDeploymentsHelper {
             if (fixedForceDeploymentsData.dangerousTestOnlyForcedBeacon == address(0)) {
                 // We need to deploy the beacon, we will use a separate contract for that to save
                 // up on size of this contract.
-                forceDeployOnAddress(
-                    _isZKsyncOS,
+                conductContractUpgrade(
+                    expectedUpgradeType,
                     fixedForceDeploymentsData.beaconDeployerInfo,
                     L2_NTV_BEACON_DEPLOYER_ADDR
                 );
@@ -215,8 +263,8 @@ library L2GenesisForceDeploymentsHelper {
             );
         }
 
-        forceDeployOnAddress(
-            _isZKsyncOS,
+        conductContractUpgrade(
+            expectedUpgradeType,
             fixedForceDeploymentsData.chainAssetHandlerBytecodeInfo,
             address(L2_CHAIN_ASSET_HANDLER_ADDR)
         );

--- a/l1-contracts/contracts/l2-upgrades/SystemContractProxy.sol
+++ b/l1-contracts/contracts/l2-upgrades/SystemContractProxy.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.28;
+
+import {TransparentUpgradeableProxy, ITransparentUpgradeableProxy} from "@openzeppelin/contracts-v4/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts-v4/proxy/ERC1967/ERC1967Proxy.sol";
+import {Proxy} from "@openzeppelin/contracts-v4/proxy/Proxy.sol";
+import {L2_COMPLEX_UPGRADER_ADDR} from "../common/l2-helpers/L2ContractAddresses.sol";
+import {ConstructorsNotSupported, NotAllowed, SystemContractProxyInitialized} from "../common/L1ContractErrors.sol";
+import {ISystemContractProxy} from "./ISystemContractProxy.sol";
+
+/// @notice Proxy contract for system contracts on L2.
+/// Note, that constructors are not supported during force deployments, so the first 
+/// thing that should happen after the contract is spawned is the initialization of the admin.
+contract SystemContractProxy is TransparentUpgradeableProxy {
+    /// @dev The constructor is never expected to be actually activated.
+    constructor() TransparentUpgradeableProxy(address(0), address(0), "") {
+        revert ConstructorsNotSupported();
+    }
+    
+    /// @notice Force initializes the admin of the proxy.
+    /// @dev You can read more about the logic in the doc-comments for the interface.
+    /// The contract does not inherit the interface for the reasons of implementing the 
+    /// transparent proxy pattern correctly.
+    function _dispatchForceInitAdmin() internal {
+        (address newAdmin) = abi.decode(msg.data[4:], (address));
+        _changeAdmin(newAdmin);
+    }
+
+    /// @notice For gas savings, we override the _fallback function to avoid the extra
+    /// storage read of the admin slot, since we know that the admin will never call the implementation of the proxy.
+    function _fallback() internal override {
+        bytes4 selector = msg.sig;
+
+        if(selector == ITransparentUpgradeableProxy.upgradeTo.selector ||
+           selector == ITransparentUpgradeableProxy.upgradeToAndCall.selector ||
+           selector == ITransparentUpgradeableProxy.changeAdmin.selector ||
+           selector == ITransparentUpgradeableProxy.admin.selector ||
+           selector == ITransparentUpgradeableProxy.implementation.selector) {
+            super._fallback();
+        } else if (selector == ISystemContractProxy.forceInitAdmin.selector) {
+            if (msg.sender != L2_COMPLEX_UPGRADER_ADDR) {
+                Proxy._fallback();
+                // The `Proxy._fallback()` will delegate the call to the implementation,
+                // and return the call result, so we don't need to do anything else here.
+            }
+
+            // This functionality is only allowed if the admin is still uninitialized.
+            // It is needed to initialize the admin after force deployments.
+            // Once initialized to a non-zero, non-upgrader address, the admin can never be changed to zero address again
+            // due to how the TransparentUpgradeableProxy is implemented.
+            require(_getAdmin() == address(0), SystemContractProxyInitialized());
+            // Call the internal function to force initialize the admin.
+            _dispatchForceInitAdmin();
+        } else {
+            // Directly delegate to implementation without admin check.
+            Proxy._fallback();
+        }
+    }
+}

--- a/l1-contracts/contracts/l2-upgrades/SystemContractProxyAdmin.sol
+++ b/l1-contracts/contracts/l2-upgrades/SystemContractProxyAdmin.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.28;
+
+import {ProxyAdmin} from "@openzeppelin/contracts-v4/proxy/transparent/ProxyAdmin.sol";
+import {ConstructorsNotSupported, Unauthorized} from "../common/L1ContractErrors.sol";
+import {L2_COMPLEX_UPGRADER_ADDR} from "../common/l2-helpers/L2ContractAddresses.sol";
+
+contract SystemContractProxyAdmin is ProxyAdmin {
+    modifier onlyUpgrader() {
+        if (msg.sender != L2_COMPLEX_UPGRADER_ADDR) {
+            revert Unauthorized(msg.sender);
+        }
+        _;
+    }
+
+    /// @notice The constructor is never expected to be actually activated.
+    constructor() {
+        revert ConstructorsNotSupported();
+    }
+
+    /// @notice Initializer function to set the owner of the ProxyAdmin.
+    function forceSetOwner(address _owner) external onlyUpgrader {
+        _transferOwnership(_owner);
+    }
+}

--- a/l1-contracts/contracts/state-transition/l2-deps/IComplexUpgrader.sol
+++ b/l1-contracts/contracts/state-transition/l2-deps/IComplexUpgrader.sol
@@ -6,18 +6,34 @@ import {IL2ContractDeployer} from "../../common/interfaces/IL2ContractDeployer.s
 /// @author Matter Labs
 /// @custom:security-contact security@matterlabs.dev
 interface IComplexUpgrader {
+    /// @notice The type of contract upgrade.
+    /// @param EraForceDeployment the force deployment for Era.
+    /// @param ZKsyncOSSystemProxyUpgrade the upgrade of the system proxy on ZKsyncOS. It will involve force
+    /// deployment of both the implementation on a random address and upgrading the implementation. In case the proxy has not been initialized yet, 
+    /// it will also involve force deploying the proxy and initializing the admin.
+    /// @param ZKsyncOSUnsafeForceDeployment the force deployment for ZKsyncOS. This should be used only 
+    /// for exceptional cases, when the deployer is certain that the contract does not contain any address
+    /// on top of it or overriding the existing bytecode is expected.
+    /// The typical use case for an unsafe deployment is to deploy the implementation of the upgrade that the ComplexUpgrader should
+    /// delegatecall to. It was also used to migrate the non-proxy system contracts to proxies during the testnet upgrade. 
+    enum ContractUpgradeType {
+        EraForceDeployment,
+        ZKsyncOSSystemProxyUpgrade,
+        ZKsyncOSUnsafeForceDeployment
+    }
+    
     /// @notice Information about the force deployment.
     /// @dev This struct is used to store the information about the force deployment.
     /// @dev For ZKsyncOS, the `deployedBytecodeInfo` is the abi-encoded tuple of `(bytes32, uint32, bytes32)`,
     /// for Era, it is the abi-encoded `bytes32`.
     /// @dev Note, that ZKsyncOS does not support constructors, so the `deployedBytecodeInfo` should only describe the
     /// deployed bytecode.
-    /// @param isZKsyncOS whether the deployment is for ZKsyncOS or Era.
+    /// @param upgradeType the type of the upgrade.
     /// @param deployedBytecodeInfo the bytecode information for deployment.
     /// @param newAddress the address where the contract should be deployed.
     // solhint-disable-next-line gas-struct-packing
-    struct UniversalForceDeploymentInfo {
-        bool isZKsyncOS;
+    struct UniversalContractUpgradeInfo {
+        ContractUpgradeType upgradeType;
         bytes deployedBytecodeInfo;
         address newAddress;
     }

--- a/l1-contracts/test/foundry/l1/unit/concrete/SystemContractProxy/SystemContractProxy.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/SystemContractProxy/SystemContractProxy.t.sol
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import "forge-std/Test.sol";
+
+// ⬇️ Adjust these import paths to your repo layout as needed.
+import { SystemContractProxy } from "contracts/l2-upgrades/SystemContractProxy.sol";
+import { ISystemContractProxy } from "contracts/l2-upgrades/ISystemContractProxy.sol";
+import { SystemContractProxyAdmin } from "contracts/l2-upgrades/SystemContractProxyAdmin.sol";
+import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts-v4/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+// The upgrader constant used by SystemContractProxy's special path.
+// (Re-use the same constant the proxy uses so tests align with prod logic.)
+import { L2_COMPLEX_UPGRADER_ADDR } from "contracts/common/l2-helpers/L2ContractAddresses.sol";
+
+// Custom errors (for revert expectation)
+import { SystemContractProxyInitialized } from "contracts/common/L1ContractErrors.sol";
+
+contract MockImplementation {
+    event Delegated(bytes4 indexed sig, address indexed arg);
+
+    // Helpers to verify delegation of admin() / implementation() calls by non-admins.
+    function admin() external pure returns (address) {
+        return address(0x00000000000000000000000000000000000A11cE);
+    }
+
+    function implementation() external pure returns (address) {
+        return address(0x000000000000000000000000000000000000bEEF);
+    }
+
+    // Admin-method-shaped functions so that when non-admin calls hit the proxy,
+    // they delegate here (not actually performing admin actions).
+    function changeAdmin(address newAdmin) external {
+        emit Delegated(msg.sig, newAdmin);
+    }
+
+    function upgradeTo(address newImpl) external {
+        emit Delegated(msg.sig, newImpl);
+    }
+
+    function upgradeToAndCall(address newImpl, bytes calldata /*data*/ ) external {
+        emit Delegated(msg.sig, newImpl);
+    }
+
+    // Same for the special forceInitAdmin selector — non-upgrader should delegate.
+    function forceInitAdmin(address who) external {
+        emit Delegated(msg.sig, who);
+    }
+
+    // A simple passthrough to show "normal" delegation also works.
+    function echo(uint256 x) external pure returns (uint256) {
+        return x + 1;
+    }
+}
+
+contract SystemContractProxyTest is Test {
+    // ERC1967 slots (from OpenZeppelin):
+    // bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1)
+    bytes32 internal constant _IMPLEMENTATION_SLOT =
+        0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    // bytes32(uint256(keccak256("eip1967.proxy.admin")) - 1)
+    bytes32 internal constant _ADMIN_SLOT =
+        0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
+
+    address internal owner;        // Owner of SystemContractProxyAdmin
+    address internal newAdmin;     // New proxy admin set later
+    address internal user;         // Non-admin user
+
+    address internal proxy;        // The etched SystemContractProxy
+    address internal proxyAdmin;   // The etched SystemContractProxyAdmin
+
+    MockImplementation internal impl1;
+    MockImplementation internal impl2;
+
+    function setUp() public {
+        owner = makeAddr("owner");
+        newAdmin = makeAddr("newAdmin");
+        user = makeAddr("user");
+
+        proxy = makeAddr("proxy");
+        proxyAdmin = makeAddr("proxyAdmin");
+
+        // 1) Etch the proxy + proxy admin runtime code (no constructors run)
+        vm.etch(proxy, type(SystemContractProxy).runtimeCode);
+        vm.etch(proxyAdmin, type(SystemContractProxyAdmin).runtimeCode);
+
+        // 2) Initialize the ProxyAdmin ownership (initializer pattern)
+        vm.prank(L2_COMPLEX_UPGRADER_ADDR);
+        SystemContractProxyAdmin(proxyAdmin).forceSetOwner(owner);
+        // Sanity: owner set
+        assertEq(SystemContractProxyAdmin(proxyAdmin).owner(), owner, "ProxyAdmin owner mismatch");
+
+        // 3) Force-initialize the proxy admin via the special path guarded by L2_COMPLEX_UPGRADER_ADDR
+        vm.prank(L2_COMPLEX_UPGRADER_ADDR);
+        ISystemContractProxy(proxy).forceInitAdmin(proxyAdmin);
+
+        // Sanity: proxy admin slot now set to proxyAdmin
+        assertEq(_readAdmin(proxy), proxyAdmin, "Proxy admin should be initialized to ProxyAdmin");
+
+        // 4) Deploy a first implementation normally (constructors allowed for non-proxy contracts)
+        impl1 = new MockImplementation();
+
+        // 5) Upgrade proxy to impl1 via ProxyAdmin.owner
+        vm.prank(owner);
+        SystemContractProxyAdmin(proxyAdmin).upgrade(ITransparentUpgradeableProxy(payable(proxy)), address(impl1));
+
+        assertEq(_readImplementation(proxy), address(impl1), "impl1 should be active");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    function _readImplementation(address p) internal view returns (address) {
+        return address(uint160(uint256(vm.load(p, _IMPLEMENTATION_SLOT))));
+    }
+
+    function _readAdmin(address p) internal view returns (address) {
+        return address(uint160(uint256(vm.load(p, _ADMIN_SLOT))));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Tests
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    function test_NonAdmin_AdminSelectorsAreDelegated() public {
+        // Non-admin calls should delegate admin() to the implementation (returning impl sentinel)
+        vm.prank(user);
+        address apparentAdmin = ITransparentUpgradeableProxy(payable(proxy)).admin();
+        assertEq(apparentAdmin, address(0x00000000000000000000000000000000000A11cE), "admin() should be delegated for non-admin callers");
+
+        // Non-admin calls should delegate implementation() to the implementation (returning impl sentinel)
+        vm.prank(user);
+        address apparentImpl = ITransparentUpgradeableProxy(payable(proxy)).implementation();
+        assertEq(apparentImpl, address(0x000000000000000000000000000000000000bEEF), "implementation() should be delegated for non-admin callers");
+    }
+
+    function test_NonAdmin_UpgradeAndChangeAdminSelectorsDelegate_NoStateChange() public {
+        // Record current impl
+        address beforeImpl = _readImplementation(proxy);
+
+        // Expect delegation events from the proxy address (delegatecall context)
+        vm.expectEmit(true, true, true, true, proxy);
+        emit MockImplementation.Delegated(ITransparentUpgradeableProxy.upgradeTo.selector, address(0x1234));
+
+        vm.prank(user);
+        ITransparentUpgradeableProxy(payable(proxy)).upgradeTo(address(0x1234));
+        // Should NOT have changed the implementation (since it was delegated to impl)
+        assertEq(_readImplementation(proxy), beforeImpl, "impl should not change when non-admin calls upgradeTo");
+
+        vm.expectEmit(true, true, true, true, proxy);
+        emit MockImplementation.Delegated(ITransparentUpgradeableProxy.changeAdmin.selector, address(0xDEAD));
+
+        vm.prank(user);
+        ITransparentUpgradeableProxy(payable(proxy)).changeAdmin(address(0xDEAD));
+        // Should NOT have changed the admin
+        assertEq(_readAdmin(proxy), proxyAdmin, "admin should not change when non-admin calls changeAdmin");
+    }
+
+    function test_ProxyAdminOwner_CanChangeProxyAdmin_And_NewAdminCanUpgrade() public {
+        // Change proxy admin from ProxyAdmin -> newAdmin using ProxyAdmin (as owner)
+        vm.prank(owner);
+        SystemContractProxyAdmin(proxyAdmin).changeProxyAdmin(ITransparentUpgradeableProxy(payable(proxy)), newAdmin);
+        assertEq(_readAdmin(proxy), newAdmin, "proxy admin should be changed to newAdmin");
+
+        // Try to upgrade again via the *old* ProxyAdmin (should now DELEGATE, not upgrade)
+        address beforeImpl = _readImplementation(proxy);
+        impl2 = new MockImplementation();
+
+        vm.prank(owner);
+        SystemContractProxyAdmin(proxyAdmin).upgrade(ITransparentUpgradeableProxy(payable(proxy)), address(impl2));
+
+        // Implementation must remain the same (old ProxyAdmin is no longer admin)
+        assertEq(_readImplementation(proxy), beforeImpl, "old ProxyAdmin should no longer be able to upgrade");
+
+        // Now the new admin (EOA) calls upgradeTo directly on the proxy: this should perform the real upgrade.
+        vm.prank(newAdmin);
+        ITransparentUpgradeableProxy(payable(proxy)).upgradeTo(address(impl2));
+        assertEq(_readImplementation(proxy), address(impl2), "newAdmin should successfully upgrade the proxy");
+    }
+
+    function test_ForceInitAdmin_Reverts_AfterInitialized() public {
+        // Admin already initialized in setUp(); calling again as the upgrader should revert.
+        vm.prank(L2_COMPLEX_UPGRADER_ADDR);
+        vm.expectRevert(abi.encodeWithSelector(SystemContractProxyInitialized.selector));
+        ISystemContractProxy(proxy).forceInitAdmin(makeAddr("irrelevant"));
+    }
+
+    function test_ForceInitAdmin_FromNonUpgrader_DelegatesToImplementation() public {
+        // Non-upgrader caller should delegate to implementation's forceInitAdmin
+        vm.expectEmit(true, true, true, true, proxy);
+        emit MockImplementation.Delegated(ISystemContractProxy.forceInitAdmin.selector, address(0xCAFE));
+
+        vm.prank(user);
+        ISystemContractProxy(proxy).forceInitAdmin(address(0xCAFE));
+    }
+
+    function test_NormalDelegation_FallbackCallsReachImplementation() public {
+        // Call an arbitrary non-admin function to ensure normal fallback delegation is intact.
+        (bool ok, bytes memory ret) = proxy.call(abi.encodeWithSignature("echo(uint256)", 41));
+        assertTrue(ok, "echo call via proxy should succeed");
+        uint256 result = abi.decode(ret, (uint256));
+        assertEq(result, 42, "echo should return x+1");
+    }
+
+    function test_AdminViewFns_ReturnRealValues_WhenCalledAsAdmin() public {
+        // When msg.sender == admin, admin() / implementation() should be served by the proxy itself.
+        address admin = _readAdmin(proxy);
+        vm.prank(admin);
+        address reportedAdmin = ITransparentUpgradeableProxy(payable(proxy)).admin();
+        assertEq(reportedAdmin, admin, "as admin, admin() should return real admin");
+
+        vm.prank(admin);
+        address reportedImpl = ITransparentUpgradeableProxy(payable(proxy)).implementation();
+        assertEq(reportedImpl, _readImplementation(proxy), "as admin, implementation() should return real implementation");
+    }
+}


### PR DESCRIPTION
## What ❔

For better compatibility with tooling that does not expect the contract's addresses to ever be force deployed the new version is proposed, where force deploy should only happen on top of an empty address. It is only to be used for zksync os chains, Era chains will continue upgrading as usual.

`SystemContractProxy` is a very similar to TUP, but to save gas for most calls by avoidiing reading the admin slot, it allows admin to reach implementation. Note, that when a new `SystemContractProxy` is force deployed, its storage is empty and so it also needs a special method to populate the chain admin.

The expected genesis state for a zksync os:
- L2ComplexUpgrader as an implementation of`SystemContractProxy.sol` (so 2 contracts in total). It already must have its admin initialized as `SystemContractProxyAdmin`.
- `SystemContractProxyAdmin` is a new predeployed contract that is tasked with managing the proxies. It must have its owner set up as the `L2ComplexUpgrader`.

The rest of the genesis is initialized via the standard process, where the rest of the contracts are deployed.

Testnets will be upgraded via a separate implementation of upgrade (not present here). It will involve deploying the implementations for the first time as well as initializing the `SystemContractProxyAdmin`

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
