### PR TITLE
M-01: add whenNotPaused to L2AssetRouter.bridgehubDepositBaseToken

### DIFF
--- a/l1-contracts/contracts/bridge/asset-router/L2AssetRouter.sol
+++ b/l1-contracts/contracts/bridge/asset-router/L2AssetRouter.sol
@@ -265,7 +265,7 @@ contract L2AssetRouter is AssetRouterBase, IL2AssetRouter, ReentrancyGuard, IERC
         bytes32 _assetId,
         address _originalCaller,
         uint256 _amount
-    ) public payable virtual override onlyL2InteropCenter {
+    ) public payable virtual override onlyL2InteropCenter whenNotPaused {
         _bridgehubDepositBaseToken(_chainId, _assetId, _originalCaller, _amount);
     }
 


### PR DESCRIPTION
## Summary
- Adds `whenNotPaused` modifier to `L2AssetRouter.bridgehubDepositBaseToken` for consistency with the L1 counterpart
- L1AssetRouter already enforces pause on this function; the L2 version did not, allowing base token deposits to bypass the pause mechanism during emergencies

## Test plan
- [ ] Verify `forge build` passes
- [ ] Confirm L2AssetRouter.bridgehubDepositBaseToken reverts when contract is paused
- [ ] Confirm no regression in interop deposit flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)