### PR TITLE
perf: reduce CI invariant test depth from 10000 to 3000

### DIFF
--- a/l1-contracts/foundry.toml
+++ b/l1-contracts/foundry.toml
@@ -79,7 +79,7 @@ optimizer = false
 suppressed_warnings = ["txorigin"]
 [profile.invariant_tests_l1context_ci.invariant]
 runs = 10
-depth = 10000
+depth = 3000
 
 [profile.invariant_tests_l2context_ci]
 test = "test"


### PR DESCRIPTION
## Summary
- Reduced `invariant_tests_l1context_ci` depth from 10,000 to 3,000
- Cuts max handler calls from 100k (10 runs × 10k) to 30k (10 runs × 3k) per invariant test
- Still 3x the local development depth (1,000), providing thorough CI coverage

## Context

Investigation of slow integration tests across era-contracts identified the biggest offenders:

### era-contracts top offenders
| Test Suite | Root Cause |
|-----------|------------|
| **Invariant tests (CI)** | **10 runs × 10,000 depth = up to 100k handler calls** |
| `L1GatewayTests.t.sol` | 7 tests, each re-deploys full L1 ecosystem + 3 ZK chains + gateway |
| `BridgehubTests.t.sol` | Deploys 7 ZK chains + 10 user addresses in setUp() |
| L2 integration tests (zkfoundry) | ZK-EVM mode inherently slow; ~15 contract deploys in setUp() |
| system-contracts `.spec.ts` | 340+ tests against anvil-zksync, sequential execution |

### Additional recommendations (not in this PR)
1. **Use `vm.snapshot()`/`vm.revertTo()` in setUp** — Foundry re-runs setUp for every test function. L1GatewayTests (7 tests) re-deploys the entire L1 ecosystem 7 times. Snapshot after initial deploy and revert in each test
2. **Split large test contracts** — `BridgehubTests.t.sol` (30.6 KB) deploys 7 chains but most tests only need 1-2. Split into basic and multi-chain variants
3. **Lazy-deploy ZK chains** — deploy chains on-demand in tests that need them, not all upfront in setUp()
4. **Parallelize system-contracts TypeScript tests** — 340+ tests run sequentially; split across workers
5. **Reduce TOML file I/O overhead** — tests use `vm.setEnv`/`vm.writeToml`/`vm.readFile` extensively for config

## Test plan
- [ ] Run `yarn l1 test:invariant:l1-context` and verify invariant tests still pass
- [ ] Compare CI runtime before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)