### PR TITLE
L-05: add batchTimestamp <= lastL2BlockTimestamp check

### DIFF
--- a/l1-contracts/contracts/common/L1ContractErrors.sol
+++ b/l1-contracts/contracts/common/L1ContractErrors.sol
@@ -53,6 +53,7 @@ error BaseTokenTransferFailed();
 error BatchHashMismatch(bytes32 expected, bytes32 actual);
 // 0xbd4455ff
 error BatchNumberMismatch(uint256 expectedBatchNumber, uint256 providedBatchNumber);
+error BatchTimestampGreaterThanLastL2BlockTimestamp();
 // 0x6cf12312
 error BridgeHubAlreadyRegistered();
 // 0xdb538614

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Committer.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Committer.sol
@@ -459,6 +459,9 @@ contract CommitterFacet is ZKChainBase, ICommitter {
             revert InvalidTxCountInPriorityMode(_newBatch.numberOfLayer2Txs, _newBatch.numberOfLayer1Txs);
         }
 
+        if (_newBatch.firstBlockTimestamp > _newBatch.lastBlockTimestamp) {
+            revert BatchTimestampGreaterThanLastL2BlockTimestamp();
+        }
         if (block.timestamp - COMMIT_TIMESTAMP_NOT_OLDER > _newBatch.firstBlockTimestamp) {
             revert TimeNotReached(_newBatch.firstBlockTimestamp, block.timestamp - COMMIT_TIMESTAMP_NOT_OLDER);
         }

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Committer.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Committer.sol
@@ -46,6 +46,7 @@ import {IChainTypeManager} from "../../IChainTypeManager.sol";
 import {IL1DAValidator, L1DAValidatorOutput} from "../../chain-interfaces/IL1DAValidator.sol";
 import {
     BatchNumberMismatch,
+    BatchTimestampGreaterThanLastL2BlockTimestamp,
     CanOnlyProcessOneBatch,
     EmptyPrecommitData,
     HashMismatch,
@@ -583,6 +584,13 @@ contract CommitterFacet is ZKChainBase, ICommitter {
         }
 
         uint256 lastL2BlockTimestamp = _packedBatchAndL2BlockTimestamp & PACKED_L2_BLOCK_TIMESTAMP_MASK;
+
+        // Ensure that batchTimestamp <= lastL2BlockTimestamp, which is required for the
+        // [batchTimestamp, lastL2BlockTimestamp] range to be valid.
+        if (batchTimestamp > lastL2BlockTimestamp) {
+            revert BatchTimestampGreaterThanLastL2BlockTimestamp();
+        }
+
         // All L2 blocks have timestamps within the range of [batchTimestamp, lastL2BlockTimestamp].
         // So here we need to only double check that:
         // - The timestamp of the batch is not too small.


### PR DESCRIPTION
## Summary
- Adds explicit validation that `batchTimestamp <= lastL2BlockTimestamp` in `Committer._verifyBatchTimestamp` (old commit path)
- Adds the same `firstBlockTimestamp <= lastBlockTimestamp` check in `_commitOneBatchZKsyncOS` (ZKsync OS commit path), which had the identical gap
- Both paths already validate "not too old" and "not too big" independently, but never compared the two timestamps against each other

## Test plan
- [ ] Verify `forge build` passes
- [ ] Confirm batches with `batchTimestamp > lastL2BlockTimestamp` are rejected (old path)
- [ ] Confirm batches with `firstBlockTimestamp > lastBlockTimestamp` are rejected (ZKsync OS path)
- [ ] Confirm valid batches still pass timestamp verification on both paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)