### PR TITLE
N-08: use dynamic origin chain lookup for base token finalization

### DIFF
--- a/l1-contracts/contracts/bridge/asset-tracker/L2AssetTracker.sol
+++ b/l1-contracts/contracts/bridge/asset-tracker/L2AssetTracker.sol
@@ -391,7 +391,7 @@ contract L2AssetTracker is AssetTrackerBase, IL2AssetTracker {
             _fromChainId: _fromChainId,
             _assetId: baseTokenAssetId,
             _amount: _amount,
-            _tokenOriginChainId: L1_CHAIN_ID,
+            _tokenOriginChainId: L2_NATIVE_TOKEN_VAULT.originChainId(baseTokenAssetId),
             _tokenAddress: address(L2_BASE_TOKEN_SYSTEM_CONTRACT)
         });
     }


### PR DESCRIPTION
## Summary
- Replace hardcoded `L1_CHAIN_ID` with `L2_NATIVE_TOKEN_VAULT.originChainId(baseTokenAssetId)` in `L2AssetTracker.handleFinalizeBaseTokenBridgingOnL2`
- A base token can originate from a chain other than L1 (e.g. a token first deployed on another L2), so the hardcoded value is incorrect in the general case
- The initiate path (`handleInitiateBaseTokenBridgingOnL2`, line 269) already uses the dynamic NTV lookup — this makes the finalize path consistent

## Test plan
- [ ] Verify `forge build` passes
- [ ] Confirm base token finalization uses the correct origin chain for tokens not originating on L1

🤖 Generated with [Claude Code](https://claude.com/claude-code)