### PR TITLE
docs: clarify duplicate README disclaimer heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See [LICENSE-MIT](LICENSE-MIT) for details.
 - [Discord](https://join.zksync.dev/)
 - [Mirror](https://zksync.mirror.xyz/)
 
-## Disclaimer
+## Security Disclaimer
 
 ZKsync Era has been through lots of testing and audits. Although it is live, it is still in alpha state and will go
 through more audits and bug bounties programs. We would love to hear our community's thoughts and suggestions about it!


### PR DESCRIPTION
## What

Renames the second of two identical `## Disclaimer` headings in the top-level `README.md` to `## Security Disclaimer`, so the two sections are distinguishable.

## Why

The README had two sections both titled `## Disclaimer`, which is ambiguous in rendered docs and table-of-contents anchors. The second one is specifically about audit/alpha-state security caveats, so the more descriptive heading clarifies intent.

## Scope

Documentation only — no code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)