### PR TITLE
test(committer): tests for BatchTimestampGreaterThanLastL2BlockTimestamp

### DIFF
--- a/l1-contracts/test/foundry/l1/unit/concrete/BatchProcessing/Committing.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/BatchProcessing/Committing.t.sol
@@ -29,6 +29,7 @@ import {
 import {
     BatchHashMismatch,
     BatchNumberMismatch,
+    BatchTimestampGreaterThanLastL2BlockTimestamp,
     CanOnlyProcessOneBatch,
     HashMismatch,
     InvalidLogSender,
@@ -176,6 +177,41 @@ contract CommittingTest is ExecutorTest {
         vm.blobhashes(defaultBlobVersionedHashes);
 
         vm.expectRevert(abi.encodeWithSelector(TimeNotReached.selector, 1, 2));
+        (uint256 commitBatchFrom, uint256 commitBatchTo, bytes memory commitData) = Utils.encodeCommitBatchesData(
+            genesisStoredBatchInfo,
+            wrongNewCommitBatchInfoArray
+        );
+        committer.commitBatchesSharedBridge(address(0), commitBatchFrom, commitBatchTo, commitData);
+    }
+
+    /// @notice Reverts when the packed (batchTimestamp, lastL2BlockTimestamp) pair has
+    ///         batchTimestamp strictly greater than lastL2BlockTimestamp. Both values are kept inside
+    ///         the valid commit window so the earlier TimeNotReached / L2TimestampTooBig guards do
+    ///         not fire first — we are specifically testing the new invariant in `_verifyBatchTimestamp`.
+    function test_RevertWhen_CommittingWithBatchTimestampGreaterThanLastL2BlockTimestamp() public {
+        uint64 batchTimestamp = uint64(currentTimestamp);
+        uint64 lastL2BlockTimestamp = uint64(currentTimestamp - 1);
+
+        bytes[] memory wrongL2Logs = Utils.createSystemLogs(l2DAValidatorOutputHash);
+        wrongL2Logs[uint256(uint256(SystemLogKey.PACKED_BATCH_AND_L2_BLOCK_TIMESTAMP_KEY))] = Utils.constructL2Log(
+            true,
+            L2_SYSTEM_CONTEXT_ADDRESS,
+            uint256(SystemLogKey.PACKED_BATCH_AND_L2_BLOCK_TIMESTAMP_KEY),
+            Utils.packBatchTimestampAndBlockTimestamp(batchTimestamp, lastL2BlockTimestamp)
+        );
+
+        CommitBatchInfo memory wrongNewCommitBatchInfo = newCommitBatchInfo;
+        wrongNewCommitBatchInfo.systemLogs = Utils.encodePacked(wrongL2Logs);
+        wrongNewCommitBatchInfo.timestamp = batchTimestamp; // must equal the packed batchTimestamp
+        wrongNewCommitBatchInfo.operatorDAInput = operatorDAInput;
+
+        CommitBatchInfo[] memory wrongNewCommitBatchInfoArray = new CommitBatchInfo[](1);
+        wrongNewCommitBatchInfoArray[0] = wrongNewCommitBatchInfo;
+
+        vm.prank(validator);
+        vm.blobhashes(defaultBlobVersionedHashes);
+
+        vm.expectRevert(abi.encodeWithSelector(BatchTimestampGreaterThanLastL2BlockTimestamp.selector));
         (uint256 commitBatchFrom, uint256 commitBatchTo, bytes memory commitData) = Utils.encodeCommitBatchesData(
             genesisStoredBatchInfo,
             wrongNewCommitBatchInfoArray

--- a/l1-contracts/test/foundry/l1/unit/concrete/BatchProcessing/CommittingZKsyncOS.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/BatchProcessing/CommittingZKsyncOS.t.sol
@@ -547,40 +547,4 @@ contract CommittingTest is ExecutorTest {
         committer.commitBatchesSharedBridge(address(0), commitBatchFrom, commitBatchTo, commitData);
     }
 
-    /// @notice Fuzz: any batch with `firstBlockTimestamp > lastBlockTimestamp` must revert with the
-    ///         new error. Inputs are bounded to keep other timestamp guards from firing first.
-    function testFuzz_RevertWhen_FirstBlockTimestampGreaterThanLastBlockTimestamp(
-        uint64 firstTs,
-        uint64 lastTs
-    ) public {
-        // Keep both timestamps inside the valid commit window so they only fail the new check.
-        firstTs = uint64(bound(uint256(firstTs), currentTimestamp - 10, currentTimestamp));
-        lastTs = uint64(bound(uint256(lastTs), currentTimestamp - 10, currentTimestamp));
-        // Enforce strict inversion; abandon degenerate inputs by rejecting them.
-        vm.assume(firstTs > lastTs);
-
-        bytes memory operatorDAInput = abi.encodePacked(bytes32(0));
-        bytes32 daCommitment = bytes32(0);
-
-        CommitBatchInfoZKsyncOS memory invertedTimestampBatch = newCommitBatchInfoZKsyncOS;
-        invertedTimestampBatch.operatorDAInput = operatorDAInput;
-        invertedTimestampBatch.daCommitment = daCommitment;
-        invertedTimestampBatch.daCommitmentScheme = L2DACommitmentScheme.EMPTY_NO_DA;
-        invertedTimestampBatch.firstBlockTimestamp = firstTs;
-        invertedTimestampBatch.lastBlockTimestamp = lastTs;
-
-        CommitBatchInfoZKsyncOS[] memory batchArray = new CommitBatchInfoZKsyncOS[](1);
-        batchArray[0] = invertedTimestampBatch;
-
-        (uint256 commitBatchFrom, uint256 commitBatchTo, bytes memory commitData) = Utils
-            .encodeCommitBatchesDataZKsyncOS(genesisStoredBatchInfo, batchArray);
-
-        address validiumL1DAValidator = address(new ValidiumL1DAValidator());
-        vm.prank(address(owner));
-        admin.setDAValidatorPair(validiumL1DAValidator, L2DACommitmentScheme.EMPTY_NO_DA);
-
-        vm.prank(validator);
-        vm.expectRevert(abi.encodeWithSignature("BatchTimestampGreaterThanLastL2BlockTimestamp()"));
-        committer.commitBatchesSharedBridge(address(0), commitBatchFrom, commitBatchTo, commitData);
-    }
 }

--- a/l1-contracts/test/foundry/l1/unit/concrete/BatchProcessing/CommittingZKsyncOS.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/BatchProcessing/CommittingZKsyncOS.t.sol
@@ -487,4 +487,100 @@ contract CommittingTest is ExecutorTest {
         vm.expectRevert(); // TimeNotReached error
         committer.commitBatchesSharedBridge(address(0), commitBatchFrom, commitBatchTo, commitData);
     }
+
+    /// @notice Reverts when the batch-level `firstBlockTimestamp` exceeds `lastBlockTimestamp`.
+    /// @dev Both timestamps stay inside the [block.timestamp - NOT_OLDER, block.timestamp + DELTA] window
+    ///      so that the earlier `TimeNotReached` and `L2TimestampTooBig` checks do not trigger first.
+    function test_RevertWhen_FirstBlockTimestampGreaterThanLastBlockTimestamp() public {
+        bytes memory operatorDAInput = abi.encodePacked(bytes32(0));
+        bytes32 daCommitment = bytes32(0);
+
+        CommitBatchInfoZKsyncOS memory invertedTimestampBatch = newCommitBatchInfoZKsyncOS;
+        invertedTimestampBatch.operatorDAInput = operatorDAInput;
+        invertedTimestampBatch.daCommitment = daCommitment;
+        invertedTimestampBatch.daCommitmentScheme = L2DACommitmentScheme.EMPTY_NO_DA;
+        // firstBlockTimestamp > lastBlockTimestamp triggers the new invariant.
+        invertedTimestampBatch.firstBlockTimestamp = uint64(currentTimestamp);
+        invertedTimestampBatch.lastBlockTimestamp = uint64(currentTimestamp - 1);
+
+        CommitBatchInfoZKsyncOS[] memory batchArray = new CommitBatchInfoZKsyncOS[](1);
+        batchArray[0] = invertedTimestampBatch;
+
+        (uint256 commitBatchFrom, uint256 commitBatchTo, bytes memory commitData) = Utils
+            .encodeCommitBatchesDataZKsyncOS(genesisStoredBatchInfo, batchArray);
+
+        address validiumL1DAValidator = address(new ValidiumL1DAValidator());
+        vm.prank(address(owner));
+        admin.setDAValidatorPair(validiumL1DAValidator, L2DACommitmentScheme.EMPTY_NO_DA);
+
+        vm.prank(validator);
+        vm.expectRevert(abi.encodeWithSignature("BatchTimestampGreaterThanLastL2BlockTimestamp()"));
+        committer.commitBatchesSharedBridge(address(0), commitBatchFrom, commitBatchTo, commitData);
+    }
+
+    /// @notice Boundary case: `firstBlockTimestamp == lastBlockTimestamp` must still commit successfully,
+    ///         because the guard uses a strict `>` comparison.
+    function test_SuccessfullyCommit_WhenFirstEqualsLastBlockTimestamp() public {
+        bytes memory operatorDAInput = abi.encodePacked(bytes32(0));
+        bytes32 daCommitment = bytes32(0);
+
+        CommitBatchInfoZKsyncOS memory equalTimestampBatch = newCommitBatchInfoZKsyncOS;
+        equalTimestampBatch.operatorDAInput = operatorDAInput;
+        equalTimestampBatch.daCommitment = daCommitment;
+        equalTimestampBatch.daCommitmentScheme = L2DACommitmentScheme.EMPTY_NO_DA;
+        // Pick a value strictly inside the valid window and set both bounds equal.
+        uint64 equalTs = uint64(currentTimestamp - 5);
+        equalTimestampBatch.firstBlockTimestamp = equalTs;
+        equalTimestampBatch.lastBlockTimestamp = equalTs;
+
+        CommitBatchInfoZKsyncOS[] memory batchArray = new CommitBatchInfoZKsyncOS[](1);
+        batchArray[0] = equalTimestampBatch;
+
+        (uint256 commitBatchFrom, uint256 commitBatchTo, bytes memory commitData) = Utils
+            .encodeCommitBatchesDataZKsyncOS(genesisStoredBatchInfo, batchArray);
+
+        address validiumL1DAValidator = address(new ValidiumL1DAValidator());
+        vm.prank(address(owner));
+        admin.setDAValidatorPair(validiumL1DAValidator, L2DACommitmentScheme.EMPTY_NO_DA);
+
+        vm.prank(validator);
+        committer.commitBatchesSharedBridge(address(0), commitBatchFrom, commitBatchTo, commitData);
+    }
+
+    /// @notice Fuzz: any batch with `firstBlockTimestamp > lastBlockTimestamp` must revert with the
+    ///         new error. Inputs are bounded to keep other timestamp guards from firing first.
+    function testFuzz_RevertWhen_FirstBlockTimestampGreaterThanLastBlockTimestamp(
+        uint64 firstTs,
+        uint64 lastTs
+    ) public {
+        // Keep both timestamps inside the valid commit window so they only fail the new check.
+        firstTs = uint64(bound(uint256(firstTs), currentTimestamp - 10, currentTimestamp));
+        lastTs = uint64(bound(uint256(lastTs), currentTimestamp - 10, currentTimestamp));
+        // Enforce strict inversion; abandon degenerate inputs by rejecting them.
+        vm.assume(firstTs > lastTs);
+
+        bytes memory operatorDAInput = abi.encodePacked(bytes32(0));
+        bytes32 daCommitment = bytes32(0);
+
+        CommitBatchInfoZKsyncOS memory invertedTimestampBatch = newCommitBatchInfoZKsyncOS;
+        invertedTimestampBatch.operatorDAInput = operatorDAInput;
+        invertedTimestampBatch.daCommitment = daCommitment;
+        invertedTimestampBatch.daCommitmentScheme = L2DACommitmentScheme.EMPTY_NO_DA;
+        invertedTimestampBatch.firstBlockTimestamp = firstTs;
+        invertedTimestampBatch.lastBlockTimestamp = lastTs;
+
+        CommitBatchInfoZKsyncOS[] memory batchArray = new CommitBatchInfoZKsyncOS[](1);
+        batchArray[0] = invertedTimestampBatch;
+
+        (uint256 commitBatchFrom, uint256 commitBatchTo, bytes memory commitData) = Utils
+            .encodeCommitBatchesDataZKsyncOS(genesisStoredBatchInfo, batchArray);
+
+        address validiumL1DAValidator = address(new ValidiumL1DAValidator());
+        vm.prank(address(owner));
+        admin.setDAValidatorPair(validiumL1DAValidator, L2DACommitmentScheme.EMPTY_NO_DA);
+
+        vm.prank(validator);
+        vm.expectRevert(abi.encodeWithSignature("BatchTimestampGreaterThanLastL2BlockTimestamp()"));
+        committer.commitBatchesSharedBridge(address(0), commitBatchFrom, commitBatchTo, commitData);
+    }
 }


### PR DESCRIPTION
## Summary

Adds Foundry tests covering the new \`BatchTimestampGreaterThanLastL2BlockTimestamp\` guards introduced in #2147 (\`CommitterFacet\`). Both revert paths are exercised, plus the non-strict boundary and a fuzz case.

## What's covered

### ZKsync OS commit path — \`CommitBatchInfoZKsyncOS\` struct check

In \`l1-contracts/test/foundry/l1/unit/concrete/BatchProcessing/CommittingZKsyncOS.t.sol\`:

- \`test_RevertWhen_FirstBlockTimestampGreaterThanLastBlockTimestamp\` — concrete case where \`firstBlockTimestamp > lastBlockTimestamp\` while both stay inside the valid commit window, so the new guard fires before \`TimeNotReached\` or \`L2TimestampTooBig\`.
- \`testFuzz_RevertWhen_FirstBlockTimestampGreaterThanLastBlockTimestamp\` — fuzz variant with timestamps bounded to the valid window.
- \`test_SuccessfullyCommit_WhenFirstEqualsLastBlockTimestamp\` — boundary: \`firstBlockTimestamp == lastBlockTimestamp\` must still commit, since the guard uses a strict \`>\`.

### Legacy Era commit path — packed \`(batchTimestamp, lastL2BlockTimestamp)\` check

In \`l1-contracts/test/foundry/l1/unit/concrete/BatchProcessing/Committing.t.sol\`:

- \`test_RevertWhen_CommittingWithBatchTimestampGreaterThanLastL2BlockTimestamp\` — packs \`(currentTimestamp, currentTimestamp - 1)\` so \`_verifyBatchTimestamp\` hits the new \`batchTimestamp > lastL2BlockTimestamp\` branch before \`TimeNotReached\` / \`L2TimestampTooBig\`.

## Sanity check

I verified the tests actually exercise the new logic: with both new guard blocks temporarily removed from \`CommitterFacet\`, the three revert tests fail (as expected) while the boundary happy-path test keeps passing. With the PR's guards in place all four pass, and the whole \`CommittingTest\` + \`CommittingZKsyncOS\` suites (49 tests total) are green.

## Test plan

- [x] \`forge test --match-test "BatchTimestampGreaterThanLastL2BlockTimestamp|FirstBlockTimestampGreaterThan|FirstEqualsLast"\` — 4/4 pass
- [x] \`forge test --match-path "test/foundry/l1/unit/concrete/BatchProcessing/Committing*.t.sol"\` — 49/49 pass
- [x] \`yarn lint:sol --fix --noPrompt\` and \`yarn prettier:fix\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)