### PR TITLE
N-03: add IERC7786Recipient to InteropHandler inheritance

### DIFF
--- a/l1-contracts/contracts/interop/InteropHandler.sol
+++ b/l1-contracts/contracts/interop/InteropHandler.sol
@@ -52,7 +52,7 @@ import {IAssetTrackerDataEncoding} from "../bridge/asset-tracker/IAssetTrackerDa
 /// @author Matter Labs
 /// @custom:security-contact security@matterlabs.dev
 /// @dev This contract serves as the entry-point for executing, verifying and unbundling interop bundles.
-contract InteropHandler is IInteropHandler, ReentrancyGuard {
+contract InteropHandler is IInteropHandler, IERC7786Recipient, ReentrancyGuard {
     /// @notice The chain ID of L1. This contract can be deployed on multiple layers, but this value is still equal to the
     /// L1 that is at the most base layer.
     uint256 public L1_CHAIN_ID;


### PR DESCRIPTION
## Summary
- Adds `IERC7786Recipient` to `InteropHandler`'s inheritance list
- The contract already imports the interface and implements `receiveMessage`, but did not formally declare ERC-7786 compliance at the type level

## Test plan
- [ ] Verify `forge build` passes
- [ ] Confirm InteropHandler still correctly processes `receiveMessage` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)