### PR TITLE
fix(anvil-interop): write CTM-output fields needed by aux-ownership step

### DIFF
--- a/l1-contracts/test/foundry/l1/integration/_EcosystemUpgradeV31ForTests.sol
+++ b/l1-contracts/test/foundry/l1/integration/_EcosystemUpgradeV31ForTests.sol
@@ -28,18 +28,42 @@ contract CTMUpgradeV31ForTests is CTMUpgrade_v31 {
         // no-op
     }
 
-    /// @dev Replaces the heavy state_transition section with the two fields the
-    ///      anvil-interop test actually reads (diamond cut data + default upgrade addr).
+    /// @dev Replaces the heavy state_transition section with the minimal fields the
+    ///      downstream tooling reads:
+    ///        - `chain_upgrade_diamond_cut` + `state_transition.default_upgrade_addr`
+    ///          are consumed by the anvil-interop test harness.
+    ///        - `state_transition.verifier_addr` plus
+    ///          `deployed_addresses.{l1_governance_upgrade_timer,l1_rollup_da_manager}`
+    ///          are consumed by protocol-ops' post-prepare auxiliary-ownership step
+    ///          (`read_aux_ownership_targets` → `ensureOwnable2StepTargetsOwnedByGovernanceWithWraps`).
+    ///      Only addresses are serialized (no heavy `bytes` blobs other than the diamond
+    ///      cut) so accumulated `vm.serialize*` JSON stays well under forge's 128 MB EVM memory.
     function saveOutput(string memory outputPath) internal override {
         bytes memory upgradeCutData = getChainUpgradeDiamondCutData();
-        address defaultUpgradeAddr = getAddresses().stateTransition.defaultUpgrade;
 
+        // state_transition section
+        vm.serializeAddress("state_transition", "verifier_addr", getAddresses().stateTransition.verifiers.verifier);
         string memory stateTransition = vm.serializeAddress(
             "state_transition",
             "default_upgrade_addr",
-            defaultUpgradeAddr
+            getAddresses().stateTransition.defaultUpgrade
         );
+
+        // deployed_addresses section: the Ownable2Step targets protocol-ops transfers
+        // to governance after prepare.
+        vm.serializeAddress(
+            "deployed_addresses",
+            "l1_rollup_da_manager",
+            getAddresses().daAddresses.daContracts.rollupDAManager
+        );
+        string memory deployedAddresses = vm.serializeAddress(
+            "deployed_addresses",
+            "l1_governance_upgrade_timer",
+            upgradeAddresses.upgradeTimer
+        );
+
         vm.serializeBytes("root", "chain_upgrade_diamond_cut", upgradeCutData);
+        vm.serializeString("root", "deployed_addresses", deployedAddresses);
         string memory toml = vm.serializeString("root", "state_transition", stateTransition);
         vm.writeToml(toml, outputPath);
     }


### PR DESCRIPTION
## Problem

The **Anvil Interop CI** (`v29-to-v31-upgrade-test` and `v30-to-v31-upgrade-test`) has been failing since commit `3ce5cdf` (\"some fixes\") with:

```
parse .../l1-contracts/script-out/v31-upgrade-ctm-0x….toml
  0: TOML parse error at line 3, column 1
3 | [state_transition]
  | ^^^^^^^^^^^^^^^^^^
missing field `verifier_addr`
```

That commit added a post-prepare **auxiliary-ownership** step to `protocol-ops`
(`run_aux_ownership_steps` → `read_aux_ownership_targets` →
`AdminFunctions.ensureOwnable2StepTargetsOwnedByGovernanceWithWraps`). It parses
each per-CTM `v31-upgrade-ctm-*.toml` emitted by the prepare script and **requires**:

- `state_transition.verifier_addr`
- `deployed_addresses.l1_governance_upgrade_timer`
- `deployed_addresses.l1_rollup_da_manager`

The production `DefaultCTMUpgrade.saveOutput` writes all of these, so real
upgrades are unaffected. But the **memory-trimmed test variant**
`CTMUpgradeV31ForTests.saveOutput` only wrote `state_transition.default_upgrade_addr`
(plus `chain_upgrade_diamond_cut`) to stay under forge's 128 MB EVM-memory limit.
The new strict parser then failed on the missing fields, aborting the prepare phase.

## Fix

Serialize the three additional addresses the aux-ownership step reads from the
test variant's `saveOutput`. These are plain addresses (no extra heavy `bytes`
blobs beyond the existing diamond-cut), so accumulated `vm.serialize*` JSON stays
well under the memory limit, and the new aux-ownership code path is now actually
exercised by CI.

The production parser is intentionally left strict (fields remain required), so a
genuinely malformed production output still fails loudly rather than silently
skipping ownership transfers.

## Verification

Ran both upgrade scenarios locally end-to-end (foundry-zksync v0.1.5, anvil v1.5.1):

- `run-v29-to-v31-upgrade-test.ts` — aux-ownership step ran (1 target), `upgrade-prepare-all completed`, `✅ All protocol versions verified successfully!`
- `run-v30-to-v31-upgrade-test.ts` — aux-ownership step ran (2 targets), `upgrade-prepare-all completed`, `✅ All protocol versions verified successfully!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)