### PR TITLE
L-02: validate ERC-7930 format of bundle addresses on source chain

### DIFF
--- a/l1-contracts/contracts/interop/InteropCenter.sol
+++ b/l1-contracts/contracts/interop/InteropCenter.sol
@@ -634,6 +634,10 @@ contract InteropCenter is
                 );
                 attributeUsed[2] = true;
                 bundleAttributes.executionAddress = AttributesDecoder.decodeInteroperableAddress(_attributes[i]);
+                // Validate ERC-7930 format early to prevent unexecutable bundles that lock funds.
+                if (bundleAttributes.executionAddress.length > 0) {
+                    InteroperableAddress.parseEvmV1(bundleAttributes.executionAddress);
+                }
             } else if (selector == IERC7786Attributes.unbundlerAddress.selector) {
                 require(!attributeUsed[3], AttributeAlreadySet(selector));
                 require(
@@ -643,6 +647,10 @@ contract InteropCenter is
                 );
                 attributeUsed[3] = true;
                 bundleAttributes.unbundlerAddress = AttributesDecoder.decodeInteroperableAddress(_attributes[i]);
+                // Validate ERC-7930 format early to prevent unexecutable bundles that lock funds.
+                if (bundleAttributes.unbundlerAddress.length > 0) {
+                    InteroperableAddress.parseEvmV1(bundleAttributes.unbundlerAddress);
+                }
             } else if (selector == IERC7786Attributes.useFixedFee.selector) {
                 require(!attributeUsed[4], AttributeAlreadySet(selector));
                 require(


### PR DESCRIPTION
## Summary
- Adds early ERC-7930 format validation for `executionAddress` and `unbundlerAddress` in `InteropCenter.parseAttributes`
- Previously these were only validated on the destination chain in `InteropHandler.parseEvmV1`, meaning a malformed address would cause bundle execution to permanently fail with funds locked in `pendingInteropBalance`
- Only validates when the address is explicitly provided (non-empty); empty addresses are defaulted to valid values later in `sendMessage`/`sendBundle`

## Test plan
- [ ] Verify `forge build` passes
- [ ] Confirm `sendMessage` with a malformed `executionAddress` attribute reverts on the source chain
- [ ] Confirm `sendMessage` with a malformed `unbundlerAddress` attribute reverts on the source chain
- [ ] Confirm valid ERC-7930 addresses still pass through without issue
- [ ] Confirm omitting both addresses (empty) still works (defaults applied downstream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)