### PR TITLE
feat: add initialVerifierVersion to GatewayVerifiersDeployerConfig

### DIFF
--- a/l1-contracts/contracts/state-transition/chain-deps/gateway-ctm-deployer/GatewayCTMDeployer.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/gateway-ctm-deployer/GatewayCTMDeployer.sol
@@ -41,6 +41,9 @@ struct GatewayCTMDeployerConfig {
     bool testnetVerifier;
     /// @notice Flag indicating whether to use ZKsync OS mode.
     bool isZKsyncOS;
+    /// @notice Initial verifier version to register in the ZKsync OS dual verifier.
+    /// @dev Only used when isZKsyncOS is true. Set to 0 to skip registration.
+    uint32 initialVerifierVersion;
     /// @notice Array of function selectors for the Admin facet.
     bytes4[] adminSelectors;
     /// @notice Array of function selectors for the Executor facet.
@@ -183,6 +186,9 @@ struct GatewayVerifiersDeployerConfig {
     bool testnetVerifier;
     /// @notice Flag indicating whether to use ZKsync OS mode.
     bool isZKsyncOS;
+    /// @notice Initial verifier version to register in the ZKsync OS dual verifier.
+    /// @dev Only used when isZKsyncOS is true. Set to 0 to skip registration.
+    uint32 initialVerifierVersion;
 }
 
 /// @notice Result from Verifiers deployer.

--- a/l1-contracts/contracts/state-transition/chain-deps/gateway-ctm-deployer/GatewayCTMDeployerVerifiersZKsyncOS.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/gateway-ctm-deployer/GatewayCTMDeployerVerifiersZKsyncOS.sol
@@ -42,24 +42,37 @@ contract GatewayCTMDeployerVerifiersZKsyncOS {
         result.verifierFflonk = address(new ZKsyncOSVerifierFflonk{salt: salt}());
         result.verifierPlonk = address(new ZKsyncOSVerifierPlonk{salt: salt}());
 
-        // Deploy main verifier
+        // Deploy main verifier with address(this) as initial owner so we can register
+        // the initial verifier version before transferring ownership to governance.
+        ZKsyncOSDualVerifier verifier;
         if (_config.testnetVerifier) {
-            result.verifier = address(
-                new ZKsyncOSTestnetVerifier{salt: salt}(
-                    IVerifierV2(result.verifierFflonk),
-                    IVerifier(result.verifierPlonk),
-                    _config.aliasedGovernanceAddress
+            verifier = ZKsyncOSDualVerifier(
+                address(
+                    new ZKsyncOSTestnetVerifier{salt: salt}(
+                        IVerifierV2(result.verifierFflonk),
+                        IVerifier(result.verifierPlonk),
+                        address(this)
+                    )
                 )
             );
         } else {
-            result.verifier = address(
-                new ZKsyncOSDualVerifier{salt: salt}(
-                    IVerifierV2(result.verifierFflonk),
-                    IVerifier(result.verifierPlonk),
-                    _config.aliasedGovernanceAddress
-                )
+            verifier = new ZKsyncOSDualVerifier{salt: salt}(
+                IVerifierV2(result.verifierFflonk),
+                IVerifier(result.verifierPlonk),
+                address(this)
             );
         }
+
+        if (_config.initialVerifierVersion != 0) {
+            verifier.addVerifier(
+                _config.initialVerifierVersion,
+                IVerifierV2(result.verifierFflonk),
+                IVerifier(result.verifierPlonk)
+            );
+        }
+
+        verifier.transferOwnership(_config.aliasedGovernanceAddress);
+        result.verifier = address(verifier);
 
         deployedResult = result;
     }

--- a/l1-contracts/deploy-script-config-template/config-deploy-ctm.toml
+++ b/l1-contracts/deploy-script-config-template/config-deploy-ctm.toml
@@ -3,6 +3,8 @@ owner_address = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
 testnet_verifier = true
 support_l2_legacy_shared_bridge_test = false
 is_zk_sync_os = false
+# The initial verifier version to register in the ZKsync OS dual verifier (only used when is_zk_sync_os = true).
+initial_verifier_version = 6
 zk_token_asset_id = "0x50c8daa176d24869d010ad74c2d374427601375ca2264e94f73784e299d572d4"
 
 [gateway]

--- a/l1-contracts/deploy-scripts/ctm/DeployCTM.s.sol
+++ b/l1-contracts/deploy-scripts/ctm/DeployCTM.s.sol
@@ -54,9 +54,6 @@ import {FixedForceDeploymentsData} from "contracts/state-transition/l2-deps/IL2G
 
 import {IDeployCTM} from "contracts/script-interfaces/IDeployCTM.sol";
 
-// TODO: pass this value from zkstack_cli
-uint32 constant DEFAULT_ZKSYNC_OS_VERIFIER_VERSION = 6;
-
 contract DeployCTMScript is Script, DeployCTMUtils, IDeployCTM {
     using stdToml for string;
 
@@ -225,7 +222,7 @@ contract DeployCTMScript is Script, DeployCTMUtils, IDeployCTM {
             // Use getDeployerAddress() to ensure the correct sender even when called from nested contracts
             vm.startBroadcast(getDeployerAddress());
             ZKsyncOSDualVerifier(ctmAddresses.stateTransition.verifiers.verifier).addVerifier(
-                DEFAULT_ZKSYNC_OS_VERIFIER_VERSION,
+                config.initialVerifierVersion,
                 IVerifierV2(ctmAddresses.stateTransition.verifiers.verifierFflonk),
                 IVerifier(ctmAddresses.stateTransition.verifiers.verifierPlonk)
             );

--- a/l1-contracts/deploy-scripts/ctm/DeployCTMUtils.s.sol
+++ b/l1-contracts/deploy-scripts/ctm/DeployCTMUtils.s.sol
@@ -83,6 +83,9 @@ struct Config {
     bool testnetVerifier;
     bool supportL2LegacySharedBridgeTest;
     bool isZKsyncOS;
+    /// @notice Initial verifier version to register in the ZKsync OS dual verifier.
+    /// @dev Only used when isZKsyncOS is true. Passed from the zkstack CLI.
+    uint32 initialVerifierVersion;
     ContractsConfig contracts;
 }
 
@@ -155,6 +158,9 @@ abstract contract DeployCTMUtils is DeployUtils {
         config.supportL2LegacySharedBridgeTest = toml.readBool("$.support_l2_legacy_shared_bridge_test");
         if (toml.keyExists("$.is_zk_sync_os")) {
             config.isZKsyncOS = toml.readBool("$.is_zk_sync_os");
+        }
+        if (toml.keyExists("$.initial_verifier_version")) {
+            config.initialVerifierVersion = uint32(toml.readUint("$.initial_verifier_version"));
         }
         if (toml.keyExists("$.zk_token_asset_id")) {
             config.zkTokenAssetId = toml.readBytes32("$.zk_token_asset_id");

--- a/l1-contracts/deploy-scripts/gateway/GatewayCTMDeployerHelper.sol
+++ b/l1-contracts/deploy-scripts/gateway/GatewayCTMDeployerHelper.sol
@@ -266,7 +266,8 @@ library GatewayCTMDeployerHelper {
             salt: config.salt,
             aliasedGovernanceAddress: config.aliasedGovernanceAddress,
             testnetVerifier: config.testnetVerifier,
-            isZKsyncOS: config.isZKsyncOS
+            isZKsyncOS: config.isZKsyncOS,
+            initialVerifierVersion: config.initialVerifierVersion
         });
 
         // Different deployer contracts for each mode
@@ -603,12 +604,14 @@ library GatewayCTMDeployerHelper {
         }
 
         // Deploy main verifier
+        // For ZKsyncOS, the deployer contract (deployerAddr) is the initial owner so it can register
+        // the initial verifier version before transferring ownership to governance.
         if (config.testnetVerifier) {
             if (config.isZKsyncOS) {
                 result.verifier = _deployInternalWithParams(
                     "ZKsyncOSTestnetVerifier",
                     "ZKsyncOSTestnetVerifier.sol",
-                    abi.encode(result.verifierFflonk, result.verifierPlonk, config.aliasedGovernanceAddress),
+                    abi.encode(result.verifierFflonk, result.verifierPlonk, innerConfig.deployerAddr),
                     innerConfig
                 );
             } else {
@@ -624,7 +627,7 @@ library GatewayCTMDeployerHelper {
                 result.verifier = _deployInternalWithParams(
                     "ZKsyncOSDualVerifier",
                     "ZKsyncOSDualVerifier.sol",
-                    abi.encode(result.verifierFflonk, result.verifierPlonk, config.aliasedGovernanceAddress),
+                    abi.encode(result.verifierFflonk, result.verifierPlonk, innerConfig.deployerAddr),
                     innerConfig
                 );
             } else {
@@ -675,12 +678,14 @@ library GatewayCTMDeployerHelper {
         }
 
         // Deploy main verifier
+        // For ZKsyncOS, the deployer contract (deployerAddr) is the initial owner so it can register
+        // the initial verifier version before transferring ownership to governance.
         if (config.testnetVerifier) {
             if (config.isZKsyncOS) {
                 result.verifier = _deployInternalWithParamsWithMode(
                     "ZKsyncOSTestnetVerifier",
                     "ZKsyncOSTestnetVerifier.sol",
-                    abi.encode(result.verifierFflonk, result.verifierPlonk, config.aliasedGovernanceAddress),
+                    abi.encode(result.verifierFflonk, result.verifierPlonk, innerConfig.deployerAddr),
                     innerConfig,
                     isZKsyncOS
                 );
@@ -698,7 +703,7 @@ library GatewayCTMDeployerHelper {
                 result.verifier = _deployInternalWithParamsWithMode(
                     "ZKsyncOSDualVerifier",
                     "ZKsyncOSDualVerifier.sol",
-                    abi.encode(result.verifierFflonk, result.verifierPlonk, config.aliasedGovernanceAddress),
+                    abi.encode(result.verifierFflonk, result.verifierPlonk, innerConfig.deployerAddr),
                     innerConfig,
                     isZKsyncOS
                 );

--- a/l1-contracts/deploy-scripts/gateway/GatewayVotePreparation.s.sol
+++ b/l1-contracts/deploy-scripts/gateway/GatewayVotePreparation.s.sol
@@ -111,6 +111,7 @@ contract GatewayVotePreparation is DeployCTMUtils, GatewayGovernanceUtils {
             l1ChainId: config.l1ChainId,
             testnetVerifier: config.testnetVerifier,
             isZKsyncOS: config.isZKsyncOS,
+            initialVerifierVersion: config.initialVerifierVersion,
             adminSelectors: Utils.getAllSelectorsForFacet("Admin"),
             executorSelectors: Utils.getAllSelectorsForFacet("Executor"),
             mailboxSelectors: Utils.getAllSelectorsForFacet("Mailbox"),

--- a/l1-contracts/test/foundry/l1/integration/deploy-scripts/script-config/config-deploy-ctm.toml
+++ b/l1-contracts/test/foundry/l1/integration/deploy-scripts/script-config/config-deploy-ctm.toml
@@ -3,6 +3,7 @@ owner_address = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
 testnet_verifier = true
 support_l2_legacy_shared_bridge_test = false
 is_zk_sync_os = false
+initial_verifier_version = 6
 zk_token_asset_id = "0x01000000000000000000000000000000000000000000000000000000000a2a6f"
 
 [gateway]

--- a/l1-contracts/test/foundry/l1/unit/concrete/GatewayCTMDeployer/GatewayCTMDeployerZKsyncOS.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/GatewayCTMDeployer/GatewayCTMDeployerZKsyncOS.t.sol
@@ -121,6 +121,7 @@ contract GatewayCTMDeployerZKsyncOSTest is Test {
             l1ChainId: 1,
             testnetVerifier: true,
             isZKsyncOS: true, // ZKsyncOS mode enabled
+            initialVerifierVersion: 6,
             adminSelectors: new bytes4[](2),
             executorSelectors: new bytes4[](2),
             mailboxSelectors: new bytes4[](2),

--- a/l1-contracts/test/foundry/l2/unit/GatewayCTMDeployer/GatewayCTMDeployer.t.sol
+++ b/l1-contracts/test/foundry/l2/unit/GatewayCTMDeployer/GatewayCTMDeployer.t.sol
@@ -172,6 +172,7 @@ contract GatewayCTMDeployerTest is Test {
             l1ChainId: 1,
             testnetVerifier: true,
             isZKsyncOS: false,
+            initialVerifierVersion: 6,
             adminSelectors: new bytes4[](2),
             executorSelectors: new bytes4[](2),
             mailboxSelectors: new bytes4[](2),
@@ -268,7 +269,8 @@ contract GatewayCTMDeployerTest is Test {
             salt: deployerConfig.salt,
             aliasedGovernanceAddress: deployerConfig.aliasedGovernanceAddress,
             testnetVerifier: deployerConfig.testnetVerifier,
-            isZKsyncOS: deployerConfig.isZKsyncOS
+            isZKsyncOS: deployerConfig.isZKsyncOS,
+            initialVerifierVersion: deployerConfig.initialVerifierVersion
         });
         new GatewayCTMDeployerVerifiers(verifiersConfig);
     }


### PR DESCRIPTION
## Summary

- Adds `initialVerifierVersion uint32` to `GatewayVerifiersDeployerConfig` and `GatewayCTMDeployerConfig`, replacing the hardcoded `DEFAULT_ZKSYNC_OS_VERIFIER_VERSION` constant with a configurable value passed from the zkstack CLI via TOML config
- `GatewayCTMDeployerVerifiersZKsyncOS` now deploys the verifier with `address(this)` as the initial owner, calls `addVerifier(initialVerifierVersion, ...)` to register the initial verifier version, then transfers ownership to the aliased governance address
- Address pre-calculation in `GatewayCTMDeployerHelper` updated to use `deployerAddr` as the verifier's initial owner constructor arg (to match the runtime behavior)
- `DeployCTM.s.sol` reads the version from `config.initialVerifierVersion` instead of the removed constant
- `DeployCTMUtils.s.sol` reads `initial_verifier_version` from the deployment config TOML

## Test plan

- [x] L1 unit test `GatewayCTMDeployerZKsyncOSTest::testGatewayCTMDeployerZKsyncOS` passes (EVM/ZKsyncOS mode)
- [x] L2 unit test `GatewayCTMDeployerTest::testGatewayCTMDeployer` passes (ZKsync mode)
- [x] Solidity linting passes (`yarn lint:sol --fix --noPrompt`)
- [x] Prettier formatting passes (`yarn prettier:fix`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)