### PR TITLE
Use 5 as default execution version

### DIFF
--- a/l1-contracts/deploy-scripts/DeployCTM.s.sol
+++ b/l1-contracts/deploy-scripts/DeployCTM.s.sol
@@ -64,7 +64,7 @@ import {EraTestnetVerifier} from "contracts/state-transition/verifiers/EraTestne
 import {Utils} from "./Utils.sol";
 
 // TODO: pass this value from zkstack_cli
-uint32 constant DEFAULT_ZKSYNC_OS_VERIFIER_VERSION = 3;
+uint32 constant DEFAULT_ZKSYNC_OS_VERIFIER_VERSION = 5;
 
 contract DeployCTMScript is Script, DeployL1HelperScript {
     using stdToml for string;


### PR DESCRIPTION
# What ❔

Uses 5 as the default execution version for zksync os.

In the future this value will be provided by zkstack cli, but for now we just need to update the hardcoded value before the release

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
