### PR TITLE
L-07: add missing input validations in Migrator and Mailbox

### DIFF
--- a/l1-contracts/contracts/common/L1ContractErrors.sol
+++ b/l1-contracts/contracts/common/L1ContractErrors.sol
@@ -121,6 +121,7 @@ error EmptyBytes32();
 error EmptyData();
 // 0x95b66fe9
 error EmptyDeposit();
+error ExpirationTimestampMustBeZero();
 // 0x84286507
 error EmptyPrecommitData(uint256 batchNumber);
 // 0x456f8f7a
@@ -348,6 +349,7 @@ error PriorityModeActivationTooEarly(uint256 earliestActivationTimestamp, uint25
 error PriorityModeIsNotAllowed();
 // 0x2b9d9c4c
 error PriorityModeRequiresPermanentRollup();
+error PermanentRollupCannotBeReverted();
 // 0xd5a99014
 error PriorityOperationsRollingHashMismatch();
 // 0xbeda0935

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol
@@ -39,6 +39,7 @@ import {IL1AssetRouter} from "../../../bridge/asset-router/IL1AssetRouter.sol";
 import {IAssetRouterShared} from "../../../bridge/asset-router/IAssetRouterShared.sol";
 import {
     AddressNotZero,
+    ExpirationTimestampMustBeZero,
     GasPerPubdataMismatch,
     InvalidChainId,
     MsgValueTooLow,
@@ -303,6 +304,7 @@ contract MailboxFacet is ZKChainBase, IMailboxImpl, MessageVerification, IMailbo
         uint256 _baseTokenAmount,
         bool _getBalanceChange
     ) public override onlyL1 returns (bytes32 canonicalTxHash) {
+        require(_expirationTimestamp == 0, ExpirationTimestampMustBeZero());
         if (!IBridgehubBase(s.bridgehub).whitelistedSettlementLayers(s.chainId)) {
             revert NotSettlementLayer();
         }

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Migrator.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Migrator.sol
@@ -39,7 +39,7 @@ import {
     VerifiedIsNotConsistentWithCommitted,
     MigrationInProgress
 } from "../../L1StateTransitionErrors.sol";
-import {NotAZKChain, NotCompatibleWithPriorityMode} from "../../../common/L1ContractErrors.sol";
+import {NotAZKChain, NotCompatibleWithPriorityMode, PermanentRollupCannotBeReverted} from "../../../common/L1ContractErrors.sol";
 import {OnlyGateway} from "../../../core/bridgehub/L1BridgehubErrors.sol";
 import {IL1AssetTracker} from "../../../bridge/asset-tracker/IL1AssetTracker.sol";
 import {TxStatus} from "../../../common/Messaging.sol";
@@ -224,6 +224,9 @@ contract MigratorFacet is ZKChainBase, IMigrator {
         s.totalBatchesCommitted = batchesCommitted;
         s.totalBatchesVerified = batchesVerified;
         s.totalBatchesExecuted = batchesExecuted;
+        if (s.isPermanentRollup) {
+            require(_commitment.isPermanentRollup, PermanentRollupCannotBeReverted());
+        }
         s.isPermanentRollup = _commitment.isPermanentRollup;
         s.precommitmentForTheLatestBatch = _commitment.precommitmentForTheLatestBatch;
 


### PR DESCRIPTION
## Summary

### Fixed
- **Migrator.forwardedBridgeMint**: validates that `isPermanentRollup` cannot be reverted from `true` to `false` — a mismatch would indicate a malicious or faulty settlement layer
- **Mailbox.requestL2TransactionToGatewayMailboxWithBalanceChange**: enforces `_expirationTimestamp == 0` as documented in IMailboxImpl ("Deprecated, always 0"). All callers already pass 0

### Not fixed (intentional)
- **InteropCenter.forwardTransactionOnGatewayWithBalanceChange**: the `baseTokenAssetId` overwrite at line 578 IS the safety mechanism — it ensures the correct on-chain value is always used regardless of caller input. Adding a pre-check (`require` that caller value matches) would defeat this purpose and could break legitimate flows where the caller hasn't determined the correct value yet

## Test plan
- [ ] Verify `forge build` passes
- [ ] Confirm `forwardedBridgeMint` reverts when trying to set `isPermanentRollup` from `true` to `false`
- [ ] Confirm `requestL2TransactionToGatewayMailboxWithBalanceChange` reverts with non-zero `_expirationTimestamp`
- [ ] Confirm normal migration flows are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)