### PR TITLE
fix(zksync-os-genesis-gen): add license field to satisfy cargo-deny

### DIFF
--- a/tools/zksync-os-genesis-gen/Cargo.toml
+++ b/tools/zksync-os-genesis-gen/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zksync-os-genesis-gen"
 version = "0.1.0"
 edition = "2024"
+license = "MIT OR Apache-2.0"
 
 [lib]
 name = "zksync_os_genesis_gen"


### PR DESCRIPTION
Adds `license = "MIT OR Apache-2.0"` to `tools/zksync-os-genesis-gen/Cargo.toml`.

`cargo deny` raises an `unlicensed` error when the crate is pulled as a library dependency from another workspace that runs deny checks. The other tools in this repo all carry the same license expression.
