### PR TITLE
Move strict ERC-7930 parsing out of vendor into StrictInteroperableAddressesParser

### DIFF
--- a/l1-contracts/contracts/bridge/asset-router/L2AssetRouter.sol
+++ b/l1-contracts/contracts/bridge/asset-router/L2AssetRouter.sol
@@ -40,6 +40,7 @@ import {
 import {IERC7786Recipient} from "../../interop/IERC7786Recipient.sol";
 import {IERC7786Attributes} from "../../interop/IERC7786Attributes.sol";
 import {InteroperableAddress} from "../../vendor/draft-InteroperableAddress.sol";
+import {StrictInteroperableAddressesParser} from "../../interop/StrictInteroperableAddressesParser.sol";
 
 /// @author Matter Labs
 /// @custom:security-contact security@matterlabs.dev
@@ -239,7 +240,7 @@ contract L2AssetRouter is AssetRouterBase, IL2AssetRouter, ReentrancyGuard, IERC
         // 4. Destination L2 validates senderAddress == address(this) for non-L1 sources
         //    (L2AssetRouter address is equal for all ZKsync chains)
 
-        (uint256 senderChainId, address senderAddress) = InteroperableAddress.parseEvmV1Calldata(sender);
+        (uint256 senderChainId, address senderAddress) = StrictInteroperableAddressesParser.parseEvmV1Calldata(sender);
 
         require((senderChainId != L1_CHAIN_ID && senderAddress == address(this)), Unauthorized(senderAddress));
 

--- a/l1-contracts/contracts/interop/InteropCenter.sol
+++ b/l1-contracts/contracts/interop/InteropCenter.sol
@@ -55,6 +55,7 @@ import {IERC7786Attributes} from "./IERC7786Attributes.sol";
 import {AttributesDecoder} from "./AttributesDecoder.sol";
 import {InteropDataEncoding} from "./InteropDataEncoding.sol";
 import {ERC7930_V1_MIN_LENGTH} from "./InteropConstants.sol";
+import {StrictInteroperableAddressesParser} from "./StrictInteroperableAddressesParser.sol";
 import {InteroperableAddress} from "../vendor/draft-InteroperableAddress.sol";
 import {IL2CrossChainSender} from "../bridge/interfaces/IL2CrossChainSender.sol";
 import {IAssetRouterShared} from "../bridge/asset-router/IAssetRouterShared.sol";
@@ -197,7 +198,9 @@ contract InteropCenter is
         bytes calldata payload,
         bytes[] calldata attributes
     ) external payable whenNotPaused nonReentrant returns (bytes32 sendId) {
-        (uint256 recipientChainId, address recipientAddress) = InteroperableAddress.parseEvmV1Calldata(recipient);
+        (uint256 recipientChainId, address recipientAddress) = StrictInteroperableAddressesParser.parseEvmV1Calldata(
+            recipient
+        );
 
         _ensureL2ToL2(recipientChainId);
 
@@ -249,7 +252,7 @@ contract InteropCenter is
 
         // Extract the actual chain ID from the ERC-7930 address
         // slither-disable-next-line unused-return
-        (uint256 destinationChainId, ) = InteroperableAddress.parseEvmV1Calldata(_destinationChainId);
+        (uint256 destinationChainId, ) = StrictInteroperableAddressesParser.parseEvmV1Calldata(_destinationChainId);
 
         // Ensure this is an L2 to L2 transaction
         _ensureL2ToL2(destinationChainId);
@@ -265,7 +268,7 @@ contract InteropCenter is
             _ensureEmptyChainReference(_callStarters[i].to);
 
             // slither-disable-next-line unused-return
-            (, address recipientAddress) = InteroperableAddress.parseEvmV1Calldata(_callStarters[i].to);
+            (, address recipientAddress) = StrictInteroperableAddressesParser.parseEvmV1Calldata(_callStarters[i].to);
 
             // Store original attributes for MessageSent event emission
             originalCallAttributes[i] = _callStarters[i].callAttributes;
@@ -539,7 +542,7 @@ contract InteropCenter is
             );
             // Parse the returned 7930 address from actualCallStarter.to
             // slither-disable-next-line unused-return
-            (, address actualCallRecipient) = InteroperableAddress.parseEvmV1(actualCallStarter.to);
+            (, address actualCallRecipient) = StrictInteroperableAddressesParser.parseEvmV1(actualCallStarter.to);
             interopCall = InteropCall({
                 version: INTEROP_CALL_VERSION,
                 shadowAccount: false,

--- a/l1-contracts/contracts/interop/InteropHandler.sol
+++ b/l1-contracts/contracts/interop/InteropHandler.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.24;
 
 import {InteroperableAddress} from "../vendor/draft-InteroperableAddress.sol";
+import {StrictInteroperableAddressesParser} from "./StrictInteroperableAddressesParser.sol";
 
 import {
     L2_BRIDGEHUB,
@@ -89,7 +90,7 @@ contract InteropHandler is IInteropHandler, ReentrancyGuard {
 
         // If the execution address is not specified then the execution is permissionless.
         if (interopBundle.bundleAttributes.executionAddress.length != 0) {
-            (uint256 executionChainId, address executionAddress) = InteroperableAddress.parseEvmV1(
+            (uint256 executionChainId, address executionAddress) = StrictInteroperableAddressesParser.parseEvmV1(
                 interopBundle.bundleAttributes.executionAddress
             );
 
@@ -165,7 +166,7 @@ contract InteropHandler is IInteropHandler, ReentrancyGuard {
         // Decode the bundle data, calculate its hash and get the current status of the bundle.
         (InteropBundle memory interopBundle, bytes32 bundleHash, BundleStatus status) = _getBundleData(_bundle);
 
-        (uint256 unbundlerChainId, address unbundlerAddress) = InteroperableAddress.parseEvmV1(
+        (uint256 unbundlerChainId, address unbundlerAddress) = StrictInteroperableAddressesParser.parseEvmV1(
             interopBundle.bundleAttributes.unbundlerAddress
         );
 
@@ -370,7 +371,7 @@ contract InteropHandler is IInteropHandler, ReentrancyGuard {
 
         bytes4 selector = bytes4(payload[:4]);
 
-        (uint256 senderChainId, address senderAddress) = InteroperableAddress.parseEvmV1Calldata(sender);
+        (uint256 senderChainId, address senderAddress) = StrictInteroperableAddressesParser.parseEvmV1Calldata(sender);
 
         // NOTE: it is important that we always support the legacy messages formats (i.e. dont change selectors)
         // since otherwise the messages that were sent before won't be executable.
@@ -403,7 +404,7 @@ contract InteropHandler is IInteropHandler, ReentrancyGuard {
 
         // If the execution address is not specified then the execution is permissionless.
         if (interopBundle.bundleAttributes.executionAddress.length != 0) {
-            (uint256 executionChainId, address executionAddress) = InteroperableAddress.parseEvmV1(
+            (uint256 executionChainId, address executionAddress) = StrictInteroperableAddressesParser.parseEvmV1(
                 interopBundle.bundleAttributes.executionAddress
             );
 
@@ -438,7 +439,7 @@ contract InteropHandler is IInteropHandler, ReentrancyGuard {
         // Decode the bundle to get unbundling permissions
         (InteropBundle memory interopBundle, , ) = _getBundleData(bundle);
 
-        (uint256 unbundlerChainId, address unbundlerAddress) = InteroperableAddress.parseEvmV1(
+        (uint256 unbundlerChainId, address unbundlerAddress) = StrictInteroperableAddressesParser.parseEvmV1(
             interopBundle.bundleAttributes.unbundlerAddress
         );
 

--- a/l1-contracts/contracts/interop/StrictInteroperableAddressesParser.sol
+++ b/l1-contracts/contracts/interop/StrictInteroperableAddressesParser.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.26;
+
+import {InteroperableAddress} from "../vendor/draft-InteroperableAddress.sol";
+import {ERC7930_V1_MIN_LENGTH} from "./InteropConstants.sol";
+
+/// @title StrictInteroperableAddressesParser
+/// @author Matter Labs
+/// @custom:security-contact security@matterlabs.dev
+/// @notice Strict wrappers around the parse/tryParse helpers from the vendored
+/// {InteroperableAddress} library. The vendored library accepts inputs with trailing bytes
+/// beyond the declared chainReference/address, because it checks
+/// `self.length < 0x06 + chainReferenceLength + addrLength` (strictly less than) as the
+/// final length guard. For protocol inputs we want to reject such inputs so that a single
+/// ERC-7930 payload has a unique encoding and cannot be extended with arbitrary bytes.
+///
+/// Each wrapper first runs the strict length check (minimum length, then chainReferenceLength,
+/// then addressLength, then exact-length equality) and only delegates to the vendor parser
+/// once the length is known to match the declared layout exactly. Because strict equality
+/// implies the vendor's `<` check passes, delegation is always safe.
+library StrictInteroperableAddressesParser {
+    /// @notice Returns true iff `_self` has a length that exactly matches the declared
+    /// ERC-7930 v1 layout: `ERC7930_V1_MIN_LENGTH + chainReferenceLength + addressLength`.
+    /// @dev The caller is responsible for providing calldata whose first bytes are safe to
+    /// read as the ERC-7930 header; we only check length before dereferencing.
+    function _hasStrictLengthCalldata(bytes calldata _self) private pure returns (bool) {
+        if (_self.length < ERC7930_V1_MIN_LENGTH) return false;
+        uint256 chainReferenceLength = uint8(_self[0x04]);
+        if (_self.length < ERC7930_V1_MIN_LENGTH + chainReferenceLength) return false;
+        uint256 addressLength = uint8(_self[0x05 + chainReferenceLength]);
+        return _self.length == ERC7930_V1_MIN_LENGTH + chainReferenceLength + addressLength;
+    }
+
+    /// @notice Memory-variant of {_hasStrictLengthCalldata}.
+    function _hasStrictLengthMemory(bytes memory _self) private pure returns (bool) {
+        if (_self.length < ERC7930_V1_MIN_LENGTH) return false;
+        uint256 chainReferenceLength = uint8(_self[0x04]);
+        if (_self.length < ERC7930_V1_MIN_LENGTH + chainReferenceLength) return false;
+        uint256 addressLength = uint8(_self[0x05 + chainReferenceLength]);
+        return _self.length == ERC7930_V1_MIN_LENGTH + chainReferenceLength + addressLength;
+    }
+
+    /// @notice Strict variant of {InteroperableAddress-parseV1Calldata}. Reverts with
+    /// `InteroperableAddressParsingError` if the payload has trailing bytes beyond the
+    /// declared layout.
+    function parseV1Calldata(
+        bytes calldata _self
+    ) internal pure returns (bytes2 chainType, bytes calldata chainReference, bytes calldata addr) {
+        require(_hasStrictLengthCalldata(_self), InteroperableAddress.InteroperableAddressParsingError(_self));
+        return InteroperableAddress.parseV1Calldata(_self);
+    }
+
+    /// @notice Strict variant of {InteroperableAddress-tryParseV1Calldata}. Returns `false`
+    /// instead of reverting when the payload has trailing bytes beyond the declared layout.
+    function tryParseV1Calldata(
+        bytes calldata _self
+    ) internal pure returns (bool success, bytes2 chainType, bytes calldata chainReference, bytes calldata addr) {
+        if (!_hasStrictLengthCalldata(_self)) {
+            return (false, 0x0000, _self[0:0], _self[0:0]);
+        }
+        return InteroperableAddress.tryParseV1Calldata(_self);
+    }
+
+    /// @notice Strict variant of {InteroperableAddress-parseEvmV1}. Reverts with
+    /// `InteroperableAddressParsingError` if the payload has trailing bytes beyond the
+    /// declared layout.
+    function parseEvmV1(bytes memory _self) internal pure returns (uint256 chainId, address addr) {
+        require(_hasStrictLengthMemory(_self), InteroperableAddress.InteroperableAddressParsingError(_self));
+        return InteroperableAddress.parseEvmV1(_self);
+    }
+
+    /// @notice Strict variant of {InteroperableAddress-parseEvmV1Calldata}. Reverts with
+    /// `InteroperableAddressParsingError` if the payload has trailing bytes beyond the
+    /// declared layout.
+    function parseEvmV1Calldata(bytes calldata _self) internal pure returns (uint256 chainId, address addr) {
+        require(_hasStrictLengthCalldata(_self), InteroperableAddress.InteroperableAddressParsingError(_self));
+        return InteroperableAddress.parseEvmV1Calldata(_self);
+    }
+
+    /// @notice Strict variant of {InteroperableAddress-tryParseEvmV1Calldata}. Returns
+    /// `false` instead of reverting when the payload has trailing bytes beyond the
+    /// declared layout.
+    function tryParseEvmV1Calldata(
+        bytes calldata _self
+    ) internal pure returns (bool success, uint256 chainId, address addr) {
+        if (!_hasStrictLengthCalldata(_self)) {
+            return (false, 0, address(0));
+        }
+        return InteroperableAddress.tryParseEvmV1Calldata(_self);
+    }
+}

--- a/l1-contracts/contracts/interop/StrictInteroperableAddressesParser.sol
+++ b/l1-contracts/contracts/interop/StrictInteroperableAddressesParser.sol
@@ -8,7 +8,7 @@ import {ERC7930_V1_MIN_LENGTH} from "./InteropConstants.sol";
 /// @title StrictInteroperableAddressesParser
 /// @author Matter Labs
 /// @custom:security-contact security@matterlabs.dev
-/// @notice Strict wrappers around the parse/tryParse helpers from the vendored
+/// @notice Strict wrappers around the parse helpers from the vendored
 /// {InteroperableAddress} library. The vendored library accepts inputs with trailing bytes
 /// beyond the declared chainReference/address, because it checks
 /// `self.length < 0x06 + chainReferenceLength + addrLength` (strictly less than) as the
@@ -51,17 +51,6 @@ library StrictInteroperableAddressesParser {
         return InteroperableAddress.parseV1Calldata(_self);
     }
 
-    /// @notice Strict variant of {InteroperableAddress-tryParseV1Calldata}. Returns `false`
-    /// instead of reverting when the payload has trailing bytes beyond the declared layout.
-    function tryParseV1Calldata(
-        bytes calldata _self
-    ) internal pure returns (bool success, bytes2 chainType, bytes calldata chainReference, bytes calldata addr) {
-        if (!_hasStrictLengthCalldata(_self)) {
-            return (false, 0x0000, _self[0:0], _self[0:0]);
-        }
-        return InteroperableAddress.tryParseV1Calldata(_self);
-    }
-
     /// @notice Strict variant of {InteroperableAddress-parseEvmV1}. Reverts with
     /// `InteroperableAddressParsingError` if the payload has trailing bytes beyond the
     /// declared layout.
@@ -76,17 +65,5 @@ library StrictInteroperableAddressesParser {
     function parseEvmV1Calldata(bytes calldata _self) internal pure returns (uint256 chainId, address addr) {
         require(_hasStrictLengthCalldata(_self), InteroperableAddress.InteroperableAddressParsingError(_self));
         return InteroperableAddress.parseEvmV1Calldata(_self);
-    }
-
-    /// @notice Strict variant of {InteroperableAddress-tryParseEvmV1Calldata}. Returns
-    /// `false` instead of reverting when the payload has trailing bytes beyond the
-    /// declared layout.
-    function tryParseEvmV1Calldata(
-        bytes calldata _self
-    ) internal pure returns (bool success, uint256 chainId, address addr) {
-        if (!_hasStrictLengthCalldata(_self)) {
-            return (false, 0, address(0));
-        }
-        return InteroperableAddress.tryParseEvmV1Calldata(_self);
     }
 }

--- a/l1-contracts/contracts/vendor/draft-InteroperableAddress.sol
+++ b/l1-contracts/contracts/vendor/draft-InteroperableAddress.sol
@@ -6,7 +6,6 @@ import {Math} from "@openzeppelin/contracts-v4/utils/math/Math.sol";
 import {SafeCast} from "@openzeppelin/contracts-v4/utils/math/SafeCast.sol";
 import {Bytes} from "./Bytes.sol";
 import {Calldata} from "./Calldata.sol";
-import {ERC7930_V1_MIN_LENGTH} from "../interop/InteropConstants.sol";
 
 /**
  * @dev Helper library to format and parse https://ethereum-magicians.org/t/erc-7930-interoperable-addresses/23365[ERC-7930] interoperable
@@ -97,24 +96,21 @@ library InteroperableAddress {
     ) internal pure returns (bool success, bytes2 chainType, bytes memory chainReference, bytes memory addr) {
         unchecked {
             success = true;
-            if (self.length < ERC7930_V1_MIN_LENGTH) return (false, 0x0000, _emptyBytesMemory(), _emptyBytesMemory());
+            if (self.length < 0x06) return (false, 0x0000, _emptyBytesMemory(), _emptyBytesMemory());
 
             bytes2 version = _readBytes2(self, 0x00);
             if (version != bytes2(0x0001)) return (false, 0x0000, _emptyBytesMemory(), _emptyBytesMemory());
             chainType = _readBytes2(self, 0x02);
 
             uint8 chainReferenceLength = uint8(self[0x04]);
-            if (self.length < ERC7930_V1_MIN_LENGTH + chainReferenceLength)
+            if (self.length < 0x06 + chainReferenceLength)
                 return (false, 0x0000, _emptyBytesMemory(), _emptyBytesMemory());
             chainReference = self.slice(0x05, 0x05 + chainReferenceLength);
 
             uint8 addrLength = uint8(self[0x05 + chainReferenceLength]);
-            if (self.length != ERC7930_V1_MIN_LENGTH + chainReferenceLength + addrLength)
+            if (self.length < 0x06 + chainReferenceLength + addrLength)
                 return (false, 0x0000, _emptyBytesMemory(), _emptyBytesMemory());
-            addr = self.slice(
-                ERC7930_V1_MIN_LENGTH + chainReferenceLength,
-                ERC7930_V1_MIN_LENGTH + chainReferenceLength + addrLength
-            );
+            addr = self.slice(0x06 + chainReferenceLength, 0x06 + chainReferenceLength + addrLength);
         }
     }
 
@@ -126,23 +122,21 @@ library InteroperableAddress {
     ) internal pure returns (bool success, bytes2 chainType, bytes calldata chainReference, bytes calldata addr) {
         unchecked {
             success = true;
-            if (self.length < ERC7930_V1_MIN_LENGTH) return (false, 0x0000, Calldata.emptyBytes(), Calldata.emptyBytes());
+            if (self.length < 0x06) return (false, 0x0000, Calldata.emptyBytes(), Calldata.emptyBytes());
 
             bytes2 version = _readBytes2Calldata(self, 0x00);
             if (version != bytes2(0x0001)) return (false, 0x0000, Calldata.emptyBytes(), Calldata.emptyBytes());
             chainType = _readBytes2Calldata(self, 0x02);
 
             uint8 chainReferenceLength = uint8(self[0x04]);
-            if (self.length < ERC7930_V1_MIN_LENGTH + chainReferenceLength)
+            if (self.length < 0x06 + chainReferenceLength)
                 return (false, 0x0000, Calldata.emptyBytes(), Calldata.emptyBytes());
             chainReference = self[0x05:0x05 + chainReferenceLength];
 
             uint8 addrLength = uint8(self[0x05 + chainReferenceLength]);
-            if (self.length != ERC7930_V1_MIN_LENGTH + chainReferenceLength + addrLength)
+            if (self.length < 0x06 + chainReferenceLength + addrLength)
                 return (false, 0x0000, Calldata.emptyBytes(), Calldata.emptyBytes());
-            addr = self[
-                ERC7930_V1_MIN_LENGTH + chainReferenceLength:ERC7930_V1_MIN_LENGTH + chainReferenceLength + addrLength
-            ];
+            addr = self[0x06 + chainReferenceLength:0x06 + chainReferenceLength + addrLength];
         }
     }
 

--- a/l1-contracts/test/foundry/l1/unit/concrete/Libraries/InteroperableAddress.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/Libraries/InteroperableAddress.t.sol
@@ -231,16 +231,6 @@ contract InteroperableAddressTest is Test {
         assertFalse(success);
     }
 
-    function test_tryParseV1Calldata_failsOnTrailingBytes() public view {
-        bytes memory formattedWithTrailingByte = bytes.concat(
-            InteroperableAddress.formatEvmV1(uint256(1), address(0x1234)),
-            hex"00"
-        );
-
-        (bool success, , , ) = helper.tryParseV1Calldata(formattedWithTrailingByte);
-        assertFalse(success);
-    }
-
     // ============ parseEvmV1 Tests ============
 
     function test_parseEvmV1_validInput() public pure {

--- a/l1-contracts/test/foundry/l1/unit/concrete/Libraries/StrictInteroperableAddressesParser.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/Libraries/StrictInteroperableAddressesParser.t.sol
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+
+import {InteroperableAddress} from "contracts/vendor/draft-InteroperableAddress.sol";
+import {StrictInteroperableAddressesParser} from "contracts/interop/StrictInteroperableAddressesParser.sol";
+
+/// @notice Helper contract to exercise the calldata-taking functions of
+/// {StrictInteroperableAddressesParser} via an external call so that `bytes memory`
+/// inputs from the test can be passed as `bytes calldata`.
+contract StrictInteroperableAddressesParserHelper {
+    function parseV1Calldata(
+        bytes calldata data
+    ) external pure returns (bytes2 chainType, bytes calldata chainReference, bytes calldata addr) {
+        return StrictInteroperableAddressesParser.parseV1Calldata(data);
+    }
+
+    function tryParseV1Calldata(
+        bytes calldata data
+    ) external pure returns (bool success, bytes2 chainType, bytes calldata chainReference, bytes calldata addr) {
+        return StrictInteroperableAddressesParser.tryParseV1Calldata(data);
+    }
+
+    function parseEvmV1Calldata(bytes calldata data) external pure returns (uint256 chainId, address addr) {
+        return StrictInteroperableAddressesParser.parseEvmV1Calldata(data);
+    }
+
+    function tryParseEvmV1Calldata(
+        bytes calldata data
+    ) external pure returns (bool success, uint256 chainId, address addr) {
+        return StrictInteroperableAddressesParser.tryParseEvmV1Calldata(data);
+    }
+}
+
+/// @notice Unit tests for the strict wrappers in {StrictInteroperableAddressesParser}.
+/// The strict wrappers forward to the vendor parser once they have confirmed that the
+/// payload length matches the declared layout exactly. The tests below therefore focus
+/// on:
+/// 1. Valid inputs still parsing identically to the vendor parser.
+/// 2. Trailing bytes beyond the declared layout being rejected (vendor accepts them).
+/// 3. Truncated inputs (shorter than the declared layout) being rejected, just like
+///    the vendor parser does.
+contract StrictInteroperableAddressesParserTest is Test {
+    StrictInteroperableAddressesParserHelper internal helper;
+
+    function setUp() public {
+        helper = new StrictInteroperableAddressesParserHelper();
+    }
+
+    // ============ parseV1Calldata ============
+
+    function test_parseV1Calldata_validInput() public view {
+        bytes memory formatted = InteroperableAddress.formatEvmV1(uint256(1), address(0x1234));
+
+        (bytes2 chainType, , ) = helper.parseV1Calldata(formatted);
+        assertEq(chainType, bytes2(0x0000));
+    }
+
+    function test_parseV1Calldata_revertsOnTrailingBytes() public {
+        bytes memory formattedWithTrailingByte = bytes.concat(
+            InteroperableAddress.formatEvmV1(uint256(1), address(0x1234)),
+            hex"00"
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                InteroperableAddress.InteroperableAddressParsingError.selector,
+                formattedWithTrailingByte
+            )
+        );
+        helper.parseV1Calldata(formattedWithTrailingByte);
+    }
+
+    function test_parseV1Calldata_revertsOnTooShortForMinimum() public {
+        bytes memory tooShort = hex"0001";
+
+        vm.expectRevert(
+            abi.encodeWithSelector(InteroperableAddress.InteroperableAddressParsingError.selector, tooShort)
+        );
+        helper.parseV1Calldata(tooShort);
+    }
+
+    function test_parseV1Calldata_revertsOnMissingAddressLengthByte() public {
+        // 5 bytes: enough to read chainReferenceLength (at index 4) but not addressLength (at
+        // index 5 + chainReferenceLength). The strict parser must reject because
+        // self.length < ERC7930_V1_MIN_LENGTH.
+        bytes memory tooShort = hex"0001000000";
+
+        vm.expectRevert(
+            abi.encodeWithSelector(InteroperableAddress.InteroperableAddressParsingError.selector, tooShort)
+        );
+        helper.parseV1Calldata(tooShort);
+    }
+
+    function test_parseV1Calldata_revertsOnTruncatedChainReference() public {
+        // Declared chainReferenceLength = 3 but only 1 byte of chainReference data present
+        // after the header; total length (7) is shorter than 6 + 3 = 9.
+        bytes memory truncated = hex"00010000030100";
+
+        vm.expectRevert(
+            abi.encodeWithSelector(InteroperableAddress.InteroperableAddressParsingError.selector, truncated)
+        );
+        helper.parseV1Calldata(truncated);
+    }
+
+    // ============ tryParseV1Calldata ============
+
+    function test_tryParseV1Calldata_validInput() public view {
+        bytes memory formatted = InteroperableAddress.formatEvmV1(uint256(1), address(0x1234));
+
+        (bool success, bytes2 chainType, , ) = helper.tryParseV1Calldata(formatted);
+        assertTrue(success);
+        assertEq(chainType, bytes2(0x0000));
+    }
+
+    function test_tryParseV1Calldata_failsOnTrailingBytes() public view {
+        bytes memory formattedWithTrailingByte = bytes.concat(
+            InteroperableAddress.formatEvmV1(uint256(1), address(0x1234)),
+            hex"00"
+        );
+
+        (bool success, , , ) = helper.tryParseV1Calldata(formattedWithTrailingByte);
+        assertFalse(success);
+    }
+
+    function test_tryParseV1Calldata_failsOnMissingAddressLengthByte() public view {
+        bytes memory tooShort = hex"0001000000";
+
+        (bool success, , , ) = helper.tryParseV1Calldata(tooShort);
+        assertFalse(success);
+    }
+
+    function test_tryParseV1Calldata_failsOnTruncatedChainReference() public view {
+        bytes memory truncated = hex"00010000030100";
+
+        (bool success, , , ) = helper.tryParseV1Calldata(truncated);
+        assertFalse(success);
+    }
+
+    // ============ parseEvmV1Calldata ============
+
+    function test_parseEvmV1Calldata_validInput() public view {
+        address expectedAddr = address(0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF);
+        bytes memory formatted = InteroperableAddress.formatEvmV1(uint256(137), expectedAddr);
+
+        (uint256 chainId, address addr) = helper.parseEvmV1Calldata(formatted);
+        assertEq(chainId, 137);
+        assertEq(addr, expectedAddr);
+    }
+
+    function test_parseEvmV1Calldata_revertsOnTrailingBytes() public {
+        bytes memory formattedWithTrailingByte = bytes.concat(
+            InteroperableAddress.formatEvmV1(uint256(1), address(0x1234)),
+            hex"abcd"
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                InteroperableAddress.InteroperableAddressParsingError.selector,
+                formattedWithTrailingByte
+            )
+        );
+        helper.parseEvmV1Calldata(formattedWithTrailingByte);
+    }
+
+    // ============ parseEvmV1 (memory) ============
+
+    function test_parseEvmV1_memory_validInput() public pure {
+        address expectedAddr = address(0x1234567890123456789012345678901234567890);
+        bytes memory formatted = InteroperableAddress.formatEvmV1(uint256(1), expectedAddr);
+
+        (uint256 chainId, address addr) = StrictInteroperableAddressesParser.parseEvmV1(formatted);
+        assertEq(chainId, 1);
+        assertEq(addr, expectedAddr);
+    }
+
+    function test_parseEvmV1_memory_revertsOnTrailingBytes() public {
+        bytes memory formattedWithTrailingByte = bytes.concat(
+            InteroperableAddress.formatEvmV1(uint256(1), address(0x1234)),
+            hex"ff"
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                InteroperableAddress.InteroperableAddressParsingError.selector,
+                formattedWithTrailingByte
+            )
+        );
+        StrictInteroperableAddressesParser.parseEvmV1(formattedWithTrailingByte);
+    }
+
+    // ============ tryParseEvmV1Calldata ============
+
+    function test_tryParseEvmV1Calldata_validInput() public view {
+        address expectedAddr = address(0x1234567890123456789012345678901234567890);
+        bytes memory formatted = InteroperableAddress.formatEvmV1(uint256(1), expectedAddr);
+
+        (bool success, uint256 chainId, address addr) = helper.tryParseEvmV1Calldata(formatted);
+        assertTrue(success);
+        assertEq(chainId, 1);
+        assertEq(addr, expectedAddr);
+    }
+
+    function test_tryParseEvmV1Calldata_failsOnTrailingBytes() public view {
+        bytes memory formattedWithTrailingByte = bytes.concat(
+            InteroperableAddress.formatEvmV1(uint256(1), address(0x1234)),
+            hex"00"
+        );
+
+        (bool success, , ) = helper.tryParseEvmV1Calldata(formattedWithTrailingByte);
+        assertFalse(success);
+    }
+
+    function test_tryParseEvmV1Calldata_failsOnInvalidChainType() public view {
+        // Non-EVM chainType (0x0001 instead of 0x0000), length matches strictly.
+        // Strict length check passes, but vendor tryParseEvmV1Calldata rejects the chainType.
+        bytes memory nonEvm = hex"000100010114001234567890123456789012345678901234567890";
+
+        (bool success, , ) = helper.tryParseEvmV1Calldata(nonEvm);
+        assertFalse(success);
+    }
+
+    // ============ Fuzz ============
+
+    function testFuzz_parseEvmV1Calldata_roundtrip(uint256 chainId, address addr) public view {
+        vm.assume(chainId > 0);
+        bytes memory formatted = InteroperableAddress.formatEvmV1(chainId, addr);
+
+        (uint256 parsedChainId, address parsedAddr) = helper.parseEvmV1Calldata(formatted);
+        assertEq(parsedChainId, chainId);
+        assertEq(parsedAddr, addr);
+    }
+
+    function testFuzz_parseEvmV1Calldata_trailingBytesAlwaysRevert(
+        uint256 chainId,
+        address addr,
+        bytes calldata tail
+    ) public {
+        vm.assume(chainId > 0);
+        vm.assume(tail.length > 0);
+        bytes memory formatted = bytes.concat(InteroperableAddress.formatEvmV1(chainId, addr), tail);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(InteroperableAddress.InteroperableAddressParsingError.selector, formatted)
+        );
+        helper.parseEvmV1Calldata(formatted);
+    }
+}

--- a/l1-contracts/test/foundry/l1/unit/concrete/Libraries/StrictInteroperableAddressesParser.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/Libraries/StrictInteroperableAddressesParser.t.sol
@@ -16,20 +16,8 @@ contract StrictInteroperableAddressesParserHelper {
         return StrictInteroperableAddressesParser.parseV1Calldata(data);
     }
 
-    function tryParseV1Calldata(
-        bytes calldata data
-    ) external pure returns (bool success, bytes2 chainType, bytes calldata chainReference, bytes calldata addr) {
-        return StrictInteroperableAddressesParser.tryParseV1Calldata(data);
-    }
-
     function parseEvmV1Calldata(bytes calldata data) external pure returns (uint256 chainId, address addr) {
         return StrictInteroperableAddressesParser.parseEvmV1Calldata(data);
-    }
-
-    function tryParseEvmV1Calldata(
-        bytes calldata data
-    ) external pure returns (bool success, uint256 chainId, address addr) {
-        return StrictInteroperableAddressesParser.tryParseEvmV1Calldata(data);
     }
 }
 
@@ -104,40 +92,6 @@ contract StrictInteroperableAddressesParserTest is Test {
         helper.parseV1Calldata(truncated);
     }
 
-    // ============ tryParseV1Calldata ============
-
-    function test_tryParseV1Calldata_validInput() public view {
-        bytes memory formatted = InteroperableAddress.formatEvmV1(uint256(1), address(0x1234));
-
-        (bool success, bytes2 chainType, , ) = helper.tryParseV1Calldata(formatted);
-        assertTrue(success);
-        assertEq(chainType, bytes2(0x0000));
-    }
-
-    function test_tryParseV1Calldata_failsOnTrailingBytes() public view {
-        bytes memory formattedWithTrailingByte = bytes.concat(
-            InteroperableAddress.formatEvmV1(uint256(1), address(0x1234)),
-            hex"00"
-        );
-
-        (bool success, , , ) = helper.tryParseV1Calldata(formattedWithTrailingByte);
-        assertFalse(success);
-    }
-
-    function test_tryParseV1Calldata_failsOnMissingAddressLengthByte() public view {
-        bytes memory tooShort = hex"0001000000";
-
-        (bool success, , , ) = helper.tryParseV1Calldata(tooShort);
-        assertFalse(success);
-    }
-
-    function test_tryParseV1Calldata_failsOnTruncatedChainReference() public view {
-        bytes memory truncated = hex"00010000030100";
-
-        (bool success, , , ) = helper.tryParseV1Calldata(truncated);
-        assertFalse(success);
-    }
-
     // ============ parseEvmV1Calldata ============
 
     function test_parseEvmV1Calldata_validInput() public view {
@@ -188,37 +142,6 @@ contract StrictInteroperableAddressesParserTest is Test {
             )
         );
         StrictInteroperableAddressesParser.parseEvmV1(formattedWithTrailingByte);
-    }
-
-    // ============ tryParseEvmV1Calldata ============
-
-    function test_tryParseEvmV1Calldata_validInput() public view {
-        address expectedAddr = address(0x1234567890123456789012345678901234567890);
-        bytes memory formatted = InteroperableAddress.formatEvmV1(uint256(1), expectedAddr);
-
-        (bool success, uint256 chainId, address addr) = helper.tryParseEvmV1Calldata(formatted);
-        assertTrue(success);
-        assertEq(chainId, 1);
-        assertEq(addr, expectedAddr);
-    }
-
-    function test_tryParseEvmV1Calldata_failsOnTrailingBytes() public view {
-        bytes memory formattedWithTrailingByte = bytes.concat(
-            InteroperableAddress.formatEvmV1(uint256(1), address(0x1234)),
-            hex"00"
-        );
-
-        (bool success, , ) = helper.tryParseEvmV1Calldata(formattedWithTrailingByte);
-        assertFalse(success);
-    }
-
-    function test_tryParseEvmV1Calldata_failsOnInvalidChainType() public view {
-        // Non-EVM chainType (0x0001 instead of 0x0000), length matches strictly.
-        // Strict length check passes, but vendor tryParseEvmV1Calldata rejects the chainType.
-        bytes memory nonEvm = hex"000100010114001234567890123456789012345678901234567890";
-
-        (bool success, , ) = helper.tryParseEvmV1Calldata(nonEvm);
-        assertFalse(success);
     }
 
     // ============ Fuzz ============


### PR DESCRIPTION
## Summary

Fork PR to #2142. Keeps the strict-length behavior that #2142 adds, but drops all edits to `l1-contracts/contracts/vendor/`.

- Reverts `l1-contracts/contracts/vendor/draft-InteroperableAddress.sol` to the pre-#2142 state (zero net diff against the parent of `68e5a25`).
- Adds `l1-contracts/contracts/interop/StrictInteroperableAddressesParser.sol`: strict wrappers for the parse entry points used in this repo (`parseV1Calldata`, `parseEvmV1`, `parseEvmV1Calldata`). Each wrapper:
  1. checks `self.length >= ERC7930_V1_MIN_LENGTH`,
  2. reads `chainReferenceLength` at byte `0x04`,
  3. checks `self.length >= ERC7930_V1_MIN_LENGTH + chainReferenceLength`,
  4. reads `addressLength` at byte `0x05 + chainReferenceLength`,
  5. asserts `self.length == ERC7930_V1_MIN_LENGTH + chainReferenceLength + addressLength`,
  6. then delegates to the vendor parser.

  Because strict equality implies the vendor's original `<` check passes, delegation is always safe; and any trailing-bytes payload that the unchanged vendor would have accepted is rejected by step 5 before delegation, exactly the behavior #2142 added by flipping the vendor's final guard from `<` to `!=`.

- The `tryParseV1Calldata` and `tryParseEvmV1Calldata` variants are not wrapped, since no production callsite in this repo uses them.
- Repoints vendor `parse*` callsites to the strict library: `InteropCenter.sol` (4 sites), `InteropHandler.sol` (4 sites), `L2AssetRouter.sol` (1 site). `InteroperableAddress.formatEvmV1` and the `InteroperableAddressParsingError` error type still come from the vendor.
- Moves the trailing-bytes test out of `InteroperableAddress.t.sol` and into a new `StrictInteroperableAddressesParser.t.sol` (valid input, trailing bytes, truncated chainReference, missing addressLength byte, plus two fuzz tests). The `InteropConstants.sol` file and the `ERC7930_V1_MIN_LENGTH` renames in `InteropCenter.sol` from #2142 are retained since they are non-vendor.

## Why ❔

Keep the vendor copy of `draft-InteroperableAddress.sol` byte-identical to the upstream draft so that future upstream pulls don't conflict, while still enforcing strict ERC-7930 parsing at every protocol entry point.

## Test plan

- [x] `forge build` clean on l1-contracts.
- [x] `forge test --match-contract StrictInteroperableAddressesParserTest` — 11 passed, 0 failed.
- [x] `forge test --match-path 'test/foundry/l1/unit/**'` — 2302 passed, 0 failed.
- [x] `prettier --check` and `solhint` clean on all edited files.
- [ ] Integration suites + CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)