### PR TITLE
[v31] local-upgrade validation fixes (era-cacher end-to-end)

### DIFF
--- a/l1-contracts/contracts/l2-upgrades/L2GenesisForceDeploymentsHelper.sol
+++ b/l1-contracts/contracts/l2-upgrades/L2GenesisForceDeploymentsHelper.sol
@@ -351,14 +351,13 @@ library L2GenesisForceDeploymentsHelper {
             _fixedForceDeploymentsData.aliasedL1Governance
         );
 
-        bytes32 previousL2TokenProxyBytecodeHash = L2NativeTokenVault(L2_NATIVE_TOKEN_VAULT_ADDR)
-            .L2_TOKEN_PROXY_BYTECODE_HASH();
-
         // solhint-disable-next-line func-named-parameters
         L2NativeTokenVault(L2_NATIVE_TOKEN_VAULT_ADDR).updateL2(
             _fixedForceDeploymentsData.l1ChainId,
             _fixedForceDeploymentsData.aliasedL1Governance,
-            previousL2TokenProxyBytecodeHash,
+            // Legacy Era chains exposed this via an immutable. After the v31 code replacement,
+            // reading it back from storage returns zero, so the L1-provided value is authoritative.
+            _fixedForceDeploymentsData.l2TokenProxyBytecodeHash,
             _getLegacySharedBridge(),
             _wrappedBaseTokenAddress,
             _additionalForceDeploymentsData.baseTokenBridgingData,

--- a/l1-contracts/deploy-scripts/AdminFunctions.s.sol
+++ b/l1-contracts/deploy-scripts/AdminFunctions.s.sol
@@ -34,8 +34,17 @@ import {IL2AssetRouter} from "contracts/bridge/asset-router/IL2AssetRouter.sol";
 import {NEW_ENCODING_VERSION} from "contracts/bridge/asset-router/IAssetRouterBase.sol";
 import {L2DACommitmentScheme} from "contracts/common/Config.sol";
 import {IL1AssetRouter} from "contracts/bridge/asset-router/IL1AssetRouter.sol";
+import {SemVer} from "contracts/common/libraries/SemVer.sol";
 
 bytes32 constant SET_TOKEN_MULTIPLIER_SETTER_ROLE = keccak256("SET_TOKEN_MULTIPLIER_SETTER_ROLE");
+
+/// @dev First protocol minor version that switched `upgradeChainFromVersion` to its 3-argument form
+/// (adding the chain address). Source chains below this version still expect the legacy 2-arg signature.
+uint32 constant UPGRADE_CHAIN_FROM_VERSION_3ARG_MINOR = 31;
+
+/// @dev Selector of the legacy `upgradeChainFromVersion(uint256,DiamondCutData)` signature used by
+/// ZKChain admin facets at protocol minor versions below {UPGRADE_CHAIN_FROM_VERSION_3ARG_MINOR}.
+bytes4 constant LEGACY_UPGRADE_CHAIN_FROM_VERSION_SELECTOR = 0xfc57565f;
 
 contract AdminFunctions is Script, IAdminFunctions {
     using stdToml for string;
@@ -238,11 +247,11 @@ contract AdminFunctions is Script, IAdminFunctions {
             currentProtocolVersion
         );
 
+        (, uint32 oldMinor, ) = SemVer.unpackSemVer(uint96(currentProtocolVersion));
         bytes memory upgradeCall;
-        uint256 oldMinor = (currentProtocolVersion >> 32) & 0xFFFF;
-        if (oldMinor < 31) {
+        if (oldMinor < UPGRADE_CHAIN_FROM_VERSION_3ARG_MINOR) {
             upgradeCall = abi.encodeWithSelector(
-                bytes4(0xfc57565f), // upgradeChainFromVersion(uint256,DiamondCutData)
+                LEGACY_UPGRADE_CHAIN_FROM_VERSION_SELECTOR,
                 currentProtocolVersion,
                 diamondCut
             );

--- a/l1-contracts/deploy-scripts/AdminFunctions.s.sol
+++ b/l1-contracts/deploy-scripts/AdminFunctions.s.sol
@@ -238,12 +238,27 @@ contract AdminFunctions is Script, IAdminFunctions {
             currentProtocolVersion
         );
 
+        bytes memory upgradeCall;
+        uint256 oldMinor = (currentProtocolVersion >> 32) & 0xFFFF;
+        if (oldMinor < 31) {
+            upgradeCall = abi.encodeWithSelector(
+                bytes4(0xfc57565f), // upgradeChainFromVersion(uint256,DiamondCutData)
+                currentProtocolVersion,
+                diamondCut
+            );
+        } else {
+            upgradeCall = abi.encodeCall(
+                IAdmin.upgradeChainFromVersion,
+                (chainAddress, currentProtocolVersion, diamondCut)
+            );
+        }
+
         // Execute the upgrade through the admin flow
         Utils.adminExecute(
             adminAddr,
             accessControlRestriction,
             chainAddress,
-            abi.encodeCall(IAdmin.upgradeChainFromVersion, (chainAddress, currentProtocolVersion, diamondCut)),
+            upgradeCall,
             0
         );
 

--- a/l1-contracts/deploy-scripts/ecosystem/CoreOnGatewayHelper.sol
+++ b/l1-contracts/deploy-scripts/ecosystem/CoreOnGatewayHelper.sol
@@ -35,7 +35,8 @@ import {
     L2_NTV_BEACON_DEPLOYER_ADDR,
     L2_TO_L1_MESSENGER_SYSTEM_CONTRACT_ADDR,
     L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT_ADDR,
-    L2_DEPLOYER_SYSTEM_CONTRACT_ADDR
+    L2_DEPLOYER_SYSTEM_CONTRACT_ADDR,
+    L2_VERSION_SPECIFIC_UPGRADER_ADDR
 } from "contracts/common/l2-helpers/L2ContractAddresses.sol";
 
 /// @title CoreOnGatewayHelper
@@ -81,6 +82,11 @@ library CoreOnGatewayHelper {
     function getCreate2DerivedForceDeploymentAddr(bool _isZKsyncOS, CoreContract _c) internal view returns (address) {
         // FIXME: add support for additional force deployments on ZKsyncOS in scripts.
         require(!_isZKsyncOS, "Additional force deployments are not supported for ZKsyncOS scripts");
+        // Era version-specific upgrader contracts must live at the canonical predeploy slot
+        // because the upgrade transaction delegatecalls that fixed address.
+        if (_c == CoreContract.L2V31Upgrade) {
+            return L2_VERSION_SPECIFIC_UPGRADER_ADDR;
+        }
         return Utils.getL2AddressViaCreate2Factory(bytes32(0), getDeployedBytecodeHash(false, _c), hex"");
     }
 
@@ -118,6 +124,11 @@ library CoreOnGatewayHelper {
 
         factoryDeps = SystemContractsProcessing.mergeBytesArrays(basicDependencies, sharedDependencies);
         factoryDeps = SystemContractsProcessing.mergeBytesArrays(factoryDeps, additionalDependencies);
+        if (!_isZKsyncOS) {
+            bytes[] memory proxyDependency = new bytes[](1);
+            proxyDependency[0] = ContractsBytecodesLib.getCreationCodeEra("TransparentUpgradeableProxy");
+            factoryDeps = SystemContractsProcessing.mergeBytesArrays(factoryDeps, proxyDependency);
+        }
         factoryDeps = SystemContractsProcessing.deduplicateBytecodes(factoryDeps);
     }
 
@@ -138,11 +149,14 @@ library CoreOnGatewayHelper {
             return new CoreContract[](0);
         }
 
-        dependencyContracts = new CoreContract[](4);
+        dependencyContracts = new CoreContract[](5);
         dependencyContracts[0] = CoreContract.L2SharedBridgeLegacy;
         dependencyContracts[1] = CoreContract.BridgedStandardERC20;
         dependencyContracts[2] = CoreContract.DiamondProxy;
         dependencyContracts[3] = CoreContract.ProxyAdmin;
+        // L2NativeTokenVault deploys bridged ERC20 proxies via BeaconProxy during deposits.
+        // The upgrade tx must therefore publish this bytecode as a known code hash up front.
+        dependencyContracts[4] = CoreContract.BeaconProxy;
     }
 
     function _getFactoryDependencyBytecodes(

--- a/l1-contracts/deploy-scripts/upgrade/SystemContractsProcessing.s.sol
+++ b/l1-contracts/deploy-scripts/upgrade/SystemContractsProcessing.s.sol
@@ -194,7 +194,7 @@ library SystemContractsProcessing {
     /// @dev Loads Era (zkout) bytecodes.
     function getOtherBuiltinContracts() internal view returns (BuiltinContractDeployInfo[] memory contracts) {
         CoreContract[] memory ids = getOtherBuiltinCoreContracts();
-        contracts = new BuiltinContractDeployInfo[](ids.length);
+        contracts = new BuiltinContractDeployInfo[](ids.length + 1);
         for (uint256 i = 0; i < ids.length; i++) {
             string memory eraName = CoreOnGatewayHelper._resolveContractName(false, ids[i]);
             contracts[i] = BuiltinContractDeployInfo({
@@ -203,6 +203,17 @@ library SystemContractsProcessing {
                 bytecode: ContractsBytecodesLib.getCreationCodeEra(eraName)
             });
         }
+        // ProxyAdmin is not part of the standard Era built-ins list, but v31 upgrade logic
+        // unconditionally calls it from `_setupProxyAdmin()`, so it must be force-deployed.
+        contracts[ids.length] = BuiltinContractDeployInfo({
+            id: CoreContract.ProxyAdmin,
+            addr: L2_SYSTEM_CONTRACT_PROXY_ADMIN_ADDR,
+            bytecode: BytecodeUtils.readBytecodeL1(
+                false,
+                "SystemContractProxyAdmin.sol",
+                "SystemContractProxyAdmin"
+            )
+        });
     }
 
     /// @notice Build Era-style ForceDeployment[] from the built-in contracts list.

--- a/l1-contracts/deploy-scripts/upgrade/default-upgrade/DefaultCTMUpgrade.s.sol
+++ b/l1-contracts/deploy-scripts/upgrade/default-upgrade/DefaultCTMUpgrade.s.sol
@@ -91,6 +91,7 @@ contract DefaultCTMUpgrade is Script, CTMUpgradeBase {
 
     struct PermanentCTMConfig {
         bytes32 create2FactorySalt;
+        address create2FactoryAddress;
         address ctmProxy;
         address bytecodesSupplier;
         bool isZKsyncOS;
@@ -122,6 +123,7 @@ contract DefaultCTMUpgrade is Script, CTMUpgradeBase {
         bool isZKsyncOS,
         address rollupDAManager,
         bytes32 create2FactorySalt,
+        address create2FactoryAddress,
         string memory newConfigPath,
         string memory _outputPath,
         address governance,
@@ -135,6 +137,7 @@ contract DefaultCTMUpgrade is Script, CTMUpgradeBase {
             isZKsyncOS,
             rollupDAManager,
             create2FactorySalt,
+            create2FactoryAddress,
             newConfigPath,
             governance,
             zkTokenAssetId
@@ -155,6 +158,9 @@ contract DefaultCTMUpgrade is Script, CTMUpgradeBase {
         // When zero, the script falls back to the CREATE2_FACTORY_SALT env var or built-in default.
         if (permanentConfig.create2FactorySalt != bytes32(0)) {
             setCreate2Salt(permanentConfig.create2FactorySalt);
+        }
+        if (permanentConfig.create2FactoryAddress != address(0)) {
+            setCreate2FactoryAddress(permanentConfig.create2FactoryAddress);
         }
         config.l1ChainId = block.chainid;
         newConfig.ctm = permanentConfig.ctmProxy;
@@ -199,6 +205,7 @@ contract DefaultCTMUpgrade is Script, CTMUpgradeBase {
         bool isZKsyncOS,
         address rollupDAManager,
         bytes32 create2FactorySalt,
+        address create2FactoryAddress,
         string memory newConfigPath,
         address governance,
         bytes32 zkTokenAssetId
@@ -210,6 +217,7 @@ contract DefaultCTMUpgrade is Script, CTMUpgradeBase {
             bytecodesSupplier: bytecodesSupplier,
             isZKsyncOS: isZKsyncOS,
             create2FactorySalt: create2FactorySalt,
+            create2FactoryAddress: create2FactoryAddress,
             zkTokenAssetId: zkTokenAssetId
         });
         // Set config.isZKsyncOS before getChainCreationParamsConfig.

--- a/l1-contracts/deploy-scripts/upgrade/default-upgrade/DefaultCoreUpgrade.s.sol
+++ b/l1-contracts/deploy-scripts/upgrade/default-upgrade/DefaultCoreUpgrade.s.sol
@@ -53,13 +53,20 @@ contract DefaultCoreUpgrade is Script, DeployL1CoreUtils {
         address bridgehubProxyAddress,
         bool isZKsyncOS,
         bytes32 create2FactorySalt,
+        address create2FactoryAddress,
         string memory upgradeInputPath,
         string memory _outputPath
     ) public virtual {
         string memory root = vm.projectRoot();
         upgradeInputPath = string.concat(root, upgradeInputPath);
 
-        initializeConfigWithArgs(bridgehubProxyAddress, isZKsyncOS, create2FactorySalt, upgradeInputPath);
+        initializeConfigWithArgs(
+            bridgehubProxyAddress,
+            isZKsyncOS,
+            create2FactorySalt,
+            create2FactoryAddress,
+            upgradeInputPath
+        );
 
         upgradeConfig.outputPath = string.concat(root, _outputPath);
         upgradeConfig.initialized = true;
@@ -111,6 +118,7 @@ contract DefaultCoreUpgrade is Script, DeployL1CoreUtils {
         address bridgehubProxyAddress,
         bool isZKsyncOS,
         bytes32 create2FactorySalt,
+        address create2FactoryAddress,
         string memory upgradeInputPath
     ) public virtual {
         string memory upgradeToml = vm.readFile(upgradeInputPath);
@@ -119,6 +127,9 @@ contract DefaultCoreUpgrade is Script, DeployL1CoreUtils {
         // When zero, the script falls back to the CREATE2_FACTORY_SALT env var or built-in default.
         if (create2FactorySalt != bytes32(0)) {
             setCreate2Salt(create2FactorySalt);
+        }
+        if (create2FactoryAddress != address(0)) {
+            setCreate2FactoryAddress(create2FactoryAddress);
         }
 
         additionalConfig.isZKsyncOS = isZKsyncOS;

--- a/l1-contracts/deploy-scripts/upgrade/default-upgrade/DefaultEcosystemUpgrade.s.sol
+++ b/l1-contracts/deploy-scripts/upgrade/default-upgrade/DefaultEcosystemUpgrade.s.sol
@@ -84,6 +84,7 @@ contract DefaultEcosystemUpgrade is Script {
             _params.bridgehubProxyAddress,
             _params.isZKsyncOS,
             _params.create2FactorySalt,
+            _params.create2FactoryAddress,
             _params.upgradeInputPath,
             _coreOutputPath
         );
@@ -97,6 +98,7 @@ contract DefaultEcosystemUpgrade is Script {
             _params.isZKsyncOS,
             _params.rollupDAManager,
             _params.create2FactorySalt,
+            _params.create2FactoryAddress,
             _params.upgradeInputPath,
             _ctmOutputPath,
             _params.governance,

--- a/l1-contracts/deploy-scripts/upgrade/default-upgrade/UpgradeParams.sol
+++ b/l1-contracts/deploy-scripts/upgrade/default-upgrade/UpgradeParams.sol
@@ -11,6 +11,7 @@ struct EcosystemUpgradeParams {
     address rollupDAManager;
     bool isZKsyncOS;
     bytes32 create2FactorySalt;
+    address create2FactoryAddress;
     string upgradeInputPath;
     string ecosystemOutputPath;
     address governance;

--- a/l1-contracts/deploy-scripts/utils/deploy/Create2FactoryUtils.s.sol
+++ b/l1-contracts/deploy-scripts/utils/deploy/Create2FactoryUtils.s.sol
@@ -31,6 +31,9 @@ abstract contract Create2FactoryUtils is Script {
     /// @notice The salt used for deterministic deployments.
     bytes32 internal _create2FactorySalt;
 
+    /// @notice Optional preconfigured CREATE2 factory address from the existing environment.
+    address internal _create2FactoryAddress;
+
     /// @notice Whether the salt was explicitly set via `setCreate2Salt`.
     bool private _saltExplicitlySet;
 
@@ -40,6 +43,13 @@ abstract contract Create2FactoryUtils is Script {
     function setCreate2Salt(bytes32 _salt) internal {
         _create2FactorySalt = _salt;
         _saltExplicitlySet = true;
+    }
+
+    /// @notice Override the default create2 factory address.
+    /// @dev Must be called before the first deployment.
+    /// @param _factoryAddress The factory address to use for subsequent create2 deployments.
+    function setCreate2FactoryAddress(address _factoryAddress) internal {
+        _create2FactoryAddress = _factoryAddress;
     }
 
     function getCreate2FactoryParams() public view returns (address create2FactoryAddr, bytes32 create2FactorySalt) {
@@ -54,6 +64,16 @@ abstract contract Create2FactoryUtils is Script {
     function instantiateCreate2Factory() internal {
         if (!_saltExplicitlySet) {
             _create2FactorySalt = vm.envOr(CREATE2_FACTORY_SALT_ENV, DEFAULT_CREATE2_FACTORY_SALT);
+        }
+
+        if (_create2FactoryAddress != address(0)) {
+            if (_create2FactoryAddress.code.length == 0) {
+                revert AddressHasNoCode(_create2FactoryAddress);
+            }
+
+            create2FactoryState = Create2FactoryState({create2FactoryAddress: _create2FactoryAddress});
+            console.log("Using configured Create2Factory address:", _create2FactoryAddress);
+            return;
         }
 
         if (Utils.DETERMINISTIC_CREATE2_ADDRESS.code.length == 0) {

--- a/l1-contracts/scripts/copy-to-zkstack-out.ts
+++ b/l1-contracts/scripts/copy-to-zkstack-out.ts
@@ -47,6 +47,9 @@ const REQUIRED_CONTRACTS = [
   "IChainAdmin.sol",
   "ISetupLegacyBridge.sol",
   "DefaultUpgrade.sol",
+  // v31 ecosystem upgrade script — zksync-era's zkstack CLI compiles its ABI in via
+  // `abigen!` to encode `noGovernancePrepare(EcosystemUpgradeParams)` calldata.
+  "EcosystemUpgrade_v31.s.sol",
   // Used by anvil-interop test suite (contracts.ts)
   "GWAssetTracker.sol",
   "L2Bridgehub.sol",

--- a/l1-contracts/test/foundry/l1/integration/UpgradeTestShared.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/UpgradeTestShared.t.sol
@@ -55,6 +55,7 @@ contract UpgradeIntegrationTestBase is Test {
             "$.deployed_addresses.state_transition.bytecodes_supplier_addr"
         );
         bool isZKsyncOs = outputDeployCTMToml.readBool("$.is_zk_sync_os");
+        address create2FactoryAddress = outputDeployL1Toml.readAddress("$.contracts.create2_factory_addr");
         address rollupDAManager;
         if (isZKsyncOs) {
             rollupDAManager = outputDeployCTMToml.readAddress(
@@ -74,6 +75,7 @@ contract UpgradeIntegrationTestBase is Test {
                 rollupDAManager: rollupDAManager,
                 isZKsyncOS: isZKsyncOs,
                 create2FactorySalt: bytes32(0),
+                create2FactoryAddress: create2FactoryAddress,
                 upgradeInputPath: ECOSYSTEM_UPGRADE_INPUT,
                 ecosystemOutputPath: ECOSYSTEM_OUTPUT,
                 governance: governance,

--- a/l1-contracts/test/foundry/l1/integration/_EcosystemUpgradeV31ForTests.sol
+++ b/l1-contracts/test/foundry/l1/integration/_EcosystemUpgradeV31ForTests.sol
@@ -96,6 +96,7 @@ contract EcosystemUpgradeV31ForTests is EcosystemUpgrade_v31 {
             : address(0);
         bool isZKsyncOS = pvToml.readBool("$.is_zk_sync_os");
         bytes32 create2FactorySalt = pvToml.readBytes32("$.permanent_contracts.create2_factory_salt");
+        address create2FactoryAddress = pvToml.readAddress("$.permanent_contracts.create2_factory_addr");
         // The ZK token asset ID is passed to `InteropCenter.initL2`, which requires it to be
         // non-zero. `initializeConfig` enforces this; we read it here and let the assertion fire
         // at TOML parse time if it's missing.
@@ -113,6 +114,7 @@ contract EcosystemUpgradeV31ForTests is EcosystemUpgrade_v31 {
                 rollupDAManager: rollupDAManager,
                 isZKsyncOS: isZKsyncOS,
                 create2FactorySalt: create2FactorySalt,
+                create2FactoryAddress: create2FactoryAddress,
                 upgradeInputPath: upgradeInputPath,
                 ecosystemOutputPath: ecosystemOutputPath,
                 governance: governance,

--- a/l1-contracts/test/foundry/l1/unit/concrete/L2V31Upgrade/L2V31Upgrade.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/L2V31Upgrade/L2V31Upgrade.t.sol
@@ -114,6 +114,67 @@ contract MockV31UpgradeNativeTokenVault {
     }
 }
 
+/// @dev Mock NTV that emulates the legacy v29/v30 readback shape after code replacement:
+/// WETH_TOKEN is readable, but L2_TOKEN_PROXY_BYTECODE_HASH() reads as zero from the new storage-backed getter.
+contract MockV31UpgradeLegacyReadbackNativeTokenVault {
+    bytes32 public immutable BASE_TOKEN_ASSET_ID;
+    uint256 public immutable L1_CHAIN_ID;
+
+    bytes32 private immutable EXPECTED_PROXY_BYTECODE_HASH;
+    address private immutable EXPECTED_WETH_TOKEN;
+
+    address public BASE_TOKEN_ORIGIN_TOKEN;
+    string public BASE_TOKEN_NAME;
+    string public BASE_TOKEN_SYMBOL;
+    uint256 public BASE_TOKEN_DECIMALS;
+
+    uint256 public updateCalls;
+
+    constructor(bytes32 _assetId, uint256 _l1ChainId, bytes32 _expectedProxyBytecodeHash, address _expectedWethToken) {
+        BASE_TOKEN_ASSET_ID = _assetId;
+        L1_CHAIN_ID = _l1ChainId;
+        EXPECTED_PROXY_BYTECODE_HASH = _expectedProxyBytecodeHash;
+        EXPECTED_WETH_TOKEN = _expectedWethToken;
+    }
+
+    function WETH_TOKEN() external view returns (address) {
+        return EXPECTED_WETH_TOKEN;
+    }
+
+    function L2_TOKEN_PROXY_BYTECODE_HASH() external pure returns (bytes32) {
+        return bytes32(0);
+    }
+
+    function registerBaseTokenIfNeeded() external {
+        // No-op for mock
+    }
+
+    function updateL2(
+        uint256 _l1ChainId,
+        address /* _aliasedOwner */,
+        bytes32 _l2TokenProxyBytecodeHash,
+        address /* _legacySharedBridge */,
+        address _wethToken,
+        TokenBridgingData calldata _baseTokenBridgingData,
+        TokenMetadata calldata _baseTokenMetadata
+    ) external {
+        if (msg.sender != L2_COMPLEX_UPGRADER_ADDR) {
+            revert Unauthorized(msg.sender);
+        }
+
+        require(_l1ChainId == L1_CHAIN_ID, "unexpected L1 chain id");
+        require(_l2TokenProxyBytecodeHash == EXPECTED_PROXY_BYTECODE_HASH, "unexpected proxy bytecode hash");
+        require(_wethToken == EXPECTED_WETH_TOKEN, "unexpected weth token");
+        require(_baseTokenBridgingData.assetId == BASE_TOKEN_ASSET_ID, "unexpected base token asset id");
+
+        BASE_TOKEN_ORIGIN_TOKEN = _baseTokenBridgingData.originToken;
+        BASE_TOKEN_NAME = _baseTokenMetadata.name;
+        BASE_TOKEN_SYMBOL = _baseTokenMetadata.symbol;
+        BASE_TOKEN_DECIMALS = _baseTokenMetadata.decimals;
+        updateCalls++;
+    }
+}
+
 /// @dev Mock AssetTracker that records initL2 and registerBaseTokenDuringUpgrade calls.
 contract MockV31UpgradeAssetTracker {
     uint256 public L1_CHAIN_ID;
@@ -270,6 +331,35 @@ contract L2V31UpgradeUnitTest is Test {
         assertEq(baseToken.initCalls(), 1, "base token should be initialized exactly once");
         assertEq(baseToken.lastInitializedL1ChainId(), L1_CHAIN_ID, "base token L1 chain id mismatch");
         assertTrue(baseToken.sawRegisteredBaseToken(), "base token should be initialized after registration");
+    }
+
+    function test_UpgradeViaComplexUpgrader_UsesL1ProvidedProxyHashWhenLegacyGetterReturnsZero() public {
+        _etchCode(
+            L2_NATIVE_TOKEN_VAULT_ADDR,
+            address(
+                new MockV31UpgradeLegacyReadbackNativeTokenVault(
+                    BASE_TOKEN_ASSET_ID,
+                    L1_CHAIN_ID,
+                    L2_TOKEN_PROXY_BYTECODE_HASH,
+                    PREDEPLOYED_WETH
+                )
+            )
+        );
+
+        bytes memory fixedData = abi.encode(_buildFixedForceDeploymentsData());
+        bytes memory additionalData = abi.encode(_buildZKChainSpecificData());
+
+        vm.prank(L2_FORCE_DEPLOYER_ADDR);
+        L2ComplexUpgrader(L2_COMPLEX_UPGRADER_ADDR).upgrade(
+            address(testUpgrade),
+            abi.encodeCall(IL2V31Upgrade.upgrade, (false, CTM_DEPLOYER, fixedData, additionalData))
+        );
+
+        MockV31UpgradeLegacyReadbackNativeTokenVault nativeTokenVault = MockV31UpgradeLegacyReadbackNativeTokenVault(
+            L2_NATIVE_TOKEN_VAULT_ADDR
+        );
+        assertEq(nativeTokenVault.updateCalls(), 1, "native token vault should be updated exactly once");
+        assertEq(nativeTokenVault.BASE_TOKEN_ORIGIN_TOKEN(), BASE_TOKEN_ORIGIN_ADDRESS, "origin token mismatch");
     }
 
     function _buildFixedForceDeploymentsData() private pure returns (FixedForceDeploymentsData memory) {

--- a/l1-contracts/zkstack-out/EcosystemUpgrade_v31.s.sol/EcosystemUpgrade_v31.json
+++ b/l1-contracts/zkstack-out/EcosystemUpgrade_v31.s.sol/EcosystemUpgrade_v31.json
@@ -1,0 +1,371 @@
+[
+  {
+    "type": "function",
+    "name": "IS_SCRIPT",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "deployNewEcosystemContractsL1",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getCTMUpgrade",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract DefaultCTMUpgrade"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getDiscoveredBridgehub",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct BridgehubAddresses",
+        "components": [
+          {
+            "name": "proxies",
+            "type": "tuple",
+            "internalType": "struct BridgehubContracts",
+            "components": [
+              {
+                "name": "bridgehub",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "messageRoot",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "ctmDeploymentTracker",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "chainAssetHandler",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "chainRegistrationSender",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "assetTracker",
+                "type": "address",
+                "internalType": "address"
+              }
+            ]
+          },
+          {
+            "name": "implementations",
+            "type": "tuple",
+            "internalType": "struct BridgehubContracts",
+            "components": [
+              {
+                "name": "bridgehub",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "messageRoot",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "ctmDeploymentTracker",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "chainAssetHandler",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "chainRegistrationSender",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "assetTracker",
+                "type": "address",
+                "internalType": "address"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getOwnerAddress",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "initializeWithArgs",
+    "inputs": [
+      {
+        "name": "_params",
+        "type": "tuple",
+        "internalType": "struct EcosystemUpgradeParams",
+        "components": [
+          {
+            "name": "bridgehubProxyAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "ctmProxy",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "bytecodesSupplier",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "rollupDAManager",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "isZKsyncOS",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "create2FactorySalt",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "create2FactoryAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "upgradeInputPath",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "ecosystemOutputPath",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "governance",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "zkTokenAssetId",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "noGovernancePrepare",
+    "inputs": [
+      {
+        "name": "_params",
+        "type": "tuple",
+        "internalType": "struct EcosystemUpgradeParams",
+        "components": [
+          {
+            "name": "bridgehubProxyAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "ctmProxy",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "bytecodesSupplier",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "rollupDAManager",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "isZKsyncOS",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "create2FactorySalt",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "create2FactoryAddress",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "upgradeInputPath",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "ecosystemOutputPath",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "governance",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "zkTokenAssetId",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "prepareDefaultGovernanceCalls",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "stage0Calls",
+        "type": "tuple[]",
+        "internalType": "struct Call[]",
+        "components": [
+          {
+            "name": "target",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      },
+      {
+        "name": "stage1Calls",
+        "type": "tuple[]",
+        "internalType": "struct Call[]",
+        "components": [
+          {
+            "name": "target",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      },
+      {
+        "name": "stage2Calls",
+        "type": "tuple[]",
+        "internalType": "struct Call[]",
+        "components": [
+          {
+            "name": "target",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "prepareEcosystemUpgrade",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "stage3",
+    "inputs": [
+      {
+        "name": "bridgehubProxy",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  }
+]


### PR DESCRIPTION
## Summary

Fixes discovered while running the v29 → v31 local-upgrade flow end to end via `infrastructure/local-upgrade-testing/era-cacher` against a live chain. Layered on top of PR #2091 (base = `kl/l2V31upgrade`) so reviewers can see only the additions.

- `SystemContractsProcessing`: force-deploy `SystemContractProxyAdmin` as an Era built-in. `L2GenesisForceDeploymentsHelper._setupProxyAdmin()` unconditionally expects it; without it the real upgrade tx reverted on `chainId()`/`owner()` against an empty proxy-admin slot at `0x…0001000c`.
- `CoreOnGatewayHelper`:
  - force-deploy `L2V31Upgrade` at `L2_VERSION_SPECIFIC_UPGRADER_ADDR` (the delegatecall target must actually contain code);
  - publish `TransparentUpgradeableProxy` bytecode in the Era factory-deps set so `_ensureWethToken` succeeds when `WETH_TOKEN()` is zero (the real v29 state);
  - publish `BeaconProxy` bytecode so NTV deposits that create bridged-ERC20 proxies don't revert with `UnknownCodeHash`.
- `L2GenesisForceDeploymentsHelper`: use the L1-provided `l2TokenProxyBytecodeHash` from `_fixedForceDeploymentsData` instead of reading `L2NativeTokenVault.L2_TOKEN_PROXY_BYTECODE_HASH()` back — the new storage-backed getter returns zero immediately after the code swap.
- `AdminFunctions.upgradeChainFromCTM`: version-aware encoding (use legacy `upgradeChainFromVersion(uint256,DiamondCutData)` for source chains at version < 31).
- CREATE2 factory propagation: thread an explicit `create2FactoryAddress` through `EcosystemUpgradeParams` → `DefaultEcosystem/Core/CTMUpgrade` → `Create2FactoryUtils`, preferring a configured live address over the deterministic `0x4e59…` fallback (which isn't deployed on locally bootstrapped v29 chains).
- Test updates for the new struct shape and a new unit test (`MockV31UpgradeLegacyReadbackNativeTokenVault`) locking in the `L2GenesisForceDeploymentsHelper` fix.

## Validation

The paired `zksync-era` PR (matter-labs/zksync-era#TBD) runs `bash ./era-cacher/do-upgrade.sh` end-to-end. Current tally on a clean rerun from `reset.sh`: `Test Suites: 1 failed, 1 skipped, 16 passed, 17 of 18 total. Tests: 7 failed, 4 skipped, 182 passed, 193 total.` Only failing suite is `prividium` (missing `chains/era/configs/private-rpc-permissions.yaml`, orthogonal).

## Test plan
- [ ] forge build --zksync
- [ ] forge test --match-contract L2V31UpgradeUnitTest
- [ ] Paired zksync-era PR runs do-upgrade.sh and all upgrade-critical integration suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)