### PR TITLE
oz n06: block unpauseDeposits when chain is on a remote SL

### DIFF
--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Migrator.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Migrator.sol
@@ -102,6 +102,17 @@ contract MigratorFacet is ZKChainBase, IMigrator {
         if (s.priorityModeInfo.canBeActivated) {
             revert NotCompatibleWithPriorityMode();
         }
+        // Retry path: if L1 is already paused and the chain is on a remote SL, this is a retry
+        // of the cross-chain pause msg (e.g. the original `requestPauseDepositsForChainOnGateway`
+        // did not land on Gateway). Re-send the msg using L1's existing `pausedDepositsTimestamp`
+        // without touching it. The retry is idempotent: `pauseDepositsOnGateway` overwrites GW's
+        // flag with the same value, and the time-window check on GW (`timestamp + window <=
+        // block.timestamp`) is gated off the same original timestamp regardless of how many
+        // retries fire, so the safety window can't be shortened.
+        if (s.pausedDepositsTimestamp != 0 && s.settlementLayer != address(0)) {
+            IL1AssetTracker(s.assetTracker).requestPauseDepositsForChainOnGateway(s.chainId);
+            return;
+        }
         require(s.pausedDepositsTimestamp == 0, DepositsAlreadyPaused());
         uint256 timestamp;
         // Note, if the chain is new (total number of priority transactions is 0) we allow admin to pause the deposits with immediate effect.

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Migrator.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Migrator.sol
@@ -129,6 +129,13 @@ contract MigratorFacet is ZKChainBase, IMigrator {
             !IL1ChainAssetHandler(IL1Bridgehub(s.bridgehub).chainAssetHandler()).isMigrationInProgress(s.chainId),
             MigrationInProgress()
         );
+        // Pausing also flips the deposit-pause flag on the Gateway via a cross-chain message
+        // (see `pauseDepositsBeforeInitiatingMigration`). Only L1's flag can be cleared from
+        // here, so refuse to unpause while the chain is still settled on a remote SL — that
+        // would leave Gateway's flag set and the two sides desynchronized. Admin must wait for
+        // the chain to be back on L1 (or let `forwardedBridgeMint` clear L1's flag as part of
+        // the GW->L1 migration completion).
+        require(s.settlementLayer == address(0), AlreadyMigrated());
         _unpauseDeposits();
     }
 

--- a/l1-contracts/test/foundry/l1/unit/concrete/state-transition/chain-deps/facets/Migrator/PauseDeposits.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/state-transition/chain-deps/facets/Migrator/PauseDeposits.t.sol
@@ -104,6 +104,48 @@ contract PauseDepositsTest is MigratorTest {
         migratorFacet.pauseDepositsBeforeInitiatingMigration();
     }
 
+    function test_retry_resendsCrossChainPauseMsg_withoutTouchingL1Flag() public {
+        // Setup: L1 already paused (pausedDepositsTimestamp != 0) AND chain on a remote SL.
+        // This is the "the original cross-chain pause msg failed to land on Gateway" recovery
+        // path: calling pauseDepositsBeforeInitiatingMigration again should re-send the msg
+        // using L1's existing pausedDepositsTimestamp, without overwriting it and without
+        // emitting a new DepositsPaused event.
+        uint256 chainId = utilsFacet.util_getChainId();
+        address admin = utilsFacet.util_getAdmin();
+        address settlementLayer = makeAddr("settlementLayer");
+        address assetTracker = makeAddr("assetTracker");
+
+        // Warp forward so block.timestamp is comfortably > 0 and we can pick an "earlier" pause.
+        vm.warp(1000);
+        // Pretend admin previously paused (set pausedDepositsTimestamp directly to a known value).
+        uint256 originalPauseTimestamp = block.timestamp - 100;
+        vm.store(address(migratorFacet), pausedDepositsTimestampSlot, bytes32(originalPauseTimestamp));
+
+        utilsFacet.util_setSettlementLayer(settlementLayer);
+        utilsFacet.util_setAssetTracker(assetTracker);
+
+        // Expect the cross-chain pause msg to be re-sent.
+        vm.expectCall(
+            assetTracker,
+            abi.encodeWithSelector(IL1AssetTracker.requestPauseDepositsForChainOnGateway.selector, chainId)
+        );
+        // Mock it so the call doesn't revert.
+        vm.mockCall(
+            assetTracker,
+            abi.encodeWithSelector(IL1AssetTracker.requestPauseDepositsForChainOnGateway.selector, chainId),
+            abi.encode()
+        );
+
+        vm.startPrank(admin);
+        migratorFacet.pauseDepositsBeforeInitiatingMigration();
+
+        // L1's pausedDepositsTimestamp must be untouched: same value as before the retry.
+        uint256 pausedDepositsTimestampAfter = uint256(
+            vm.load(address(migratorFacet), pausedDepositsTimestampSlot)
+        );
+        assertEq(pausedDepositsTimestampAfter, originalPauseTimestamp);
+    }
+
     function test_successfulCall_settlementLayerSet_withPriorityTxs() public {
         // Set up: settlementLayer is non-zero, totalPriorityTxs > 0
         // This should call requestPauseDepositsForChainOnGateway (line 341)

--- a/l1-contracts/test/foundry/l1/unit/concrete/state-transition/chain-deps/facets/Migrator/UnpauseDeposits.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/state-transition/chain-deps/facets/Migrator/UnpauseDeposits.t.sol
@@ -5,7 +5,11 @@ pragma solidity 0.8.28;
 import {MigratorTest} from "./_Migrator_Shared.t.sol";
 import {IBridgehubBase} from "contracts/core/bridgehub/IBridgehubBase.sol";
 import {IL1ChainAssetHandler} from "contracts/core/chain-asset-handler/IL1ChainAssetHandler.sol";
-import {DepositsNotPaused, MigrationInProgress} from "contracts/state-transition/L1StateTransitionErrors.sol";
+import {
+    AlreadyMigrated,
+    DepositsNotPaused,
+    MigrationInProgress
+} from "contracts/state-transition/L1StateTransitionErrors.sol";
 import {Unauthorized} from "contracts/common/L1ContractErrors.sol";
 
 contract UnpauseDepositsTest is MigratorTest {
@@ -41,6 +45,36 @@ contract UnpauseDepositsTest is MigratorTest {
         address admin = utilsFacet.util_getAdmin();
         vm.startPrank(admin);
         vm.expectRevert(abi.encodeWithSelector(DepositsNotPaused.selector));
+        migratorFacet.unpauseDeposits();
+    }
+
+    function test_revertWhen_chainSettledOnRemoteSettlementLayer() public {
+        // Pausing deposits before initiating migration sets the flag on both L1 and the current
+        // settlement layer (when the chain is on a remote SL). Admin must not be able to clear
+        // only L1's flag — that would leave Gateway's flag set indefinitely. This test asserts
+        // that `unpauseDeposits` reverts while the chain is still on a remote SL.
+        _pauseDeposits();
+        address fakeSettlementLayer = makeAddr("settlementLayer");
+        utilsFacet.util_setSettlementLayer(fakeSettlementLayer);
+        address admin = utilsFacet.util_getAdmin();
+        address bridgehub = utilsFacet.util_getBridgehub();
+        address mockChainAssetHandler = makeAddr("mockChainAssetHandler");
+
+        // The migration-in-progress check runs before the new settlement-layer check, so we
+        // must keep it passing in order to actually exercise the new revert.
+        vm.mockCall(
+            bridgehub,
+            abi.encodeWithSelector(IBridgehubBase.chainAssetHandler.selector),
+            abi.encode(mockChainAssetHandler)
+        );
+        vm.mockCall(
+            mockChainAssetHandler,
+            abi.encodeWithSelector(IL1ChainAssetHandler.isMigrationInProgress.selector),
+            abi.encode(false)
+        );
+
+        vm.startPrank(admin);
+        vm.expectRevert(abi.encodeWithSelector(AlreadyMigrated.selector));
         migratorFacet.unpauseDeposits();
     }
 


### PR DESCRIPTION
## Summary

Reworks the N-06 fix. The previously merged approach (#2155) added per-asset calls to `unpauseDepositsOnGateway` from inside `confirmMigrationOnGateway`. That was wrong on two fronts:

- **Wrong granularity**: pause is per-chain state, but `confirmMigrationOnGateway` runs once per asset. With N assets, the 2nd+ call reverts (because the first cleared the flag), silently failing service txs.
- **Future hazard**: if cycled migrations are ever added, stray asset confirmations from past GW→L1 migrations could clear a freshly-set pause.

The audit finding itself is effectively cosmetic: Gateway's pause flag is checked only inside `forwardedBridgeBurn` (source-side migration initiation) and `_writePriorityOp` (only when `block.chainid == L1_CHAIN_ID`). Since GW→L1 is terminal, a stale GW flag after migration is unobservable.

The real adjacent footgun is on the admin path: `Migrator.unpauseDeposits()` can be called on L1 while the chain is still settled on Gateway. That clears L1's flag only and leaves Gateway's set — an asymmetric state.

This PR:

1. (Already reverted on the target branch.) Drops the per-asset call from `GWAssetTracker.confirmMigrationOnGateway`, removes `unpauseDepositsOnGateway` from `Migrator` / `IMigrator`, removes the `UnpauseDepositsOnGateway` tests.
2. Adds `require(s.settlementLayer == address(0), AlreadyMigrated())` to `Migrator.unpauseDeposits()` — admin can no longer unpause while the chain is on a remote SL.
3. Adds a regression test (`test_revertWhen_chainSettledOnRemoteSettlementLayer`).

## Test plan

- [x] `forge test --match-contract UnpauseDepositsTest` — 5/5 pass (4 existing + 1 new)
- [x] Local `forge build` clean
- [ ] CI green