### PR TITLE
N-04: revert on invalid BUNDLE_IDENTIFIER in GWAssetTracker

### DIFF
--- a/l1-contracts/contracts/bridge/asset-tracker/GWAssetTracker.sol
+++ b/l1-contracts/contracts/bridge/asset-tracker/GWAssetTracker.sol
@@ -40,6 +40,7 @@ import {AssetRouterBase} from "../asset-router/AssetRouterBase.sol";
 import {INativeTokenVaultBase} from "../ntv/INativeTokenVaultBase.sol";
 import {
     ChainIdNotRegistered,
+    InvalidBundleIdentifier,
     InvalidInteropCalldata,
     InvalidMessage,
     ReconstructionMismatch,
@@ -496,8 +497,7 @@ contract GWAssetTracker is AssetTrackerBase, IGWAssetTracker {
         bytes calldata _message
     ) internal returns (uint256 chargeableCallCount) {
         if (_message[0] != BUNDLE_IDENTIFIER) {
-            // This should not be possible in V31. In V31 this will be a trigger.
-            return 0;
+            revert InvalidBundleIdentifier();
         }
 
         InteropBundle memory interopBundle = abi.decode(_message[1:], (InteropBundle));

--- a/l1-contracts/contracts/common/L1ContractErrors.sol
+++ b/l1-contracts/contracts/common/L1ContractErrors.sol
@@ -172,6 +172,7 @@ error IncorrectTokenAddressFromNTV(bytes32 assetId, address tokenAddress);
 error InsufficientFunds(uint256 required, uint256 actual);
 // 0x9bf8b9aa
 error InvalidBatchNumber(uint256 provided, uint256 expected);
+error InvalidBundleIdentifier();
 // 0xd438e1fa
 error InvalidBlockRange(uint64 batchNumber, uint64 from, uint64 to);
 // 0xcbd9d2e0


### PR DESCRIPTION
## Summary
- Replaces `return 0` with `revert InvalidBundleIdentifier()` in `GWAssetTracker._handleInteropCenterMessage` when `BUNDLE_IDENTIFIER` check fails
- The existing comment stated this should not be possible in V31 and should trigger a revert, but the code silently returned 0 instead

## Test plan
- [ ] Verify `forge build` passes
- [ ] Confirm invalid messages (wrong first byte) cause a revert instead of silent return
- [ ] Confirm valid bundle messages still process correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)