### PR TITLE
chore(v30): make currentSettlementLayerChainId public

### DIFF
--- a/l1-contracts/contracts/bridge/asset-tracker/L2AssetTracker.sol
+++ b/l1-contracts/contracts/bridge/asset-tracker/L2AssetTracker.sol
@@ -88,7 +88,7 @@ contract L2AssetTracker is AssetTrackerBase, IL2AssetTracker {
 
     function _registerTokenOnL2(bytes32 _assetId) internal {
         /// If the chain is settling on Gateway, then withdrawals are not automatically allowed for new tokens.
-        if (L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT.getSettlementLayerChainId() == _l1ChainId()) {
+        if (L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT.currentSettlementLayerChainId() == _l1ChainId()) {
             assetMigrationNumber[block.chainid][_assetId] = L2_CHAIN_ASSET_HANDLER.migrationNumber(block.chainid);
         }
     }
@@ -162,7 +162,7 @@ contract L2AssetTracker is AssetTrackerBase, IL2AssetTracker {
         /// otherwise withdrawals might fail in the GWAssetTracker when the chain settles.
         require(
             savedAssetMigrationNumber == migrationNumber ||
-                L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT.getSettlementLayerChainId() == _l1ChainId(),
+                L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT.currentSettlementLayerChainId() == _l1ChainId(),
             TokenBalanceNotMigratedToGateway(_assetId, savedAssetMigrationNumber, migrationNumber)
         );
     }
@@ -273,7 +273,7 @@ contract L2AssetTracker is AssetTrackerBase, IL2AssetTracker {
     /// @dev This function is permissionless, it does not affect the state of the contract substantially, and can be called multiple times.
     function initiateL1ToGatewayMigrationOnL2(bytes32 _assetId) external {
         require(
-            L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT.getSettlementLayerChainId() != L1_CHAIN_ID,
+            L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT.currentSettlementLayerChainId() != L1_CHAIN_ID,
             OnlyGatewaySettlementLayer()
         );
         address tokenAddress = _tryGetTokenAddress(_assetId);

--- a/l1-contracts/contracts/common/interfaces/ISystemContext.sol
+++ b/l1-contracts/contracts/common/interfaces/ISystemContext.sol
@@ -41,6 +41,8 @@ interface ISystemContext {
 
     function baseFee() external view returns (uint256);
 
+    function currentSettlementLayerChainId() external view returns (uint256);
+
     function txNumberInBlock() external view returns (uint16);
 
     function getBlockHashEVM(uint256 _block) external view returns (bytes32);
@@ -60,6 +62,4 @@ interface ISystemContext {
     function getCurrentPubdataSpent() external view returns (uint256 currentPubdataSpent);
 
     function setChainId(uint256 _newChainId) external;
-
-    function getSettlementLayerChainId() external view returns (uint256);
 }

--- a/l1-contracts/contracts/interop/InteropCenter.sol
+++ b/l1-contracts/contracts/interop/InteropCenter.sol
@@ -293,7 +293,7 @@ contract InteropCenter is
         BundleAttributes memory _bundleAttributes,
         bytes[][] memory _originalCallAttributes
     ) internal returns (bytes32 bundleHash) {
-        require(L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT.getSettlementLayerChainId() != L1_CHAIN_ID, NotInGatewayMode());
+        require(L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT.currentSettlementLayerChainId() != L1_CHAIN_ID, NotInGatewayMode());
 
         // Form an InteropBundle.
         InteropBundle memory bundle = InteropBundle({

--- a/l1-contracts/contracts/interop/InteropHandler.sol
+++ b/l1-contracts/contracts/interop/InteropHandler.sol
@@ -331,7 +331,7 @@ contract InteropHandler is IInteropHandler, ReentrancyGuard {
         bundleStatus[_bundleHash] = BundleStatus.Verified;
 
         /// We send the fact of verification to L1 so that the GWAssetTracker can process the chainBalance changes.
-        require(L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT.getSettlementLayerChainId() != L1_CHAIN_ID, NotInGatewayMode());
+        require(L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT.currentSettlementLayerChainId() != L1_CHAIN_ID, NotInGatewayMode());
 
         // slither-disable-next-line reentrancy-no-eth,unused-return
         L2_TO_L1_MESSENGER_SYSTEM_CONTRACT.sendToL1(bytes.concat(this.verifyBundle.selector, _bundleHash));

--- a/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/_SharedL2ContractDeployer.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/_SharedL2ContractDeployer.sol
@@ -171,7 +171,7 @@ abstract contract SharedL2ContractDeployer is UtilsCallMockerTest, DeployIntegra
         );
         vm.mockCall(
             address(L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT),
-            abi.encodeWithSelector(L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT.getSettlementLayerChainId.selector),
+            abi.encodeWithSelector(L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT.currentSettlementLayerChainId.selector),
             abi.encode(block.chainid)
         );
         vm.prank(L2_BRIDGEHUB_ADDR);

--- a/l1-contracts/test/foundry/l1/integration/l2-tests-in-l1-context/_SharedL2ContractL1Deployer.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-in-l1-context/_SharedL2ContractL1Deployer.sol
@@ -32,7 +32,7 @@ contract SharedL2ContractL1Deployer is SharedL2ContractDeployer, DeployCTMIntegr
         L2UtilsBase.initSystemContracts(_args);
         vm.mockCall(
             L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT_ADDR,
-            abi.encodeWithSelector(ISystemContext.getSettlementLayerChainId.selector),
+            abi.encodeWithSelector(ISystemContext.currentSettlementLayerChainId.selector),
             abi.encode(9)
         );
     }

--- a/system-contracts/contracts/SystemContext.sol
+++ b/system-contracts/contracts/SystemContext.sol
@@ -6,7 +6,7 @@ import {ISystemContext} from "./interfaces/ISystemContext.sol";
 import {SystemContractBase} from "./abstract/SystemContractBase.sol";
 import {ISystemContextDeprecated} from "./interfaces/ISystemContextDeprecated.sol";
 import {SystemContractHelper} from "./libraries/SystemContractHelper.sol";
-import {BOOTLOADER_FORMAL_ADDRESS, COMPLEX_UPGRADER_CONTRACT, L2_ASSET_TRACKER_ADDRESS, L2_CHAIN_ASSET_HANDLER, L2_INTEROP_CENTER_ADDRESS, SystemLogKey} from "./Constants.sol";
+import {BOOTLOADER_FORMAL_ADDRESS, COMPLEX_UPGRADER_CONTRACT, L2_CHAIN_ASSET_HANDLER, SystemLogKey} from "./Constants.sol";
 import {CannotInitializeFirstVirtualBlock, CannotReuseL2BlockNumberFromPreviousBatch, CurrentBatchNumberMustBeGreaterThanZero, DeprecatedFunction, InconsistentNewBatchTimestamp, IncorrectL2BlockHash, IncorrectSameL2BlockPrevBlockHash, IncorrectSameL2BlockTimestamp, IncorrectVirtualBlockInsideMiniblock, InvalidNewL2BlockNumber, L2BlockAndBatchTimestampMismatch, L2BlockNumberZero, NoVirtualBlocks, NonMonotonicL2BlockTimestamp, PreviousL2BlockHashIsIncorrect, ProvidedBatchNumberIsNotCorrect, TimestampsShouldBeIncremental, UpgradeTransactionMustBeFirst} from "contracts/SystemContractErrors.sol";
 
 /**
@@ -83,16 +83,8 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, SystemContra
     /// @notice The information about the virtual blocks upgrade, which tracks when the migration to the L2 blocks has started and finished.
     VirtualBlockUpgradeInfo internal virtualBlockUpgradeInfo;
 
-    uint256 internal currentSettlementLayerChainId;
-
-    error OnlyL2AssetTrackerOrInteropCenter();
-
-    modifier onlyL2AssetTrackerOrInteropCenter() {
-        if (msg.sender != L2_ASSET_TRACKER_ADDRESS && msg.sender != L2_INTEROP_CENTER_ADDRESS) {
-            revert OnlyL2AssetTrackerOrInteropCenter();
-        }
-        _;
-    }
+    /// @notice The chainId of the settlement layer.
+    uint256 public currentSettlementLayerChainId;
 
     /// @notice Set the chainId origin.
     /// @param _newChainId The chainId
@@ -105,10 +97,6 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, SystemContra
             L2_CHAIN_ASSET_HANDLER.setSettlementLayerChainId(currentSettlementLayerChainId, _newSettlementLayerChainId);
             currentSettlementLayerChainId = _newSettlementLayerChainId;
         }
-    }
-
-    function getSettlementLayerChainId() external view onlyL2AssetTrackerOrInteropCenter returns (uint256) {
-        return currentSettlementLayerChainId;
     }
 
     /// @notice Number of current transaction in block.


### PR DESCRIPTION
# What ❔

Currently `getSettlementLayerChainId` is set as `internal`, and can only be read by the L2 asset tracker or interop center, the reasoning being to "prevent" users' contracts from reading this value. This adds unnecessary complexity, since if someone really wants to read this value, they can.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
