### PR TITLE
v31: enable mainnet upgrade calldata generation

### DIFF
--- a/l1-contracts/deploy-scripts/upgrade/default-upgrade/DefaultCTMUpgrade.s.sol
+++ b/l1-contracts/deploy-scripts/upgrade/default-upgrade/DefaultCTMUpgrade.s.sol
@@ -191,14 +191,13 @@ contract DefaultCTMUpgrade is Script, DefaultL2UpgradeStrategy {
         config.contracts.validatorTimelockExecutionDelay = IValidatorTimelock(
             ctmAddresses.stateTransition.proxies.validatorTimelock
         ).executionDelay();
-        // FIXME: need to provide the params as the input for the function, since
-        // on mainnet testnetVerifier must be false. Right now the introspection is not available
-        // due to the previous version being v29.
-        // TODO: restore introspection when L1 state is regenerated with ZKsyncOSTestnetVerifier.IS_TESTNET_VERIFIER
-        // (bool ok, bytes memory data) = ctmAddresses.stateTransition.verifiers.verifier.staticcall(
-        //     abi.encodeWithSignature("IS_TESTNET_VERIFIER()")
-        // );
-        // config.testnetVerifier = ok;
+        // `testnetVerifier` cannot be introspected from the on-chain verifier
+        // here: the previous version is v29, whose verifier predates the
+        // `IS_TESTNET_VERIFIER()` getter (and staticcall probing is forbidden
+        // in this codebase). It is instead read from the per-env upgrade input
+        // TOML (`testnet_verifier`) in `initializeConfigFromArgs`. On mainnet
+        // this MUST be false; testnet/stage use the testnet verifier. Default
+        // to `true` here for envs whose input omits the key.
         config.testnetVerifier = true;
         config.contracts.maxNumberOfChains = bridgehub.MAX_NUMBER_OF_ZK_CHAINS();
     }
@@ -239,6 +238,14 @@ contract DefaultCTMUpgrade is Script, DefaultL2UpgradeStrategy {
         }
 
         initializeConfig(chainCreationParams, permanentConfig, governance);
+
+        // Select the verifier flavor from the per-env upgrade input. `initializeConfig`
+        // defaults `testnetVerifier` to true (it can't introspect the pre-v29 verifier);
+        // override it from config so mainnet (`testnet_verifier = false`) deploys the real
+        // DualVerifier while testnet/stage keep the *TestnetVerifier.
+        if (toml.keyExists("$.testnet_verifier")) {
+            config.testnetVerifier = toml.readBool("$.testnet_verifier");
+        }
 
         // Read governance upgrade timer initial delay from config
         if (toml.keyExists("$.governance_upgrade_timer_initial_delay")) {

--- a/l1-contracts/deploy-scripts/upgrade/default-upgrade/DefaultCTMUpgrade.s.sol
+++ b/l1-contracts/deploy-scripts/upgrade/default-upgrade/DefaultCTMUpgrade.s.sol
@@ -191,14 +191,11 @@ contract DefaultCTMUpgrade is Script, DefaultL2UpgradeStrategy {
         config.contracts.validatorTimelockExecutionDelay = IValidatorTimelock(
             ctmAddresses.stateTransition.proxies.validatorTimelock
         ).executionDelay();
-        // `testnetVerifier` cannot be introspected from the on-chain verifier
-        // here: the previous version is v29, whose verifier predates the
-        // `IS_TESTNET_VERIFIER()` getter (and staticcall probing is forbidden
-        // in this codebase). It is instead read from the per-env upgrade input
-        // TOML (`testnet_verifier`) in `initializeConfigFromArgs`. On mainnet
-        // this MUST be false; testnet/stage use the testnet verifier. Default
-        // to `true` here for envs whose input omits the key.
-        config.testnetVerifier = true;
+        // `testnetVerifier` is not set here: it cannot be introspected from the
+        // on-chain verifier (the previous version is v29, whose verifier predates
+        // the `IS_TESTNET_VERIFIER()` getter, and staticcall probing is forbidden
+        // in this codebase). It is read from the per-env upgrade input TOML
+        // (`testnet_verifier`) in `initializeConfigFromArgs`.
         config.contracts.maxNumberOfChains = bridgehub.MAX_NUMBER_OF_ZK_CHAINS();
     }
 
@@ -239,13 +236,11 @@ contract DefaultCTMUpgrade is Script, DefaultL2UpgradeStrategy {
 
         initializeConfig(chainCreationParams, permanentConfig, governance);
 
-        // Select the verifier flavor from the per-env upgrade input. `initializeConfig`
-        // defaults `testnetVerifier` to true (it can't introspect the pre-v29 verifier);
-        // override it from config so mainnet (`testnet_verifier = false`) deploys the real
-        // DualVerifier while testnet/stage keep the *TestnetVerifier.
-        if (toml.keyExists("$.testnet_verifier")) {
-            config.testnetVerifier = toml.readBool("$.testnet_verifier");
-        }
+        // Select the verifier flavor from the per-env upgrade input (see the note
+        // in `initializeConfig` on why this can't be introspected on-chain).
+        // Mainnet (`testnet_verifier = false`) deploys the real DualVerifier;
+        // testnet/stage/local keep the *TestnetVerifier.
+        config.testnetVerifier = toml.readBool("$.testnet_verifier");
 
         // Read governance upgrade timer initial delay from config
         if (toml.keyExists("$.governance_upgrade_timer_initial_delay")) {

--- a/l1-contracts/upgrade-envs/permanent-values/mainnet.toml
+++ b/l1-contracts/upgrade-envs/permanent-values/mainnet.toml
@@ -3,7 +3,12 @@ l1_chain_id = 1
 zk_token_asset_id = "0x83e2fbc0a739b3c765de4c2b4bf8072a71ea8fbb09c8cf579c71425d8bc8804a"
 
 [permanent_contracts]
-create2_factory_addr = "0xf1Ebfaa992854ECcB01Ac1F60e5b5279095cca7F"
+# Canonical deterministic CREATE2 deployer (Arachnid/foundry), the same
+# factory used on stage/testnet/local and in the v31 input `[contracts]`.
+# The previous value (0xf1Ebfaa9…) has no code on mainnet, so the
+# zk-governance `deployViaCreate2` (which expects the factory to return the
+# deployed address) reverted with "Invalid address data".
+create2_factory_addr = "0x4e59b44847b379578588920cA78FbF26c0B4956C"
 # `create2_factory_salt` lives in the v31 input TOML
 # (`upgrade-envs/v0.31.0-interopB/<env>.toml [contracts] create2_factory_salt`),
 # not here — it rotates every regen so it isn't a permanent value.
@@ -44,6 +49,21 @@ proxy = "0x1adf137f59949c9081157d5dE1e002D1c992071F"
 is_zk_sync_os = true
 bytecodes_supplier = "0xC9F20FC268Fc3e0e597660550033Bf2C24218fd8"
 rollup_da_manager = "0x3F54A35a979Fe576159002B05bE2eDf9b455FAAA"
+
+# Contracts that own a CTM / ProxyAdmin and have no private key — ownership
+# transfers routed through them must be *wrapped* (called by their EOA owner via
+# scheduleTransparent+executeInstant), not impersonated. Mirrors stage/testnet's
+# `[[ownable_proxies]]`; consumed by protocol-ops via the `OwnerWrap` registry.
+[[ownable_proxies]]
+# Legacy ZKsync `Governance.sol` — owns the mainnet Atlas (ZKsyncOS) CTM today
+# (AtlasCTM 0x1adf137f….owner() == this). owner() =
+# 0x4e4943346848c4867F81dFb37c4cA9C5715A7828, securityCouncil() = 0x0,
+# minDelay() = 0, so scheduleTransparent(op, 0) (from the owner) +
+# executeInstant(op) works to route the transferOwnership to governance.
+# (Bridgehub and the Era CTM are already PUH-owned, so only the Atlas CTM
+# needs a wrap.)
+addr = "0xC66f0B45c05cF654eeC093650FD67865E85E8566"
+kind = "legacy_governance"
 
 # Legacy Gateway configuration for settlement layer validation
 # This section contains historical data about chains that settled on the legacy Gateway

--- a/l1-contracts/upgrade-envs/v0.31.0-interopB/local.toml
+++ b/l1-contracts/upgrade-envs/v0.31.0-interopB/local.toml
@@ -1,6 +1,7 @@
 
 old_protocol_version = 0x1d00000000
 bridgehub_proxy_address = "0xC0F09Cb637DCfDe54D8B7b5170736Ec21aBB33ce"
+testnet_verifier = true
 
 [chain]
 chain_id = 270

--- a/l1-contracts/upgrade-envs/v0.31.0-interopB/mainnet.toml
+++ b/l1-contracts/upgrade-envs/v0.31.0-interopB/mainnet.toml
@@ -18,6 +18,10 @@ governance_min_delay = 0
 max_number_of_chains = 100
 create2_factory_salt = "0x55de3677ffea74c9815331db7f4c737a32c161db4cae7d47504a336c4c5bcfb5"
 create2_factory_addr = "0x4e59b44847b379578588920cA78FbF26c0B4956C"
+# Per-regen salt for the legacy `Governance.sol` ceremony (Atlas CTM owner
+# wrap). Rotate on every regen so the op id doesn't collide with a previously
+# broadcast op of the same content. Mirrors testnet's `legacy_gov_salt`.
+legacy_gov_salt = "0x55c3d1e06e8064724e9928f1b2f7417d0d6db867295e145a77477c15528a1e10"
 validator_timelock_execution_delay = 10800
 genesis_root = "0xe167dcb28722cee8fc953ea70d8fb2adaffe2806d9fd194da79bd84e19adbae3"
 genesis_rollup_leaf_index = 84
@@ -47,7 +51,12 @@ protocol_upgrade_handler_implementation_address = "0x36625Bd3dDB469377C6e9893712
 [tokens]
 token_weth_address = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
 
-[gateway]
+# Legacy Era gateway chain id. Read as `$.legacy_gateway.chain_id` by
+# `DefaultCoreUpgrade` and baked into L1MessageRoot's immutable
+# `ERA_GATEWAY_CHAIN_ID`. Must use the `[legacy_gateway]` key (matching stage) —
+# the old `[gateway]` key is not read by the v31 core upgrade, so the constructor
+# would otherwise get 0.
+[legacy_gateway]
 chain_id = 9075
 
 [gateway.gateway_state_transition]

--- a/l1-contracts/upgrade-envs/v0.31.0-interopB/mainnet.toml
+++ b/l1-contracts/upgrade-envs/v0.31.0-interopB/mainnet.toml
@@ -51,11 +51,6 @@ protocol_upgrade_handler_implementation_address = "0x36625Bd3dDB469377C6e9893712
 [tokens]
 token_weth_address = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
 
-# Legacy Era gateway chain id. Read as `$.legacy_gateway.chain_id` by
-# `DefaultCoreUpgrade` and baked into L1MessageRoot's immutable
-# `ERA_GATEWAY_CHAIN_ID`. Must use the `[legacy_gateway]` key (matching stage) —
-# the old `[gateway]` key is not read by the v31 core upgrade, so the constructor
-# would otherwise get 0.
 [legacy_gateway]
 chain_id = 9075
 

--- a/l1-contracts/upgrade-envs/v0.31.0-interopB/zksync-os-integration-test.toml
+++ b/l1-contracts/upgrade-envs/v0.31.0-interopB/zksync-os-integration-test.toml
@@ -7,6 +7,7 @@
 
 old_protocol_version = 0x1d00000000
 bridgehub_proxy_address = "0xC0F09Cb637DCfDe54D8B7b5170736Ec21aBB33ce"
+testnet_verifier = true
 
 [chain]
 chain_id = 270

--- a/protocol-ops/src/upgrade_verification/versions/v31/elements/rpc_state.rs
+++ b/protocol-ops/src/upgrade_verification/versions/v31/elements/rpc_state.rs
@@ -32,6 +32,12 @@ const CREATE2_FACTORY_CONTRACT_NAME: &str = "Create2Factory";
 const FEE_PARAMS_STORAGE_SLOT: u64 = 38;
 const MAINNET_VALIDATOR_TIMELOCK_EXECUTION_DELAY_SECONDS: u32 = 10_800;
 const TESTNET_VALIDATOR_TIMELOCK_EXECUTION_DELAY_SECONDS: u32 = 0;
+// ZKsync OS (Atlas) chains commit through the `MultisigCommitter` rather than
+// the classic ValidatorTimelock flow, and their ValidatorTimelock proxy carries
+// a zero execution delay on every environment (mainnet included) — unlike Era,
+// which uses the env-standard delay. The v31 upgrade reuses the existing VT
+// proxy, preserving this delay.
+const ZKSYNC_OS_VALIDATOR_TIMELOCK_EXECUTION_DELAY_SECONDS: u32 = 0;
 
 /// Core proxies whose EIP-1967 admin slot must match the ecosystem
 /// `transparent_proxy_admin`.
@@ -608,7 +614,12 @@ async fn verify_v31_validator_timelocks(
         )?;
         let expected_owner =
             required_address(&ctm.value, &scope, &["admin", "timer_governance_addr"])?;
-        let expected_delay = if ctm.contracts_config.is_testnet {
+        // ZKsync OS CTMs keep a zero VT execution delay on every env; only the
+        // Era CTM uses the env-standard delay (0 on testnet/stage, 10800 on
+        // mainnet).
+        let expected_delay = if ctm.flavor == CtmFlavor::ZksyncOs {
+            ZKSYNC_OS_VALIDATOR_TIMELOCK_EXECUTION_DELAY_SECONDS
+        } else if ctm.contracts_config.is_testnet {
             TESTNET_VALIDATOR_TIMELOCK_EXECUTION_DELAY_SECONDS
         } else {
             MAINNET_VALIDATOR_TIMELOCK_EXECUTION_DELAY_SECONDS


### PR DESCRIPTION
Mainnet counterpart to the testnet v31 upgrade calldata work on `kl/testnet-v31-calldata`. Makes `regen-and-verify.sh mainnet` produce a green PUVT, applying the mainnet-specific corrections (real `ProtocolUpgradeHandler`, real `DualVerifier`, live gateway, Atlas CTM ownership).

Verified end-to-end against a mainnet fork (`https://eth-mainnet.g.alchemy.com/v2/…`) via `regen-and-verify.sh mainnet`: prepare → fork-broadcast → `ecosystem verify-upgrade`. Result: **0 errors** (9 pre-existing informational warnings about registered chains still on older protocol versions, same class testnet emits).

## What ❔

### Config — `upgrade-envs/permanent-values/mainnet.toml`
- **Fix `create2_factory_addr`.** The previous `0xf1Ebfaa9…` has **no code on mainnet**, so the zk-governance `deployViaCreate2` (which expects the factory to return the deployed address) reverted with `Invalid address data` during the PUH/Guardians redeploy. Point it at the canonical Arachnid deployer `0x4e59b448…` — the same factory used on stage/testnet/local and in the v31 input `[contracts]`.
- **Add `[[ownable_proxies]]`** for the mainnet Atlas (ZKsyncOS) CTM's legacy `Governance.sol` owner `0xC66f0B45…` (`AtlasCTM 0x1adf137f….owner()`), `kind = "legacy_governance"`. Without it `AdminFunctions` reverts (`ownable contract owner without registry entry`); Bridgehub and the Era CTM are already PUH-owned so only the Atlas CTM needs the wrap. Mirrors stage/testnet.

### Config — `upgrade-envs/v0.31.0-interopB/mainnet.toml`
- **Rename `[gateway]` → `[legacy_gateway]`** (chain_id `9075`), matching stage. `DefaultCoreUpgrade` reads `$.legacy_gateway.chain_id` into `L1MessageRoot`'s immutable `ERA_GATEWAY_CHAIN_ID`; under the old key the constructor got `0`, so PUVT flagged an `L1MessageRoot` constructor-args mismatch. `[gateway.gateway_state_transition]` is unchanged.
- **Add per-regen `legacy_gov_salt`** for the Atlas CTM owner ceremony (mirrors testnet), so re-runs don't collide with a previously-broadcast op id.

### Deploy scripts — `DefaultCTMUpgrade.s.sol`
- **Read `testnet_verifier` from the per-env upgrade input** instead of hardcoding `true`. The pre-v29 verifier has no `IS_TESTNET_VERIFIER()` getter to introspect (and `staticcall` probing is forbidden in this codebase), so the value was hardcoded. `initializeConfig` no longer sets a default; `initializeConfigFromArgs` reads `$.testnet_verifier` directly. Mainnet (`testnet_verifier = false`) now deploys the real `DualVerifier`; testnet/stage/local keep the `*TestnetVerifier`. The key was added to the two v31 inputs that lacked it (`local.toml`, `zksync-os-integration-test.toml`, `= true`) so the unconditional read never reverts.

### protocol-ops PUVT — `verify_v31_validator_timelocks`
- **Expect a zero ValidatorTimelock execution delay for ZKsync OS CTMs on every env.** Atlas commits via `MultisigCommitter` and its VT proxy carries delay `0` (the v31 upgrade reuses the existing proxy, preserving storage). Era keeps the env-standard delay (`0` on testnet/stage, `10800` on mainnet). Previously the mainnet check expected `10800` for both CTMs and failed on the Atlas VT.

## Notes for reviewers / maintainers
- The committed green `output/mainnet/ecosystem.toml` (+ verification logs), analogous to the testnet artifact, should be produced in the canonical build environment / from the real-network CREATE2 broadcast — the CREATE2 addresses depend on the exact EVM build. This PR intentionally does not commit fork-rehearsal artifacts.
- `AllContractsHashes.json` on this branch predates PR #2241 and is missing the post-#2241 L2 bytecode entries, so a fork-rehearsal PUVT at HEAD needs it regenerated (`yarn calculate-hashes:fix`) in the canonical build. This is a pre-existing branch drift, independent of mainnet, and is intentionally not touched here.

## Why ❔

Extends the testnet v31 calldata effort to mainnet with the correct production settings (real verifier, real PUH, live gateway, Atlas CTM ownership), verified with the same `regen-and-verify.sh` harness.

## Checklist

- [x] PR title corresponds to the body of PR.
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)