### PR TITLE
chore: fix hex prefix in L2_COMPLEX_UPGRADER_IMPL_ADDR

### DIFF
--- a/tools/zksync-os-genesis-gen/src/main.rs
+++ b/tools/zksync-os-genesis-gen/src/main.rs
@@ -12,7 +12,7 @@ const L2_WRAPPED_BASE_TOKEN: Address = Address(FixedBytes::<20>(hex_literal::hex
 const SYSTEM_CONTRACT_PROXY_ADMIN: Address = Address(FixedBytes::<20>(hex_literal::hex!("000000000000000000000000000000000001000c")));
 // keccak256("L2_COMPLEX_UPGRADER_IMPL_ADDR") - 1.
 // We need it predeployed to make the genesis upgrade work at all.
-const L2_COMPLEX_UPGRADER_IMPL_ADDR: Address = Address(FixedBytes::<20>(hex_literal::hex!("0xd704e29df32c189b8613f79fcc043b2dc01d5f53")));
+const L2_COMPLEX_UPGRADER_IMPL_ADDR: Address = Address(FixedBytes::<20>(hex_literal::hex!("d704e29df32c189b8613f79fcc043b2dc01d5f53")));
 
 const SYSTEM_PROXY_ADMIN_OWNER_SLOT: B256 = B256::ZERO;
 const EIP1967_IMPLEMENTATION_SLOT: B256 = FixedBytes::<32>(hex_literal::hex!(


### PR DESCRIPTION
# What ❔

* [x] fix hex prefix in L2_COMPLEX_UPGRADER_IMPL_ADDR

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To fix build issues caused by the `0x` prefix:
```
error[E0080]: evaluation of constant value failed
  --> src/main.rs:15:73
   |
15 | ...s(FixedBytes::<20>(hex_literal::hex!("0xd704e29df32c189b8613f79fcc043b2dc01d5f53")));
   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: Encountered invalid ASCII character
```

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
