### PR TITLE
N-13: fix misleading or incomplete comments

### DIFF
--- a/l1-contracts/contracts/bridge/asset-router/AssetRouterBase.sol
+++ b/l1-contracts/contracts/bridge/asset-router/AssetRouterBase.sol
@@ -236,7 +236,7 @@ abstract contract AssetRouterBase is IAssetRouterBase, Ownable2StepUpgradeable, 
     /// @dev send the burn message to the asset
     /// @notice Forwards the burn request for specific asset to respective asset handler.
     /// @param _chainId The chain ID of the ZK chain to which to deposit.
-    /// @param _nextMsgValue The L2 `msg.value` from the L1 -> L2 deposit transaction.
+    /// @param _nextMsgValue The L2 `msg.value` from the deposit or interop transaction.
     /// @param _assetId The deposited asset ID.
     /// @param _originalCaller The `msg.sender` address from the external call that initiated current one.
     /// @param _transferData The encoded data, which is used by the asset handler to determine L2 recipient and amount. Might include extra information.

--- a/l1-contracts/contracts/core/chain-asset-handler/ChainAssetHandlerBase.sol
+++ b/l1-contracts/contracts/core/chain-asset-handler/ChainAssetHandlerBase.sol
@@ -365,7 +365,7 @@ abstract contract ChainAssetHandlerBase is
             if (zkChain == address(0)) {
                 revert ChainIdNotRegistered(bridgehubMintData.chainId);
             }
-            // We want to allow any chain to be migrated,
+            // We want to allow any chain to be migrated, so we register it unconditionally.
             IBridgehubBase(_bridgehub()).registerNewZKChain(bridgehubMintData.chainId, zkChain, false);
             _messageRoot().addNewChain(bridgehubMintData.chainId, bridgehubMintData.batchNumber);
         } else {

--- a/l1-contracts/contracts/state-transition/chain-interfaces/IMigrator.sol
+++ b/l1-contracts/contracts/state-transition/chain-interfaces/IMigrator.sol
@@ -19,7 +19,7 @@ interface IMigrator is IZKChainBase {
     /// @notice Emitted when deposits are unpaused.
     event DepositsUnpaused(uint256 chainId);
 
-    /// @notice Pauses deposits before initiating migration to the Gateway.
+    /// @notice Pauses deposits before initiating a chain migration (L1 → GW or GW → L1).
     function pauseDepositsBeforeInitiatingMigration() external;
 
     /// @notice Unpauses deposits, used after the chain is initialized


### PR DESCRIPTION
## Summary
- **IMigrator.sol**: clarify `pauseDepositsBeforeInitiatingMigration` applies to both L1→GW and GW→L1 migrations
- **AssetRouterBase._burn**: update param comment to reflect v31 interop usage, not just L1→L2 deposits
- **ChainAssetHandlerBase.bridgeMint**: complete trailing sentence fragment

## Test plan
- [ ] Verify `forge build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)