### PR TITLE
fix: BASE_TOKEN_HOLDER behaviour in genesis

### DIFF
--- a/tools/zksync-os-genesis-gen/src/consts.rs
+++ b/tools/zksync-os-genesis-gen/src/consts.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{Address, FixedBytes, B256};
+use alloy::primitives::{Address, B256, FixedBytes};
 
 /// Represents the source of a contract's bytecode.
 #[derive(Clone, Copy)]
@@ -6,14 +6,11 @@ pub enum ContractSource {
     /// Load bytecode from a compiled contract artifact by name from l1-contracts.
     L1ContractName(&'static str),
     /// Load bytecode from a compiled contract artifact by name from da-contracts.
+    #[allow(dead_code)]
     DAContractName(&'static str),
     /// Use bytecode directly.
     Bytecode(&'static [u8]),
 }
-
-pub const BASE_TOKEN_HOLDER_ADDR: Address = Address(FixedBytes::<20>(hex_literal::hex!(
-    "0000000000000000000000000000000000010011"
-)));
 
 pub const L2_COMPLEX_UPGRADER_ADDR: Address = Address(FixedBytes::<20>(hex_literal::hex!(
     "000000000000000000000000000000000000800f"
@@ -86,13 +83,13 @@ pub const L2_DEPLOYER_SYSTEM_CONTRACT_ADDR: Address = Address(FixedBytes::<20>(h
     "0000000000000000000000000000000000008006"
 )));
 
-pub const L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR: Address = Address(FixedBytes::<20>(hex_literal::hex!(
-    "0000000000000000000000000000000000008008"
-)));
+pub const L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR: Address = Address(FixedBytes::<20>(
+    hex_literal::hex!("0000000000000000000000000000000000008008"),
+));
 
-pub const L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR: Address = Address(FixedBytes::<20>(hex_literal::hex!(
-    "000000000000000000000000000000000000800a"
-)));
+pub const L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR: Address = Address(FixedBytes::<20>(
+    hex_literal::hex!("000000000000000000000000000000000000800a"),
+));
 
 // keccak256("L2_COMPLEX_UPGRADER_IMPL_ADDR") - 1.
 // We need it predeployed to make the genesis upgrade work at all.
@@ -109,26 +106,86 @@ pub const EIP1967_ADMIN_SLOT: B256 = FixedBytes::<32>(hex_literal::hex!(
 ));
 
 pub const INITIAL_CONTRACTS: [(Address, ContractSource); 20] = [
-    (L2_COMPLEX_UPGRADER_ADDR, ContractSource::L1ContractName("SystemContractProxy")),
-    (L2_GENESIS_UPGRADE, ContractSource::L1ContractName("L2GenesisUpgrade")),
-    (L2_WRAPPED_BASE_TOKEN, ContractSource::L1ContractName("L2WrappedBaseToken")),
-    (SYSTEM_CONTRACT_PROXY_ADMIN, ContractSource::L1ContractName("SystemContractProxyAdmin")),
-    (L2_COMPLEX_UPGRADER_IMPL_ADDR, ContractSource::L1ContractName("L2ComplexUpgrader")),
-    (L2_MESSAGE_ROOT_ADDR, ContractSource::L1ContractName("L2MessageRoot")),
-    (L2_BRIDGEHUB_ADDR, ContractSource::L1ContractName("L2Bridgehub")),
-    (L2_ASSET_ROUTER_ADDR, ContractSource::L1ContractName("L2AssetRouter")),
-    (L2_NATIVE_TOKEN_VAULT_ADDR, ContractSource::L1ContractName("L2NativeTokenVaultZKOS")),
-    (L2_NTV_BEACON_DEPLOYER_ADDR, ContractSource::L1ContractName("UpgradeableBeaconDeployer")),
-    (L2_CHAIN_ASSET_HANDLER_ADDR, ContractSource::L1ContractName("L2ChainAssetHandler")),
-    (L2_ASSET_TRACKER_ADDR, ContractSource::L1ContractName("L2AssetTracker")),
-    (GW_ASSET_TRACKER_ADDR, ContractSource::L1ContractName("GWAssetTracker")),
-    (L2_INTEROP_CENTER_ADDR, ContractSource::L1ContractName("InteropCenter")),
-    (L2_INTEROP_HANDLER_ADDR, ContractSource::L1ContractName("InteropHandler")),
-    (L2_BASE_TOKEN_HOLDER_ADDR, ContractSource::L1ContractName("BaseTokenHolder")),
+    (
+        L2_COMPLEX_UPGRADER_ADDR,
+        ContractSource::L1ContractName("SystemContractProxy"),
+    ),
+    (
+        L2_GENESIS_UPGRADE,
+        ContractSource::L1ContractName("L2GenesisUpgrade"),
+    ),
+    (
+        L2_WRAPPED_BASE_TOKEN,
+        ContractSource::L1ContractName("L2WrappedBaseToken"),
+    ),
+    (
+        SYSTEM_CONTRACT_PROXY_ADMIN,
+        ContractSource::L1ContractName("SystemContractProxyAdmin"),
+    ),
+    (
+        L2_COMPLEX_UPGRADER_IMPL_ADDR,
+        ContractSource::L1ContractName("L2ComplexUpgrader"),
+    ),
+    (
+        L2_MESSAGE_ROOT_ADDR,
+        ContractSource::L1ContractName("L2MessageRoot"),
+    ),
+    (
+        L2_BRIDGEHUB_ADDR,
+        ContractSource::L1ContractName("L2Bridgehub"),
+    ),
+    (
+        L2_ASSET_ROUTER_ADDR,
+        ContractSource::L1ContractName("L2AssetRouter"),
+    ),
+    (
+        L2_NATIVE_TOKEN_VAULT_ADDR,
+        ContractSource::L1ContractName("L2NativeTokenVaultZKOS"),
+    ),
+    (
+        L2_NTV_BEACON_DEPLOYER_ADDR,
+        ContractSource::L1ContractName("UpgradeableBeaconDeployer"),
+    ),
+    (
+        L2_CHAIN_ASSET_HANDLER_ADDR,
+        ContractSource::L1ContractName("L2ChainAssetHandler"),
+    ),
+    (
+        L2_ASSET_TRACKER_ADDR,
+        ContractSource::L1ContractName("L2AssetTracker"),
+    ),
+    (
+        GW_ASSET_TRACKER_ADDR,
+        ContractSource::L1ContractName("GWAssetTracker"),
+    ),
+    (
+        L2_INTEROP_CENTER_ADDR,
+        ContractSource::L1ContractName("InteropCenter"),
+    ),
+    (
+        L2_INTEROP_HANDLER_ADDR,
+        ContractSource::L1ContractName("InteropHandler"),
+    ),
+    (
+        L2_BASE_TOKEN_HOLDER_ADDR,
+        ContractSource::L1ContractName("BaseTokenHolder"),
+    ),
     // System contracts (0x8000 range)
-    (L2_DEPLOYER_SYSTEM_CONTRACT_ADDR, ContractSource::L1ContractName("ZKOSContractDeployer")),
-    (L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR, ContractSource::L1ContractName("L1MessengerZKOS")),
-    (L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR, ContractSource::L1ContractName("L2BaseTokenZKOS")),
+    (
+        L2_DEPLOYER_SYSTEM_CONTRACT_ADDR,
+        ContractSource::L1ContractName("ZKOSContractDeployer"),
+    ),
+    (
+        L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR,
+        ContractSource::L1ContractName("L1MessengerZKOS"),
+    ),
+    (
+        L2_BASE_TOKEN_SYSTEM_CONTRACT_ADDR,
+        ContractSource::L1ContractName("L2BaseTokenZKOS"),
+    ),
     // Deterministic Create2 factory
-    (DETERMINISTIC_CREATE2_ADDRESS, ContractSource::Bytecode(CREATE2_FACTORY_RUNTIME_BYTECODE)),
+    (
+        DETERMINISTIC_CREATE2_ADDRESS,
+        ContractSource::Bytecode(CREATE2_FACTORY_RUNTIME_BYTECODE),
+    ),
 ];

--- a/tools/zksync-os-genesis-gen/src/genesis.rs
+++ b/tools/zksync-os-genesis-gen/src/genesis.rs
@@ -1,18 +1,18 @@
 use crate::consts::{
     ContractSource, EIP1967_ADMIN_SLOT, EIP1967_IMPLEMENTATION_SLOT, INITIAL_CONTRACTS,
-    L2_BASE_TOKEN_HOLDER_ADDR, L2_COMPLEX_UPGRADER_ADDR, L2_COMPLEX_UPGRADER_IMPL_ADDR,
-    SYSTEM_CONTRACT_PROXY_ADMIN, SYSTEM_PROXY_ADMIN_OWNER_SLOT,
+    L2_COMPLEX_UPGRADER_ADDR, L2_COMPLEX_UPGRADER_IMPL_ADDR, SYSTEM_CONTRACT_PROXY_ADMIN,
+    SYSTEM_PROXY_ADMIN_OWNER_SLOT,
 };
 use crate::types::{InitialGenesisInput, LeafInfo, MAX_B256_VALUE, MERKLE_TREE_DEPTH};
 use crate::utils::{address_to_b256, da_contract_name_to_code, l1_contract_name_to_code};
-use alloy::consensus::{Header, EMPTY_OMMER_ROOT_HASH};
+use alloy::consensus::{EMPTY_OMMER_ROOT_HASH, Header};
 use alloy::eips::eip1559::INITIAL_BASE_FEE;
-use alloy::primitives::{Address, Bloom, B256, B64, U256};
+use alloy::primitives::{Address, B64, B256, Bloom, U256};
 use blake2::{Blake2s256, Digest};
 use std::collections::BTreeMap;
 use zk_os_api::helpers::{set_properties_code, set_properties_nonce};
 use zk_os_basic_system::system_implementation::flat_storage_model::{
-    AccountProperties, ACCOUNT_PROPERTIES_STORAGE_ADDRESS,
+    ACCOUNT_PROPERTIES_STORAGE_ADDRESS, AccountProperties,
 };
 
 impl InitialGenesisInput {

--- a/tools/zksync-os-genesis-gen/src/genesis.rs
+++ b/tools/zksync-os-genesis-gen/src/genesis.rs
@@ -175,10 +175,6 @@ pub fn build_genesis_root_hash(genesis_input: &InitialGenesisInput) -> anyhow::R
         // When contracts are deployed, they have a nonce of 1.
         set_properties_nonce(&mut account_properties, 1);
         set_properties_code(&mut account_properties, &deployed_code);
-        // The base token holder contract should hold a large balance
-        if *address == L2_BASE_TOKEN_HOLDER_ADDR {
-            account_properties.balance = alloy::primitives::Uint::from(u128::MAX);
-        }
 
         let flat_storage_key = account_properties_flat_key(*address);
         let account_properties_hash = account_properties.compute_hash();

--- a/tools/zksync-os-genesis-gen/src/genesis.rs
+++ b/tools/zksync-os-genesis-gen/src/genesis.rs
@@ -1,13 +1,13 @@
 use crate::consts::{
-    BASE_TOKEN_HOLDER_ADDR, ContractSource, EIP1967_ADMIN_SLOT, EIP1967_IMPLEMENTATION_SLOT, INITIAL_CONTRACTS,
-    L2_COMPLEX_UPGRADER_ADDR, L2_COMPLEX_UPGRADER_IMPL_ADDR, SYSTEM_CONTRACT_PROXY_ADMIN,
-    SYSTEM_PROXY_ADMIN_OWNER_SLOT,
+    ContractSource, EIP1967_ADMIN_SLOT, EIP1967_IMPLEMENTATION_SLOT, INITIAL_CONTRACTS,
+    L2_BASE_TOKEN_HOLDER_ADDR, L2_COMPLEX_UPGRADER_ADDR, L2_COMPLEX_UPGRADER_IMPL_ADDR,
+    SYSTEM_CONTRACT_PROXY_ADMIN, SYSTEM_PROXY_ADMIN_OWNER_SLOT,
 };
 use crate::types::{InitialGenesisInput, LeafInfo, MAX_B256_VALUE, MERKLE_TREE_DEPTH};
 use crate::utils::{address_to_b256, da_contract_name_to_code, l1_contract_name_to_code};
 use alloy::consensus::{Header, EMPTY_OMMER_ROOT_HASH};
 use alloy::eips::eip1559::INITIAL_BASE_FEE;
-use alloy::primitives::{Address, Bloom, B256, B64, U256, Uint};
+use alloy::primitives::{Address, Bloom, B256, B64, U256};
 use blake2::{Blake2s256, Digest};
 use std::collections::BTreeMap;
 use zk_os_api::helpers::{set_properties_code, set_properties_nonce};
@@ -175,6 +175,10 @@ pub fn build_genesis_root_hash(genesis_input: &InitialGenesisInput) -> anyhow::R
         // When contracts are deployed, they have a nonce of 1.
         set_properties_nonce(&mut account_properties, 1);
         set_properties_code(&mut account_properties, &deployed_code);
+        // The base token holder contract should hold a large balance
+        if *address == L2_BASE_TOKEN_HOLDER_ADDR {
+            account_properties.balance = alloy::primitives::Uint::from(u128::MAX);
+        }
 
         let flat_storage_key = account_properties_flat_key(*address);
         let account_properties_hash = account_properties.compute_hash();
@@ -259,16 +263,6 @@ fn construct_additional_storage() -> BTreeMap<Address, BTreeMap<B256, B256>> {
         address_to_b256(&SYSTEM_CONTRACT_PROXY_ADMIN),
     );
     map.insert(L2_COMPLEX_UPGRADER_ADDR, l2_complex_upgrader_storage);
-
-    let mut account_properties_storage = BTreeMap::new();
-    account_properties_storage.insert(
-        address_to_b256(&BASE_TOKEN_HOLDER_ADDR),
-        AccountProperties {
-            balance: Uint::from(u128::MAX),
-            ..Default::default()
-        }.compute_hash().as_u8_array().into(),
-    );
-    map.insert(ACCOUNT_PROPERTIES_STORAGE_ADDRESS.to_be_bytes().into(), account_properties_storage);
 
     map
 }

--- a/tools/zksync-os-genesis-gen/src/types.rs
+++ b/tools/zksync-os-genesis-gen/src/types.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use alloy::primitives::{Address, FixedBytes, B256};
+use alloy::primitives::{Address, B256, FixedBytes};
 
 use blake2::{Blake2s256, Digest};
 

--- a/tools/zksync-os-genesis-gen/src/utils.rs
+++ b/tools/zksync-os-genesis-gen/src/utils.rs
@@ -11,8 +11,8 @@ pub fn da_contract_name_to_code(contract_name: &str) -> Vec<u8> {
 }
 
 fn contract_artifact_to_code(path: &str, contract_name: &str) -> Vec<u8> {
-    let file_content =
-        std::fs::read_to_string(path).expect(format!("Failed to read contract bytecode file {}", path).as_str());
+    let file_content = std::fs::read_to_string(path)
+        .expect(format!("Failed to read contract bytecode file {}", path).as_str());
     let artifact: serde_json::Value =
         serde_json::from_str(&file_content).expect("Failed to parse JSON file");
 


### PR DESCRIPTION
# What ❔

Since L2_BASE_TOKEN_HOLDER was added to initial contracts, there's no need to separately mint balance to its account - instead we do it when setting its account properties along with code