### PR TITLE
L-01: fix minimum length check in ERC-7930 address validation

### DIFF
--- a/l1-contracts/contracts/interop/InteropCenter.sol
+++ b/l1-contracts/contracts/interop/InteropCenter.sol
@@ -312,7 +312,7 @@ contract InteropCenter is
     /// @param _interoperableAddress The ERC-7930 address to verify.
     function _ensureEmptyChainReference(bytes calldata _interoperableAddress) internal pure {
         require(
-            _interoperableAddress.length >= 5,
+            _interoperableAddress.length >= 6,
             InteroperableAddress.InteroperableAddressParsingError(_interoperableAddress)
         );
         uint8 chainReferenceLength = uint8(_interoperableAddress[0x04]);
@@ -325,7 +325,7 @@ contract InteropCenter is
     /// @param _interoperableAddress The ERC-7930 address to verify.
     function _ensureEmptyAddress(bytes calldata _interoperableAddress) internal pure {
         require(
-            _interoperableAddress.length >= 5,
+            _interoperableAddress.length >= 6,
             InteroperableAddress.InteroperableAddressParsingError(_interoperableAddress)
         );
         uint8 chainReferenceLength = uint8(_interoperableAddress[0x04]);


### PR DESCRIPTION
## Summary
- Changes `>= 5` to `>= 6` in `_ensureEmptyChainReference` and `_ensureEmptyAddress` in InteropCenter.sol
- The minimum valid ERC-7930 v1 address is 6 bytes (4-byte header + 1 byte chainReferenceLength + 1 byte addressLength), consistent with `tryParseV1`/`tryParseV1Calldata` which already check `< 0x06`
- A 5-byte input could pass the first require but lack the required addressLength byte

## Test plan
- [ ] Verify `forge build` passes
- [ ] Confirm 5-byte inputs are rejected by both `_ensureEmptyChainReference` and `_ensureEmptyAddress`
- [ ] Confirm valid 6+ byte inputs still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)