### PR TITLE
chore: add workspace section into zksync-os-genesis-gen

### DIFF
--- a/tools/verifier-gen/Cargo.toml
+++ b/tools/verifier-gen/Cargo.toml
@@ -15,4 +15,5 @@ handlebars = "4.4.0"
 sha3 = "0.10.8"
 hex = "0.4.3"
 
+# Use workspace to allow using the tool from other workspaces without conflicts
 [workspace]

--- a/tools/zksync-os-genesis-gen/Cargo.toml
+++ b/tools/zksync-os-genesis-gen/Cargo.toml
@@ -17,3 +17,6 @@ zk_os_basic_system = { package = "basic_system", git = "https://github.com/matte
 anyhow = "1"
 hex = "0.4"
 hex-literal = "1.0.0"
+
+# Use workspace to allow using the tool from other workspaces without conflicts
+[workspace]


### PR DESCRIPTION
# What ❔

* [x] Add workspace section into zksync-os-genesis-gen.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

When using this tool from another directory that might contains Rust workspace, it causes issues if this tool is not a workspace itself. There is no harm in adding the `[workspace]` to solve this and make this tool easier to use from any directory during the protocol upgrade.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
