### PR TITLE
v31: use ValidatorTimelock for Era, MultisigCommitter for ZKsyncOS

### DIFF
--- a/l1-contracts/deploy-scripts/upgrade/v31/CTMUpgrade_v31.s.sol
+++ b/l1-contracts/deploy-scripts/upgrade/v31/CTMUpgrade_v31.s.sol
@@ -93,11 +93,15 @@ contract CTMUpgrade_v31 is Script, DefaultCTMUpgrade {
 
         // v31 adds `UPGRADER_ROLE` + `upgradeChainFromVersion()` (IChainUpgrader) to ValidatorTimelock;
         // existing chains' proxy still points at the v30 impl, so swap it under the same CREATE2 flow.
-        // Deploy `MultisigCommitter` (a superset of ValidatorTimelock) as the default validator impl so the
-        // upgrade does NOT downgrade proxies that already run a MultisigCommitter — the v31 stage-1 upgrade
-        // previously deployed plain `ValidatorTimelock` here, which silently dropped multisig-commit support.
+        // The validator implementation is chain-type specific:
+        //  - Era uses plain `ValidatorTimelock`.
+        //  - ZKsyncOS uses `MultisigCommitter` (a superset of ValidatorTimelock) so the upgrade does NOT
+        //    downgrade ZKsyncOS proxies that already run a MultisigCommitter — deploying plain
+        //    `ValidatorTimelock` there would silently drop multisig-commit support.
+        string memory validatorTimelockContractName = config.isZKsyncOS ? "MultisigCommitter" : "ValidatorTimelock";
+        console.log("Deploying validator timelock implementation:", validatorTimelockContractName);
         ctmAddresses.stateTransition.implementations.validatorTimelock = deploySimpleContract(
-            "MultisigCommitter",
+            validatorTimelockContractName,
             false
         );
 
@@ -105,10 +109,13 @@ contract CTMUpgrade_v31 is Script, DefaultCTMUpgrade {
     }
 
     /// @notice Append the ValidatorTimelock proxy-admin upgrade to the stage-1 governance bundle.
-    /// @dev Plain `ProxyAdmin.upgrade` (not `upgradeAndCall`): the new `MultisigCommitter` impl is deployed
-    ///      with no reinitializer call. Proxies already running a MultisigCommitter are at `_initialized=2`
-    ///      with their multisig storage intact, so the swap just restores the multisig code; calling
-    ///      `reinitializeV2()` again would revert "already initialized".
+    /// @dev Plain `ProxyAdmin.upgrade` (not `upgradeAndCall`): the new impl (Era: `ValidatorTimelock`,
+    ///      ZKsyncOS: `MultisigCommitter`) is deployed with no reinitializer call.
+    ///      - ZKsyncOS proxies already run a MultisigCommitter at `_initialized=2` with their multisig
+    ///        storage intact, so the swap just restores the multisig code; calling `reinitializeV2()`
+    ///        again would revert "already initialized".
+    ///      - `ValidatorTimelock` has no v2 reinitializer and adds no new storage (the v31 `UPGRADER_ROLE`
+    ///        is granted lazily when validators are (re)added), so the plain swap is storage-compatible.
     function prepareVersionSpecificStage1GovernanceCallsL1() public virtual override returns (Call[] memory calls) {
         address validatorTimelockProxy = ctmAddresses.stateTransition.proxies.validatorTimelock;
         address newImpl = ctmAddresses.stateTransition.implementations.validatorTimelock;

--- a/l1-contracts/deploy-scripts/upgrade/v31/CTMUpgrade_v31.s.sol
+++ b/l1-contracts/deploy-scripts/upgrade/v31/CTMUpgrade_v31.s.sol
@@ -109,13 +109,10 @@ contract CTMUpgrade_v31 is Script, DefaultCTMUpgrade {
     }
 
     /// @notice Append the ValidatorTimelock proxy-admin upgrade to the stage-1 governance bundle.
-    /// @dev Plain `ProxyAdmin.upgrade` (not `upgradeAndCall`): the new impl (Era: `ValidatorTimelock`,
-    ///      ZKsyncOS: `MultisigCommitter`) is deployed with no reinitializer call.
-    ///      - ZKsyncOS proxies already run a MultisigCommitter at `_initialized=2` with their multisig
-    ///        storage intact, so the swap just restores the multisig code; calling `reinitializeV2()`
-    ///        again would revert "already initialized".
-    ///      - `ValidatorTimelock` has no v2 reinitializer and adds no new storage (the v31 `UPGRADER_ROLE`
-    ///        is granted lazily when validators are (re)added), so the plain swap is storage-compatible.
+    /// @dev Plain `ProxyAdmin.upgrade` (not `upgradeAndCall`): the new `MultisigCommitter` impl is deployed
+    ///      with no reinitializer call. Proxies already running a MultisigCommitter are at `_initialized=2`
+    ///      with their multisig storage intact, so the swap just restores the multisig code; calling
+    ///      `reinitializeV2()` again would revert "already initialized".
     function prepareVersionSpecificStage1GovernanceCallsL1() public virtual override returns (Call[] memory calls) {
         address validatorTimelockProxy = ctmAddresses.stateTransition.proxies.validatorTimelock;
         address newImpl = ctmAddresses.stateTransition.implementations.validatorTimelock;

--- a/l1-contracts/upgrade-envs/v0.31.0-interopB/output/testnet/sim-inputs/manifest.json
+++ b/l1-contracts/upgrade-envs/v0.31.0-interopB/output/testnet/sim-inputs/manifest.json
@@ -3,27 +3,21 @@
     {
       "file": "01_ecosystem.upgrade-prepare-all_0x5555555590930f501c88b73ea43b3eeb5a71643c.safe.json",
       "index": 1,
-      "steps": [
-        "ecosystem.upgrade-prepare-all"
-      ],
+      "steps": ["ecosystem.upgrade-prepare-all"],
       "target": "0x5555555590930f501c88b73ea43b3eeb5a71643c",
       "tx_count": 3
     },
     {
       "file": "02_ecosystem.upgrade-prepare-all_0x343ee72ddd8ccd80cd43d6adbc6c463a2de433a7.safe.json",
       "index": 2,
-      "steps": [
-        "ecosystem.upgrade-prepare-all"
-      ],
+      "steps": ["ecosystem.upgrade-prepare-all"],
       "target": "0x343ee72ddd8ccd80cd43d6adbc6c463a2de433a7",
       "tx_count": 3
     },
     {
       "file": "03_ecosystem.upgrade-prepare-all_0x5555555590930f501c88b73ea43b3eeb5a71643c.safe.json",
       "index": 3,
-      "steps": [
-        "ecosystem.upgrade-prepare-all"
-      ],
+      "steps": ["ecosystem.upgrade-prepare-all"],
       "target": "0x5555555590930f501c88b73ea43b3eeb5a71643c",
       "tx_count": 6
     }

--- a/protocol-ops/src/upgrade_verification/versions/v31/elements/deployed_addresses.rs
+++ b/protocol-ops/src/upgrade_verification/versions/v31/elements/deployed_addresses.rs
@@ -1079,6 +1079,15 @@ async fn verify_ctm_provenance(
         CtmFlavor::ZksyncOs => "l1-contracts/ZKsyncOSChainTypeManager",
     };
 
+    // Per-flavor validator implementation. Era keeps plain `ValidatorTimelock`;
+    // ZKsyncOS deploys `MultisigCommitter` (a superset with the same `(bridgehub)`
+    // constructor) so its upgrade does not downgrade proxies already running a
+    // MultisigCommitter. Both share the same constructor, only the bytecode differs.
+    let validator_timelock_file = match ctm.flavor {
+        CtmFlavor::Era => "l1-contracts/ValidatorTimelock",
+        CtmFlavor::ZksyncOs => "l1-contracts/MultisigCommitter",
+    };
+
     // Single dispatch table: (address, encoded ctor args, expected file).
     let checks: Vec<(Address, Vec<u8>, &str)> = vec![
         // CommitterFacet(_l1ChainId).
@@ -1149,14 +1158,15 @@ async fn verify_ctm_provenance(
         ),
         // Validator impl(bridgehub). Deployed once per CTM by `CTMUpgrade_v31`;
         // stage-1 governance swaps this behind the per-CTM ValidatorTimelock
-        // proxy. v31 deploys `MultisigCommitter` (a superset of ValidatorTimelock
-        // with the same `(bridgehub)` constructor) as the default validator impl,
-        // so the upgrade does not downgrade proxies already running a
+        // proxy. The impl is flavor-specific (see `validator_timelock_file`):
+        // Era uses plain `ValidatorTimelock`, ZKsyncOS uses `MultisigCommitter`
+        // (a superset of ValidatorTimelock with the same `(bridgehub)` constructor),
+        // so the ZKsyncOS upgrade does not downgrade proxies already running a
         // MultisigCommitter.
         (
             validator_timelock_impl,
             V31ValidatorTimelock::constructorCall::new((bridgehub_addr,)).abi_encode(),
-            "l1-contracts/MultisigCommitter",
+            validator_timelock_file,
         ),
     ];
     for (addr, args, file) in &checks {


### PR DESCRIPTION
Splits the v31 CTM-upgrade validator-timelock implementation per chain type instead of always deploying `MultisigCommitter`: **Era uses `ValidatorTimelock`, ZKsyncOS uses `MultisigCommitter`**.

## What ❔

- **`l1-contracts/deploy-scripts/upgrade/v31/CTMUpgrade_v31.s.sol`** — `deployNewCTMContracts()` now picks the validator impl by `config.isZKsyncOS` (`MultisigCommitter` for ZKsyncOS, `ValidatorTimelock` for Era), mirroring the existing per-flavor `ChainTypeManager` selection. Comments on the deploy block updated.
- **`protocol-ops/src/upgrade_verification/versions/v31/elements/deployed_addresses.rs`** — `verify_ctm_provenance` hardcoded the expected validator implementation bytecode as `l1-contracts/MultisigCommitter` for every CTM. It is now flavor-aware (`Era → l1-contracts/ValidatorTimelock`, `ZKsyncOs → l1-contracts/MultisigCommitter`), matching the `ctm_file` pattern already used in that function. Both bytecode names already exist in `AllContractsHashes.json`; the constructor is identical (`(bridgehub)`).

## Why ❔

The previous behavior deployed `MultisigCommitter` for every CTM so the upgrade wouldn't downgrade proxies already running a MultisigCommitter. We only want the multisig-commit superset on ZKsyncOS; Era should stay on plain `ValidatorTimelock`.

The stage-1 `ProxyAdmin.upgrade` remains a plain swap (no reinitializer) for both flavors:
- `ValidatorTimelock` has no v2 reinitializer and introduces no new storage — the v31 `UPGRADER_ROLE` is granted lazily when validators are (re)added — so the in-place swap is storage-compatible.
- `MultisigCommitter` proxies are already at `_initialized=2` with their multisig storage intact, so calling `reinitializeV2()` again would revert.

## Follow-up: regenerate committed artifacts

The committed calldata snapshots `l1-contracts/upgrade-envs/v0.31.0-interopB/output/{testnet,stage}/ecosystem.toml` each contain an `[ctms.era]` section whose `validator_timelock_implementation_addr` (and the dependent stage-1 Era VT `ProxyAdmin.upgrade` calldata) still bake `MultisigCommitter`. These need a regen so Era resolves to `ValidatorTimelock`.

The diff is deterministic and focused: the CREATE2 salt is committed (`create2_factory_salt`) and the factory is the singleton `0x4e59…4956C`, so only the Era validator impl address and its single stage-1 call change — everything else (including the entire ZKsyncOS section) is unaffected. Left to the branch owner to regenerate with the canonical deployer via `l1-contracts/test/anvil-interop/regen-and-verify.sh {testnet,stage}`.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.

## CI

Also prettier-formatted `output/testnet/sim-inputs/manifest.json` (single-element `steps` arrays collapsed). This was a pre-existing `Lint` failure on the base branch — unrelated to the validator-timelock change — included here so this PR's `Lint` job is green.
