### PR TITLE
feat: add initialVerifierVersion to GatewayVerifiersDeployerConfig

### DIFF
--- a/l1-contracts/contracts/state-transition/chain-deps/gateway-ctm-deployer/GatewayCTMDeployer.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/gateway-ctm-deployer/GatewayCTMDeployer.sol
@@ -6,6 +6,10 @@ pragma solidity 0.8.28;
 // The deployment uses a mix of deployer contracts (for contracts requiring owner initialization)
 // and direct deployments in scripts (for contracts without owner initialization).
 
+// The default verifier version to register in the ZKsync OS dual verifier during deployment.
+// solhint-disable-next-line var-name-mixedcase
+uint32 constant DEFAULT_ZKSYNC_OS_VERIFIER_VERSION = 6;
+
 /// @notice Diamond facet contract addresses.
 // solhint-disable-next-line gas-struct-packing
 struct Facets {
@@ -183,6 +187,9 @@ struct GatewayVerifiersDeployerConfig {
     bool testnetVerifier;
     /// @notice Flag indicating whether to use ZKsync OS mode.
     bool isZKsyncOS;
+    /// @notice Initial verifier version to register in the ZKsync OS dual verifier.
+    /// @dev Only used when isZKsyncOS is true. Set to 0 to skip registration.
+    uint32 initialVerifierVersion;
 }
 
 /// @notice Result from Verifiers deployer.

--- a/l1-contracts/contracts/state-transition/chain-deps/gateway-ctm-deployer/GatewayCTMDeployerVerifiersZKsyncOS.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/gateway-ctm-deployer/GatewayCTMDeployerVerifiersZKsyncOS.sol
@@ -42,24 +42,37 @@ contract GatewayCTMDeployerVerifiersZKsyncOS {
         result.verifierFflonk = address(new ZKsyncOSVerifierFflonk{salt: salt}());
         result.verifierPlonk = address(new ZKsyncOSVerifierPlonk{salt: salt}());
 
-        // Deploy main verifier
+        // Deploy main verifier with address(this) as initial owner so we can register
+        // the initial verifier version before transferring ownership to governance.
+        ZKsyncOSDualVerifier verifier;
         if (_config.testnetVerifier) {
-            result.verifier = address(
-                new ZKsyncOSTestnetVerifier{salt: salt}(
-                    IVerifierV2(result.verifierFflonk),
-                    IVerifier(result.verifierPlonk),
-                    _config.aliasedGovernanceAddress
+            verifier = ZKsyncOSDualVerifier(
+                address(
+                    new ZKsyncOSTestnetVerifier{salt: salt}(
+                        IVerifierV2(result.verifierFflonk),
+                        IVerifier(result.verifierPlonk),
+                        address(this)
+                    )
                 )
             );
         } else {
-            result.verifier = address(
-                new ZKsyncOSDualVerifier{salt: salt}(
-                    IVerifierV2(result.verifierFflonk),
-                    IVerifier(result.verifierPlonk),
-                    _config.aliasedGovernanceAddress
-                )
+            verifier = new ZKsyncOSDualVerifier{salt: salt}(
+                IVerifierV2(result.verifierFflonk),
+                IVerifier(result.verifierPlonk),
+                address(this)
             );
         }
+
+        if (_config.initialVerifierVersion != 0) {
+            verifier.addVerifier(
+                _config.initialVerifierVersion,
+                IVerifierV2(result.verifierFflonk),
+                IVerifier(result.verifierPlonk)
+            );
+        }
+
+        verifier.transferOwnership(_config.aliasedGovernanceAddress);
+        result.verifier = address(verifier);
 
         deployedResult = result;
     }

--- a/l1-contracts/deploy-scripts/ctm/DeployCTM.s.sol
+++ b/l1-contracts/deploy-scripts/ctm/DeployCTM.s.sol
@@ -54,8 +54,7 @@ import {FixedForceDeploymentsData} from "contracts/state-transition/l2-deps/IL2G
 
 import {IDeployCTM} from "contracts/script-interfaces/IDeployCTM.sol";
 
-// TODO: pass this value from zkstack_cli
-uint32 constant DEFAULT_ZKSYNC_OS_VERIFIER_VERSION = 6;
+import {DEFAULT_ZKSYNC_OS_VERIFIER_VERSION} from "contracts/state-transition/chain-deps/gateway-ctm-deployer/GatewayCTMDeployer.sol";
 
 contract DeployCTMScript is Script, DeployCTMUtils, IDeployCTM {
     using stdToml for string;

--- a/l1-contracts/deploy-scripts/gateway/GatewayCTMDeployerHelper.sol
+++ b/l1-contracts/deploy-scripts/gateway/GatewayCTMDeployerHelper.sol
@@ -41,7 +41,8 @@ import {
     GatewayVerifiersDeployerConfig,
     Verifiers,
     GatewayCTMFinalConfig,
-    GatewayCTMFinalResult
+    GatewayCTMFinalResult,
+    DEFAULT_ZKSYNC_OS_VERIFIER_VERSION
 } from "contracts/state-transition/chain-deps/gateway-ctm-deployer/GatewayCTMDeployer.sol";
 
 import {CTMCoreDeploymentConfig} from "../ctm/DeployCTML1OrGateway.sol";
@@ -266,7 +267,8 @@ library GatewayCTMDeployerHelper {
             salt: config.salt,
             aliasedGovernanceAddress: config.aliasedGovernanceAddress,
             testnetVerifier: config.testnetVerifier,
-            isZKsyncOS: config.isZKsyncOS
+            isZKsyncOS: config.isZKsyncOS,
+            initialVerifierVersion: DEFAULT_ZKSYNC_OS_VERIFIER_VERSION
         });
 
         // Different deployer contracts for each mode
@@ -603,12 +605,14 @@ library GatewayCTMDeployerHelper {
         }
 
         // Deploy main verifier
+        // For ZKsyncOS, the deployer contract (deployerAddr) is the initial owner so it can register
+        // the initial verifier version before transferring ownership to governance.
         if (config.testnetVerifier) {
             if (config.isZKsyncOS) {
                 result.verifier = _deployInternalWithParams(
                     "ZKsyncOSTestnetVerifier",
                     "ZKsyncOSTestnetVerifier.sol",
-                    abi.encode(result.verifierFflonk, result.verifierPlonk, config.aliasedGovernanceAddress),
+                    abi.encode(result.verifierFflonk, result.verifierPlonk, innerConfig.deployerAddr),
                     innerConfig
                 );
             } else {
@@ -624,7 +628,7 @@ library GatewayCTMDeployerHelper {
                 result.verifier = _deployInternalWithParams(
                     "ZKsyncOSDualVerifier",
                     "ZKsyncOSDualVerifier.sol",
-                    abi.encode(result.verifierFflonk, result.verifierPlonk, config.aliasedGovernanceAddress),
+                    abi.encode(result.verifierFflonk, result.verifierPlonk, innerConfig.deployerAddr),
                     innerConfig
                 );
             } else {
@@ -675,12 +679,14 @@ library GatewayCTMDeployerHelper {
         }
 
         // Deploy main verifier
+        // For ZKsyncOS, the deployer contract (deployerAddr) is the initial owner so it can register
+        // the initial verifier version before transferring ownership to governance.
         if (config.testnetVerifier) {
             if (config.isZKsyncOS) {
                 result.verifier = _deployInternalWithParamsWithMode(
                     "ZKsyncOSTestnetVerifier",
                     "ZKsyncOSTestnetVerifier.sol",
-                    abi.encode(result.verifierFflonk, result.verifierPlonk, config.aliasedGovernanceAddress),
+                    abi.encode(result.verifierFflonk, result.verifierPlonk, innerConfig.deployerAddr),
                     innerConfig,
                     isZKsyncOS
                 );
@@ -698,7 +704,7 @@ library GatewayCTMDeployerHelper {
                 result.verifier = _deployInternalWithParamsWithMode(
                     "ZKsyncOSDualVerifier",
                     "ZKsyncOSDualVerifier.sol",
-                    abi.encode(result.verifierFflonk, result.verifierPlonk, config.aliasedGovernanceAddress),
+                    abi.encode(result.verifierFflonk, result.verifierPlonk, innerConfig.deployerAddr),
                     innerConfig,
                     isZKsyncOS
                 );

--- a/l1-contracts/test/foundry/l2/unit/GatewayCTMDeployer/GatewayCTMDeployer.t.sol
+++ b/l1-contracts/test/foundry/l2/unit/GatewayCTMDeployer/GatewayCTMDeployer.t.sol
@@ -16,7 +16,8 @@ import {
     GatewayVerifiersDeployerConfig,
     Verifiers,
     GatewayCTMFinalConfig,
-    GatewayCTMFinalResult
+    GatewayCTMFinalResult,
+    DEFAULT_ZKSYNC_OS_VERIFIER_VERSION
 } from "contracts/state-transition/chain-deps/gateway-ctm-deployer/GatewayCTMDeployer.sol";
 import {GatewayCTMDeployerDA} from "contracts/state-transition/chain-deps/gateway-ctm-deployer/GatewayCTMDeployerDA.sol";
 import {GatewayCTMDeployerProxyAdmin} from "contracts/state-transition/chain-deps/gateway-ctm-deployer/GatewayCTMDeployerProxyAdmin.sol";
@@ -268,7 +269,8 @@ contract GatewayCTMDeployerTest is Test {
             salt: deployerConfig.salt,
             aliasedGovernanceAddress: deployerConfig.aliasedGovernanceAddress,
             testnetVerifier: deployerConfig.testnetVerifier,
-            isZKsyncOS: deployerConfig.isZKsyncOS
+            isZKsyncOS: deployerConfig.isZKsyncOS,
+            initialVerifierVersion: DEFAULT_ZKSYNC_OS_VERIFIER_VERSION
         });
         new GatewayCTMDeployerVerifiers(verifiersConfig);
     }


### PR DESCRIPTION
## Summary

- Moves `DEFAULT_ZKSYNC_OS_VERIFIER_VERSION` from `DeployCTM.s.sol` into `GatewayCTMDeployer.sol` so it is accessible to both the L1 deploy script and the gateway helper
- Adds `initialVerifierVersion uint32` to `GatewayVerifiersDeployerConfig`
- `GatewayCTMDeployerVerifiersZKsyncOS` now deploys the verifier with `address(this)` as the initial owner, calls `addVerifier(initialVerifierVersion, ...)` to register the initial verifier version, then transfers ownership via `transferOwnership`
- `GatewayCTMDeployerHelper` passes `DEFAULT_ZKSYNC_OS_VERIFIER_VERSION` as `initialVerifierVersion` when building `GatewayVerifiersDeployerConfig`; address pre-calculation updated to use `deployerAddr` as the verifier's initial owner constructor arg to match runtime behavior

## Test plan

- [x] L1 unit test `GatewayCTMDeployerZKsyncOSTest::testGatewayCTMDeployerZKsyncOS` passes
- [x] L2 unit test `GatewayCTMDeployerTest::testGatewayCTMDeployer` passes
- [x] Solidity linting passes (`yarn lint:sol --fix --noPrompt`)
- [x] Prettier formatting passes (`yarn prettier:fix`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)