### PR TITLE
ci: add generate-ecosystem-upgrade-calldata workflow

### DIFF
--- a/.github/workflows/generate-ecosystem-upgrade-calldata.yaml
+++ b/.github/workflows/generate-ecosystem-upgrade-calldata.yaml
@@ -1,0 +1,15 @@
+name: "Ecosystem Upgrade Calldata"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: List repository contents
+        run: ls -a

--- a/system-contracts/scripts/preprocess-bootloader.ts
+++ b/system-contracts/scripts/preprocess-bootloader.ts
@@ -16,7 +16,7 @@ const SYSTEM_PARAMS = require("../../SystemConfig.json");
 const OUTPUT_DIR_1 = "contracts-preprocessed/bootloader";
 const OUTPUT_DIR_2 = "bootloader/build";
 
-const PREPROCCESING_MODES = ["proved_batch", "playground_batch"];
+const PREPROCESSING_MODES = ["proved_batch", "playground_batch"];
 
 function getSelector(contractName: string, method: string): string {
   let contractInterface;
@@ -175,7 +175,7 @@ function createTestFramework(tests: string[]): string {
 function validateSource(source: string) {
   const matches = source.matchAll(/<!-- @if BOOTLOADER_TYPE=='([^']*)' -->/g);
   for (const match of matches) {
-    if (!PREPROCCESING_MODES.includes(match[1])) {
+    if (!PREPROCESSING_MODES.includes(match[1])) {
       throw Error(`Invalid preprocessing mode '${match[1]}' at position ${match.index}`);
     }
   }


### PR DESCRIPTION
Adds `.github/workflows/generate-ecosystem-upgrade-calldata.yaml`, a `workflow_dispatch` workflow that checks out the repo and lists its contents (`ls -a`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)