### PR TITLE
N-09: fix naming inconsistencies for v31

### DIFF
--- a/l1-contracts/contracts/bridge/asset-router/AssetRouterBase.sol
+++ b/l1-contracts/contracts/bridge/asset-router/AssetRouterBase.sol
@@ -252,8 +252,8 @@ abstract contract AssetRouterBase is IAssetRouterBase, Ownable2StepUpgradeable, 
         bool _passValue,
         address _nativeTokenVault
     ) internal returns (bytes memory bridgeMintCalldata) {
-        address l1AssetHandler = assetHandlerAddress[_assetId];
-        if (l1AssetHandler == address(0)) {
+        address assetHandler = assetHandlerAddress[_assetId];
+        if (assetHandler == address(0)) {
             // As a UX feature, whenever an asset handler is not present, we always try to register asset within native token vault.
             // The Native Token Vault is trusted to revert in an asset does not belong to it.
             //
@@ -265,11 +265,11 @@ abstract contract AssetRouterBase is IAssetRouterBase, Ownable2StepUpgradeable, 
             // We do not do any additional transformations here (like setting `assetHandler` in the mapping),
             // because we expect that all those happened inside `tryRegisterTokenFromBurnData`
 
-            l1AssetHandler = _nativeTokenVault;
+            assetHandler = _nativeTokenVault;
         }
 
         uint256 msgValue = _passValue ? msg.value : 0;
-        bridgeMintCalldata = IAssetHandler(l1AssetHandler).bridgeBurn{value: msgValue}({
+        bridgeMintCalldata = IAssetHandler(assetHandler).bridgeBurn{value: msgValue}({
             _chainId: _chainId,
             _msgValue: _nextMsgValue,
             _assetId: _assetId,

--- a/l1-contracts/contracts/state-transition/L1StateTransitionErrors.sol
+++ b/l1-contracts/contracts/state-transition/L1StateTransitionErrors.sol
@@ -76,8 +76,6 @@ error NotEnoughSignatures();
 error NotEraChain();
 // 0xa7050bf6
 error NotHistoricalRoot(bytes32);
-// 0x32ddf9a2
-error NotHyperchain();
 // 0x87470e36
 error NotL1(uint256 blockChainId);
 // 0x1e9f6a9e

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol
@@ -42,13 +42,14 @@ import {
     GasPerPubdataMismatch,
     InvalidChainId,
     MsgValueTooLow,
+    NotAZKChain,
     NotAssetRouter,
     OnlyEraSupported,
     TooManyFactoryDeps,
     TransactionNotAllowed,
     ZeroAddress
 } from "../../../common/L1ContractErrors.sol";
-import {DepositsPaused, NotHyperchain, NotL1, NotSettlementLayer} from "../../L1StateTransitionErrors.sol";
+import {DepositsPaused, NotL1, NotSettlementLayer} from "../../L1StateTransitionErrors.sol";
 
 // While formally the following import is not used, it is needed to inherit documentation from it
 import {IZKChainBase} from "../../chain-interfaces/IZKChainBase.sol";
@@ -307,7 +308,7 @@ contract MailboxFacet is ZKChainBase, IMailboxImpl, MessageVerification, IMailbo
             revert NotSettlementLayer();
         }
         if (IBridgehubBase(s.bridgehub).getZKChain(_chainId) != msg.sender) {
-            revert NotHyperchain();
+            revert NotAZKChain(msg.sender);
         }
         // Note during the upgrade to V31 no chain will be on GW.
 

--- a/l1-contracts/test/foundry/l1/unit/concrete/state-transition/chain-deps/facets/Mailbox/MailboxExtended.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/state-transition/chain-deps/facets/Mailbox/MailboxExtended.t.sol
@@ -20,10 +20,9 @@ import {IChainAssetHandlerBase} from "contracts/core/chain-asset-handler/IChainA
 
 import {IEIP7702Checker} from "contracts/state-transition/chain-interfaces/IEIP7702Checker.sol";
 
-import {AddressNotZero, ZeroAddress} from "contracts/common/L1ContractErrors.sol";
+import {AddressNotZero, NotAZKChain, ZeroAddress} from "contracts/common/L1ContractErrors.sol";
 import {
     DepositsPaused,
-    NotHyperchain,
     NotL1,
     NotSettlementLayer
 } from "contracts/state-transition/L1StateTransitionErrors.sol";


### PR DESCRIPTION
## Summary

### Addressed
- Replace `NotHyperchain()` with `NotAZKChain(msg.sender)` in `Mailbox.requestL2TransactionToGatewayMailboxWithBalanceChange` — uses the existing error from `L1ContractErrors` which follows current ZKChain terminology and includes the caller address for better debuggability. Removes the now-unused `NotHyperchain` definition from `L1StateTransitionErrors.sol`
- Rename `l1AssetHandler` → `assetHandler` in `AssetRouterBase._burn` — the variable holds the resolved handler for the given assetId, which may be an L2 handler in interop (L2→L2) flows; the "l1" prefix is misleading since v31

## Test plan
- [ ] Verify `forge build` passes
- [ ] Confirm `NotAZKChain` is reverted with the correct sender address when caller is not the expected ZKChain

🤖 Generated with [Claude Code](https://claude.com/claude-code)