### PR TITLE
test: cover base-token finalization vs. totalSupply backfill

### DIFF
--- a/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2AssetTracker.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2AssetTracker.t.sol
@@ -38,7 +38,7 @@ import {DataEncoding} from "contracts/common/libraries/DataEncoding.sol";
 import {L2AssetTrackerData} from "./L2AssetTrackerData.sol";
 import {L2UtilsBase} from "../l2-tests-in-l1-context/L2UtilsBase.sol";
 
-import {Unauthorized} from "contracts/common/L1ContractErrors.sol";
+import {Unauthorized, BaseTokenPreV31TotalSupplyNotSet} from "contracts/common/L1ContractErrors.sol";
 import {RAND_ADDRESS} from "test/foundry/TestConstants.sol";
 
 import {LogFinder} from "../utils/LogFinder.sol";
@@ -644,6 +644,13 @@ abstract contract L2AssetTrackerTest is Test, SharedL2ContractDeployer {
             .sig("originChainId(bytes32)")
             .with_key(baseTokenAssetId)
             .checked_write(l1ChainId);
+
+        // Pin down the precondition the fix relies on: while the backfill is pending, the real
+        // base token's `totalSupply()` genuinely reverts with `BaseTokenPreV31TotalSupplyNotSet`.
+        // This is the exact call `_needToForceSetAssetMigrationOnL2` makes, so without the fix the
+        // finalization below reverts with this very error instead of recording the deposit.
+        vm.expectRevert(BaseTokenPreV31TotalSupplyNotSet.selector);
+        IERC20(address(L2_BASE_TOKEN_SYSTEM_CONTRACT)).totalSupply();
 
         // Register the base token exactly as the V31 upgrade does for an existing chain.
         vm.prank(L2_COMPLEX_UPGRADER_ADDR);

--- a/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2AssetTracker.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2AssetTracker.t.sol
@@ -29,6 +29,7 @@ import {MAX_TOKEN_BALANCE} from "contracts/bridge/asset-tracker/IAssetTrackerBas
 import {L2AssetTracker} from "contracts/bridge/asset-tracker/L2AssetTracker.sol";
 import {IL2AssetTracker} from "contracts/bridge/asset-tracker/IL2AssetTracker.sol";
 import {AssetAlreadyRegistered, AssetIdNotRegistered} from "contracts/bridge/asset-tracker/AssetTrackerErrors.sol";
+import {L2BaseTokenZKOS} from "contracts/l2-system/zksync-os/L2BaseTokenZKOS.sol";
 import {INativeTokenVaultBase} from "contracts/bridge/ntv/INativeTokenVaultBase.sol";
 import {L2NativeTokenVault} from "contracts/bridge/ntv/L2NativeTokenVault.sol";
 import {TestnetERC20Token} from "contracts/dev-contracts/TestnetERC20Token.sol";
@@ -614,5 +615,58 @@ abstract contract L2AssetTrackerTest is Test, SharedL2ContractDeployer {
         (bool isSaved, uint256 amount) = L2AssetTracker(L2_ASSET_TRACKER_ADDR).totalPreV31TotalSupply(assetId);
         assertTrue(isSaved, "totalPreV31TotalSupply.isSaved should be true");
         assertEq(amount, totalSupply, "totalPreV31TotalSupply.amount should match token totalSupply");
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════════
+    //  Regression: `handleFinalizeBaseTokenBridgingOnL2` must not read the base-token
+    //  `totalSupply()` while the pre-V31 supply is still pending backfill.
+    //
+    //  `_needToForceSetAssetMigrationOnL2` reads `totalSupply()` as a proxy for "no deposit
+    //  finalized yet". On a ZKsync OS chain upgraded from a pre-v31 version, the base token's
+    //  `totalSupply()` reverts with `BaseTokenPreV31TotalSupplyNotSet` until it is backfilled,
+    //  so before the fix the first base-token deposit finalization reverted. With a real
+    //  `L2BaseTokenZKOS` at the base-token address (whose `totalSupply()` genuinely reverts
+    //  while the backfill is pending) the finalization must still succeed.
+    // ════════════════════════════════════════════════════════════════════════════════
+    function test_handleFinalizeBaseTokenBridgingOnL2_succeedsWhileBackfillPending() public {
+        bytes32 baseTokenAssetId = keccak256("zkos_base_token_pending_backfill");
+        uint256 l1ChainId = 1;
+
+        // Use the real ZKsync OS base token: its `totalSupply()` reverts while the pre-V31
+        // supply has not been backfilled, so no mock is needed for the behaviour under test.
+        vm.etch(address(L2_BASE_TOKEN_SYSTEM_CONTRACT), address(new L2BaseTokenZKOS()).code);
+
+        stdstore.target(L2_ASSET_TRACKER_ADDR).sig("BASE_TOKEN_ASSET_ID()").checked_write(uint256(baseTokenAssetId));
+        stdstore.target(L2_ASSET_TRACKER_ADDR).sig("L1_CHAIN_ID()").checked_write(l1ChainId);
+        stdstore.target(L2_ASSET_TRACKER_ADDR).sig("needBaseTokenTotalSupplyBackfill()").checked_write(true);
+        stdstore
+            .target(address(L2_NATIVE_TOKEN_VAULT_ADDR))
+            .sig("originChainId(bytes32)")
+            .with_key(baseTokenAssetId)
+            .checked_write(l1ChainId);
+
+        // Register the base token exactly as the V31 upgrade does for an existing chain.
+        vm.prank(L2_COMPLEX_UPGRADER_ADDR);
+        L2_ASSET_TRACKER.registerBaseTokenDuringUpgrade();
+
+        // Settle on L1 so the deposit is accounted (same mock the sibling base-token tests use).
+        vm.mockCall(
+            address(L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT),
+            abi.encodeWithSelector(L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT.currentSettlementLayerChainId.selector),
+            abi.encode(l1ChainId)
+        );
+
+        uint256 depositsBefore = _readTotalSuccessfulDepositsFromL1(baseTokenAssetId);
+
+        // The asset migration number is 0 (never set), which is exactly the path that reached the
+        // reverting `totalSupply()` read before the fix; the finalization must now succeed.
+        vm.prank(L2_BASE_TOKEN_HOLDER_ADDR);
+        L2_ASSET_TRACKER.handleFinalizeBaseTokenBridgingOnL2(l1ChainId, 300);
+
+        assertEq(
+            _readTotalSuccessfulDepositsFromL1(baseTokenAssetId) - depositsBefore,
+            300,
+            "base-token deposit should be recorded while the supply is pending backfill"
+        );
     }
 }


### PR DESCRIPTION
## What

Adds a regression test for the base-token `totalSupply()` usage fix in `L2AssetTracker`. Stacked on top of the fix branch; this PR contains **only tests**.

## The bug being covered

`L2AssetTracker._needToForceSetAssetMigrationOnL2` reads a token's live `totalSupply()` as a proxy for "no deposit finalized yet" (`totalSupply() == 0`). For the **base token of a ZKsync OS chain upgraded from a pre-v31 version**, `L2BaseTokenZKOS.totalSupply()` reverts with `BaseTokenPreV31TotalSupplyNotSet` until the supply is backfilled — so the first base-token deposit finalization (`handleFinalizeBaseTokenBridgingOnL2`) reverted. The fix short-circuits that read while `needBaseTokenTotalSupplyBackfill` is set for the base token.

## Test added

In `test/foundry/l1/integration/l2-tests-abstract/L2AssetTracker.t.sol` (runs in the L1 context via `L2AssetTrackerL1Test`):

- `test_handleFinalizeBaseTokenBridgingOnL2_succeedsWhileBackfillPending` — etches the **real** `L2BaseTokenZKOS` at the base-token address (no mock for the behaviour under test), sets the backfill flag, and asserts the first base-token deposit finalization succeeds and records the deposit while the asset migration number is still `0` (the exact path that reached the reverting `totalSupply()` read before the fix).

  The test also pins down the precondition explicitly:

  ```solidity
  vm.expectRevert(BaseTokenPreV31TotalSupplyNotSet.selector);
  IERC20(address(L2_BASE_TOKEN_SYSTEM_CONTRACT)).totalSupply();
  ```

  i.e. while the backfill is pending the real base token's `totalSupply()` genuinely reverts — the same call `_needToForceSetAssetMigrationOnL2` makes — so without the fix the finalization reverts with this very error instead of recording the deposit.

## Verification

```
forge test --ffi --match-contract L2AssetTrackerL1Test \
  --match-test test_handleFinalizeBaseTokenBridgingOnL2_succeedsWhileBackfillPending
# 1 passed; 0 failed   (with the fix)
```

Reverting the fix on the source branch and re-running makes the test fail with `BaseTokenPreV31TotalSupplyNotSet()` at the `handleFinalizeBaseTokenBridgingOnL2` call (the `expectRevert` precondition still passes) — confirming the test catches the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
