### PR TITLE
N-10: remove unused constant and modifiers

### DIFF
--- a/l1-contracts/contracts/bridge/asset-tracker/AssetTrackerBase.sol
+++ b/l1-contracts/contracts/bridge/asset-tracker/AssetTrackerBase.sol
@@ -6,16 +6,12 @@ import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable-v4/ac
 import {ReentrancyGuard} from "../../common/ReentrancyGuard.sol";
 
 import {IAssetTrackerBase} from "./IAssetTrackerBase.sol";
-import {GatewayToL1TokenBalanceMigrationData, L1ToGatewayTokenBalanceMigrationData} from "../../common/Messaging.sol";
-
-import {L2_TO_L1_MESSENGER_SYSTEM_CONTRACT} from "../../common/l2-helpers/L2ContractInterfaces.sol";
 import {INativeTokenVaultBase} from "../ntv/INativeTokenVaultBase.sol";
 import {Unauthorized} from "../../common/L1ContractErrors.sol";
 import {DynamicIncrementalMerkleMemory} from "../../common/libraries/DynamicIncrementalMerkleMemory.sol";
 import {SERVICE_TRANSACTION_SENDER} from "../../common/Config.sol";
 import {AssetHandlerModifiers} from "../interfaces/AssetHandlerModifiers.sol";
 import {InsufficientChainBalance} from "./AssetTrackerErrors.sol";
-import {IAssetTrackerDataEncoding} from "./IAssetTrackerDataEncoding.sol";
 
 abstract contract AssetTrackerBase is
     IAssetTrackerBase,
@@ -126,24 +122,6 @@ abstract contract AssetTrackerBase is
             revert InsufficientChainBalance(_chainId, _assetId, _amount);
         }
         chainBalance[_chainId][_assetId] -= _amount;
-    }
-
-    /// @notice Sends L1 -> Gateway migration data to L1 through the L2->L1 messenger.
-    /// @param _data The migration payload.
-    function _sendL1ToGatewayMigrationDataToL1(L1ToGatewayTokenBalanceMigrationData memory _data) internal {
-        // slither-disable-next-line unused-return,reentrancy-no-eth
-        L2_TO_L1_MESSENGER_SYSTEM_CONTRACT.sendToL1(
-            abi.encodeCall(IAssetTrackerDataEncoding.receiveL1ToGatewayMigrationOnL1, _data)
-        );
-    }
-
-    /// @notice Sends Gateway -> L1 migration data to L1 through the L2->L1 messenger.
-    /// @param _data The migration payload.
-    function _sendGatewayToL1MigrationDataToL1(GatewayToL1TokenBalanceMigrationData memory _data) internal {
-        // slither-disable-next-line unused-return,reentrancy-no-eth
-        L2_TO_L1_MESSENGER_SYSTEM_CONTRACT.sendToL1(
-            abi.encodeCall(IAssetTrackerDataEncoding.receiveGatewayToL1MigrationOnL1, _data)
-        );
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/l1-contracts/contracts/bridge/asset-tracker/GWAssetTracker.sol
+++ b/l1-contracts/contracts/bridge/asset-tracker/GWAssetTracker.sol
@@ -30,6 +30,7 @@ import {
     L2_KNOWN_CODE_STORAGE_SYSTEM_CONTRACT_ADDR,
     L2_MESSAGE_ROOT,
     L2_NATIVE_TOKEN_VAULT,
+    L2_TO_L1_MESSENGER_SYSTEM_CONTRACT,
     L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR,
     MAX_BUILT_IN_CONTRACT_ADDR,
     L2_ASSET_ROUTER,
@@ -732,6 +733,15 @@ contract GWAssetTracker is AssetTrackerBase, IGWAssetTracker {
         assetMigrationNumber[_chainId][_assetId] = chainMigrationNumber;
 
         emit GatewayToL1MigrationInitiated(_assetId, _chainId, amount);
+    }
+
+    /// @notice Sends Gateway -> L1 migration data to L1 through the L2->L1 messenger.
+    /// @param _data The migration payload.
+    function _sendGatewayToL1MigrationDataToL1(GatewayToL1TokenBalanceMigrationData memory _data) internal {
+        // slither-disable-next-line unused-return,reentrancy-no-eth
+        L2_TO_L1_MESSENGER_SYSTEM_CONTRACT.sendToL1(
+            abi.encodeCall(IAssetTrackerDataEncoding.receiveGatewayToL1MigrationOnL1, _data)
+        );
     }
 
     function _calculatePreviousChainMigrationNumber(uint256 _chainId) internal view returns (uint256) {

--- a/l1-contracts/contracts/bridge/asset-tracker/IAssetTrackerBase.sol
+++ b/l1-contracts/contracts/bridge/asset-tracker/IAssetTrackerBase.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.21;
 
 bytes1 constant BALANCE_CHANGE_VERSION = bytes1(uint8(1));
 bytes1 constant TOKEN_BALANCE_MIGRATION_DATA_VERSION = bytes1(uint8(1));
-bytes1 constant INTEROP_BALANCE_CHANGE_VERSION = bytes1(uint8(1));
 uint256 constant MAX_TOKEN_BALANCE = type(uint256).max;
 
 struct SavedTotalSupply {

--- a/l1-contracts/contracts/bridge/asset-tracker/L2AssetTracker.sol
+++ b/l1-contracts/contracts/bridge/asset-tracker/L2AssetTracker.sol
@@ -33,6 +33,8 @@ import {
 } from "./AssetTrackerErrors.sol";
 import {AssetTrackerBase} from "./AssetTrackerBase.sol";
 import {IL2AssetTracker} from "./IL2AssetTracker.sol";
+import {IAssetTrackerDataEncoding} from "./IAssetTrackerDataEncoding.sol";
+import {L2_TO_L1_MESSENGER_SYSTEM_CONTRACT} from "../../common/l2-helpers/L2ContractInterfaces.sol";
 
 contract L2AssetTracker is AssetTrackerBase, IL2AssetTracker {
     uint256 public L1_CHAIN_ID;
@@ -443,6 +445,15 @@ contract L2AssetTracker is AssetTrackerBase, IL2AssetTracker {
         _sendL1ToGatewayMigrationDataToL1(tokenBalanceMigrationData);
 
         emit IL2AssetTracker.L1ToGatewayMigrationInitiated(_assetId, block.chainid);
+    }
+
+    /// @notice Sends L1 -> Gateway migration data to L1 through the L2->L1 messenger.
+    /// @param _data The migration payload.
+    function _sendL1ToGatewayMigrationDataToL1(L1ToGatewayTokenBalanceMigrationData memory _data) internal {
+        // slither-disable-next-line unused-return,reentrancy-no-eth
+        L2_TO_L1_MESSENGER_SYSTEM_CONTRACT.sendToL1(
+            abi.encodeCall(IAssetTrackerDataEncoding.receiveL1ToGatewayMigrationOnL1, _data)
+        );
     }
 
     /// @notice Confirms a migration operation has been completed and updates the asset migration number.

--- a/system-contracts/contracts/abstract/SystemContractBase.sol
+++ b/system-contracts/contracts/abstract/SystemContractBase.sol
@@ -3,12 +3,10 @@
 pragma solidity ^0.8.20;
 
 import {SystemContractHelper} from "../libraries/SystemContractHelper.sol";
-import {BOOTLOADER_FORMAL_ADDRESS, L2_INTEROP_CENTER_ADDRESS, L2_INTEROP_HANDLER_ADDRESS} from "../Constants.sol";
-import {L2_NATIVE_TOKEN_VAULT} from "../Contracts.sol";
+import {BOOTLOADER_FORMAL_ADDRESS} from "../Constants.sol";
 import {
     CallerMustBeBootloader,
     CallerMustBeEvmContract,
-    CallerMustBeInteropCenterOrNTV,
     CallerMustBeSystemContract,
     SystemCallFlagRequired,
     Unauthorized
@@ -69,21 +67,4 @@ abstract contract SystemContractBase {
         _;
     }
 
-    /// @notice Modifier that makes sure that the method
-    /// can only be called from the bootloader.
-    modifier onlyCallFromBootloaderOrInteropHandler() {
-        if (msg.sender != BOOTLOADER_FORMAL_ADDRESS && msg.sender != L2_INTEROP_HANDLER_ADDRESS) {
-            revert CallerMustBeBootloader();
-        }
-        _;
-    }
-
-    /// @notice Modifier that makes sure that the method
-    /// can only be called from the interop center or the NTV.
-    modifier onlyCallFromInteropCenterOrNTV() {
-        if (msg.sender != L2_INTEROP_CENTER_ADDRESS && msg.sender != address(L2_NATIVE_TOKEN_VAULT)) {
-            revert CallerMustBeInteropCenterOrNTV();
-        }
-        _;
-    }
 }


### PR DESCRIPTION
## Summary

### Addressed
- Remove unused `INTEROP_BALANCE_CHANGE_VERSION` constant from `IAssetTrackerBase.sol` (zero references in codebase)
- Remove unused `onlyCallFromBootloaderOrInteropHandler` and `onlyCallFromInteropCenterOrNTV` modifiers from `SystemContractBase.sol` (zero references), along with their now-unused imports
- Move `_sendL1ToGatewayMigrationDataToL1` from `AssetTrackerBase` to `L2AssetTracker` (its only caller)
- Move `_sendGatewayToL1MigrationDataToL1` from `AssetTrackerBase` to `GWAssetTracker` (its only caller)
- Clean up now-unused imports in `AssetTrackerBase`

### Skipped
- **`SAVED_TOTAL_SUPPLY` / `isSaved` field**: actively used in `L2AssetTracker.sol:119` — audit claim is incorrect
- **Redundant imports (`FinalizeDepositParams`, `IBridgehubBase`, `MigrationConfirmationData`)**: claims don't hold for current code — these symbols are either directly used in contract bodies or no longer present
- **`receive()` in `BaseTokenHolder`**: used on ZK OS chains during `L2BaseTokenZKOS.initL2()` which sends ETH via `Address.sendValue` — audit only considered the Era path where balance is set via storage
- **Chain ID check in `_finalizeBridgeBurn`**: defense-in-depth; the `block.chainid == _l1ChainId()` guard makes the L1-only intent explicit at the call site even though `_recordMigrationToSL` is only implemented on L1

## Test plan
- [ ] Verify `forge build` passes for both l1-contracts and system-contracts
- [ ] Confirm no references to removed symbols exist
- [ ] Confirm L2AssetTracker and GWAssetTracker migration flows work with relocated functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)