### PR TITLE
test(atomic-interop): real message-inclusion for the atomic proof tests (de-mock)

### DIFF
--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProof.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProof.t.sol
@@ -21,17 +21,16 @@ import {IMTLeafValueMismatch, IMTLowLeafNextTooSmall} from "contracts/common/L1C
 /// of the L1-free atomic interop flow). Atomicity is deployed only on L1-settled ecosystems, so every
 /// fixture uses a single L1 settlement layer (`SETTLEMENT_LAYER_CHAIN_ID`).
 ///
-/// The IMT membership half is driven against a REAL {L2InteropCommitmentTree} (the oracle); the
-/// cross-chain message verifier is mocked (isolating the separately-tested message-inclusion layer)
-/// while the real `messageProof` blob is still parsed by `MessageHashing._getProofData`, so the
-/// settlement-layer / deadline / inclusion branches all run for real. See {AtomicInteropProofBuilder}.
+/// Both halves run for real: the IMT membership half is driven against a REAL {L2InteropCommitmentTree}
+/// (the oracle), and the cross-chain authentication half against the REAL {L2MessageVerification} + a real
+/// interop-root storage. Each proof is a genuine inclusion proof whose imported root the builder seeds
+/// (see {AtomicInteropProofBuilder} / {InteropInclusionProofLib}); the "root not included" branch is
+/// reached by withholding that seed, never by mocking the verifier.
 contract AtomicInteropProofTest is AtomicInteropProofBuilder {
     uint256 internal constant SOURCE_CHAIN_ID = 271;
     uint256 internal constant SETTLEMENT_LAYER_CHAIN_ID = 1; // L1
     uint256 internal constant BATCH_N = 100;
     uint64 internal constant DEADLINE = 1_000;
-
-    bytes32 internal constant WRONG_ROOT = bytes32(uint256(0x1234));
 
     uint256 internal committedValue;
     uint256 internal committedIndex;
@@ -39,14 +38,18 @@ contract AtomicInteropProofTest is AtomicInteropProofBuilder {
 
     function setUp() public {
         _setUpAtomicFixtures();
-        // The message verifier is authenticated-true by default; individual reverts re-mock it to false.
-        _mockVerifier(true);
 
         committedValue = _commitValue(keccak256("flowA"), keccak256("bundleA"));
         committedIndex = _insertCommit(committedValue);
 
         // A value for a flow that was never committed on this chain (used by the timeout/absence tests).
         absentValue = _commitValue(keccak256("flowB"), keccak256("bundleB"));
+    }
+
+    /// @dev Perturbs a membership path so it no longer hashes to the tree root, without touching the
+    /// leaf value — the IMT engine then reports non-membership rather than a value mismatch.
+    function _corruptMembershipPath(bytes32[] memory _path) internal pure {
+        _path[0] = bytes32(uint256(_path[0]) ^ 1);
     }
 
     // ============ commitValue ============
@@ -73,18 +76,23 @@ contract AtomicInteropProofTest is AtomicInteropProofBuilder {
         proofLib.verifyInclusion(proof, committedValue, DEADLINE, SETTLEMENT_LAYER_CHAIN_ID);
     }
 
-    /// @dev The root-authentication adapter must forward both message coordinates. Keeping them distinct
-    /// and non-zero prevents the all-zero default fixture from hiding a hardcoded index or tx number.
+    /// @dev The root-authentication adapter must forward both message coordinates. A wider log tree with a
+    /// non-zero `txNumberInBatch` / `messageIndex` binds them into the proven leaf, so if either coordinate
+    /// were dropped the (real) verifier could not reconstruct the imported root.
     function test_verifyInclusion_forwardsNonZeroMessageCoordinatesToVerifier() public {
-        ImtProof memory proof = _inclusionProof(
+        bytes32[] memory logSiblings = new bytes32[](1);
+        logSiblings[0] = keccak256("sibling-log");
+
+        ImtProof memory proof = _inclusionProofWithCoordinates(
             SOURCE_CHAIN_ID,
             BATCH_N,
             committedIndex,
             SETTLEMENT_LAYER_CHAIN_ID,
-            DEADLINE - 1
+            DEADLINE - 1,
+            7, // txNumberInBatch
+            1, // messageIndex (message sits at index 1 under logSiblings[0])
+            logSiblings
         );
-        proof.messageTxNumberInBatch = 7;
-        proof.messageIndex = 1;
 
         _expectRootAuthentication(proof);
         proofLib.verifyInclusion(proof, committedValue, DEADLINE, SETTLEMENT_LAYER_CHAIN_ID);
@@ -105,9 +113,9 @@ contract AtomicInteropProofTest is AtomicInteropProofBuilder {
 
     // ============ verifyInclusion — reverts ============
 
+    /// @dev The imported root is never seeded, so the real verifier cannot authenticate the root message.
     function test_RevertWhen_inclusion_rootMessageInclusionFails() public {
-        _mockVerifier(false);
-        ImtProof memory proof = _inclusionProof(
+        ImtProof memory proof = _unresolvedInclusionProof(
             SOURCE_CHAIN_ID,
             BATCH_N,
             committedIndex,
@@ -120,15 +128,8 @@ contract AtomicInteropProofTest is AtomicInteropProofBuilder {
     }
 
     function test_RevertWhen_inclusion_missingSettlementLayerAnchor() public {
-        ImtProof memory proof = _inclusionProof(
-            SOURCE_CHAIN_ID,
-            BATCH_N,
-            committedIndex,
-            SETTLEMENT_LAYER_CHAIN_ID,
-            DEADLINE - 1
-        );
-        // A final-node (single-level) proof carries no settlement-layer anchor.
-        proof.messageProof = _finalMessageProof();
+        // A final-node (single-level) proof authenticates but carries no settlement-layer anchor.
+        ImtProof memory proof = _missingAnchorProof(SOURCE_CHAIN_ID, BATCH_N, committedIndex);
         _expectRootAuthentication(proof);
         vm.expectRevert(abi.encodeWithSelector(ProofMissingSettlementLayerAnchor.selector, SOURCE_CHAIN_ID, BATCH_N));
         proofLib.verifyInclusion(proof, committedValue, DEADLINE, SETTLEMENT_LAYER_CHAIN_ID);
@@ -158,9 +159,10 @@ contract AtomicInteropProofTest is AtomicInteropProofBuilder {
         proofLib.verifyInclusion(proof, committedValue, DEADLINE, SETTLEMENT_LAYER_CHAIN_ID);
     }
 
-    /// @dev Correct commit value + correct settlement/deadline, but the membership proof does not hash to
-    /// the claimed root: the IMT check fails (distinct from a value/leaf mismatch, which the engine catches
-    /// earlier). We keep the real leaf (so `leaf.value == commitValue`) and only corrupt `chainImtRoot`.
+    /// @dev Correct commit value + correct settlement/deadline + authenticated root, but the membership
+    /// proof does not hash to the tree root: the IMT check fails (distinct from a value/leaf mismatch,
+    /// which the engine catches earlier). We keep the authenticated root real and only corrupt the
+    /// membership path, so the failure is isolated to the IMT half.
     function test_RevertWhen_inclusion_inclusionFailed() public {
         ImtProof memory proof = _inclusionProof(
             SOURCE_CHAIN_ID,
@@ -169,9 +171,9 @@ contract AtomicInteropProofTest is AtomicInteropProofBuilder {
             SETTLEMENT_LAYER_CHAIN_ID,
             DEADLINE - 1
         );
-        proof.chainImtRoot = WRONG_ROOT;
+        _corruptMembershipPath(proof.imtProof);
         _expectRootAuthentication(proof);
-        vm.expectRevert(abi.encodeWithSelector(ProofInclusionFailed.selector, WRONG_ROOT, committedValue));
+        vm.expectRevert(abi.encodeWithSelector(ProofInclusionFailed.selector, proof.chainImtRoot, committedValue));
         proofLib.verifyInclusion(proof, committedValue, DEADLINE, SETTLEMENT_LAYER_CHAIN_ID);
     }
 
@@ -269,6 +271,8 @@ contract AtomicInteropProofTest is AtomicInteropProofBuilder {
         proofLib.verifyTimeoutAdjacency(absence, successor, absentValue, DEADLINE, SETTLEMENT_LAYER_CHAIN_ID);
     }
 
+    /// @dev The low-nullifier leaf brackets `absentValue`, but its membership path no longer hashes to the
+    /// tree root, so absence is not certified. The authenticated root stays real.
     function test_RevertWhen_timeout_nonInclusionFailed() public {
         ImtProof memory absence = _nonInclusionProof(
             SOURCE_CHAIN_ID,
@@ -277,9 +281,7 @@ contract AtomicInteropProofTest is AtomicInteropProofBuilder {
             SETTLEMENT_LAYER_CHAIN_ID,
             DEADLINE - 1
         );
-        // The low-nullifier leaf brackets `absentValue`, but the membership path no longer hashes to the
-        // claimed root, so absence is not certified.
-        absence.chainImtRoot = WRONG_ROOT;
+        _corruptMembershipPath(absence.imtProof);
         ImtProof memory successor = _rootAuthProof(
             SOURCE_CHAIN_ID,
             BATCH_N + 1,
@@ -287,7 +289,7 @@ contract AtomicInteropProofTest is AtomicInteropProofBuilder {
             uint256(DEADLINE) + 1
         );
         _expectRootAuthentication(absence);
-        vm.expectRevert(abi.encodeWithSelector(ProofNonInclusionFailed.selector, WRONG_ROOT, absentValue));
+        vm.expectRevert(abi.encodeWithSelector(ProofNonInclusionFailed.selector, absence.chainImtRoot, absentValue));
         proofLib.verifyTimeoutAdjacency(absence, successor, absentValue, DEADLINE, SETTLEMENT_LAYER_CHAIN_ID);
     }
 
@@ -368,7 +370,8 @@ contract AtomicInteropProofTest is AtomicInteropProofBuilder {
         _expectRootAuthentication(inclusion);
         proofLib.verifyInclusion(inclusion, committedValue, DEADLINE, SETTLEMENT_LAYER_CHAIN_ID);
 
-        // Build an (illegitimate) absence proof using the committed value's true predecessor leaf.
+        // Build an (illegitimate) absence proof using the committed value's true predecessor leaf,
+        // authenticated by a real, seeded root proof.
         uint256 predIndex = _predecessorIndexOf(committedValue);
         ImtProof memory absence = ImtProof({
             sourceChainId: SOURCE_CHAIN_ID,
@@ -376,7 +379,7 @@ contract AtomicInteropProofTest is AtomicInteropProofBuilder {
             chainImtRoot: tree.root(),
             messageTxNumberInBatch: 0,
             messageIndex: 0,
-            messageProof: _messageProof(SETTLEMENT_LAYER_CHAIN_ID, DEADLINE - 1),
+            messageProof: _seededRootProof(SOURCE_CHAIN_ID, BATCH_N, SETTLEMENT_LAYER_CHAIN_ID, DEADLINE - 1),
             leaf: tree.leafAt(predIndex),
             imtLeafIndex: predIndex,
             imtProof: tree.merklePath(predIndex)

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProofBuilder.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProofBuilder.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {Test} from "forge-std/Test.sol";
+import {InteropVerificationFixture} from "./InteropVerificationFixture.sol";
+import {InteropInclusionProofLib} from "./InteropInclusionProofLib.sol";
 
 import {AtomicInteropProof} from "contracts/atomic-interop/libraries/AtomicInteropProof.sol";
 import {L2InteropCommitmentTree} from "contracts/atomic-interop/L2InteropCommitmentTree.sol";
 import {ImtProof, ATOMIC_COMMIT_LEAF_TAG} from "contracts/atomic-interop/IAtomicInterop.sol";
 import {IMTLeaf} from "contracts/common/libraries/IndexedMerkleTree.sol";
 import {L2Message} from "contracts/common/Messaging.sol";
-import {SUPPORTED_PROOF_METADATA_VERSION} from "contracts/common/Config.sol";
 import {
     L2_ATOMIC_FLOW_MANAGER_ADDR,
     L2_INTEROP_COMMITMENT_TREE_ADDR
@@ -55,33 +55,37 @@ contract AtomicInteropProofWrapper {
 ///     `insert` path and read `root()`/`leafAt`/`merklePath` to assemble genuine inclusion /
 ///     non-inclusion `ImtProof`s. No second (off-chain) IMT implementation is maintained, so on-chain
 ///     and off-chain layouts cannot drift.
-///   - The two system contracts the proof authentication reaches are mocked to ISOLATE this library
-///     from separately-tested machinery (justified inline at each mock):
-///       * `L2_TO_L1_MESSENGER_SYSTEM_CONTRACT.sendToL1` — the tree publishes its root on init/insert;
-///         the messenger is a system contract, not under test here.
-///       * `L2_MESSAGE_VERIFICATION.proveL2MessageInclusionShared` — the cross-chain message-inclusion
-///         layer is covered by L2MessageVerification.t.sol; here we drive it to true/false to reach the
-///         library's own branches. It does NOT bypass `MessageHashing._getProofData`, which still parses
-///         the real `messageProof` blob we build below (so the SL-match / deadline branches stay live).
+///   - The cross-chain message verifier is REAL too (see {InteropVerificationFixture}): every
+///     `messageProof` is a genuine inclusion proof built by {InteropInclusionProofLib}, and each builder
+///     seeds the imported interop root the real recursion resolves against. `proveL2MessageInclusionShared`
+///     therefore runs for real — a proof is authenticated iff its root was actually imported, so the
+///     "root not included" branch is reached by *withholding* the seed, not by mocking a `false`.
+///   - The only stub is the L2->L1 messenger (`sendToL1`): the commitment tree publishes its root on
+///     seed/insert, but that publish is an unrelated system-contract side-effect, not the authentication
+///     logic under test. It is made inert (justified inline at `_mockMessenger`).
 ///
-/// The `messageProof` blob is a minimal well-formed non-final proof carrying a caller-chosen
-/// `(settlementLayerChainId, l1Timestamp)`; `_getProofData` only *parses* it (it does not re-verify the
-/// root, which is the mocked verifier's job), so it does not need to hash to any real interop root.
-abstract contract AtomicInteropProofBuilder is Test {
+/// Each proof is anchored at a fresh settlement-layer block (`_nextSlBlock`) so that seeding one proof's
+/// interop root never overwrites another's within the same test.
+abstract contract AtomicInteropProofBuilder is InteropVerificationFixture {
     AtomicInteropProofWrapper internal proofLib;
     L2InteropCommitmentTree internal tree;
 
-    /// @dev Deploys the wrapper + a fresh commitment tree, mocks the messenger, and seeds the tree.
+    /// @dev Monotonic settlement-layer block counter; each built proof gets its own anchor block so their
+    /// imported interop roots occupy distinct `interopRoots[slChainId][slBlock]` slots.
+    uint256 private slBlockNonce;
+
+    /// @dev Deploys the wrapper + a fresh commitment tree + the real verifier stack, and seeds the tree.
     function _setUpAtomicFixtures() internal {
         proofLib = new AtomicInteropProofWrapper();
         tree = new L2InteropCommitmentTree();
         _mockMessenger();
+        _deployMessageVerification();
         // Seeds the `{0,0,0}` head leaf at index 0 (and publishes the seed root via the mocked messenger).
         tree.initialize();
     }
 
     // ------------------------------------------------------------------------------------------------
-    // Mocks (system contracts, not under test — see contract docstring)
+    // Messenger stub (system contract, not under test — see contract docstring)
     // ------------------------------------------------------------------------------------------------
 
     /// @dev The tree publishes `abi.encode(root)` to L1 on every seed/insert; make that call inert.
@@ -93,18 +97,9 @@ abstract contract AtomicInteropProofBuilder is Test {
         );
     }
 
-    /// @dev Drives the (separately-tested) cross-chain message verifier to `_ok` for every call.
-    function _mockVerifier(bool _ok) internal {
-        vm.mockCall(
-            address(L2_MESSAGE_VERIFICATION),
-            abi.encodeWithSelector(L2_MESSAGE_VERIFICATION.proveL2MessageInclusionShared.selector),
-            abi.encode(_ok)
-        );
-    }
-
     /// @dev Asserts that the proof library authenticates exactly the root-publishing message for `_proof`.
-    /// The default verifier mock remains selector-wide for branch-driving; this expectation makes the
-    /// adapter boundary fail if chain id, batch, index, sender, encoded root, tx number, or proof drift.
+    /// This makes the adapter boundary fail if chain id, batch, index, sender, encoded root, tx number, or
+    /// proof drift between the {ImtProof} and the `proveL2MessageInclusionShared` call.
     function _expectRootAuthentication(ImtProof memory _proof) internal {
         vm.expectCall(address(L2_MESSAGE_VERIFICATION), _rootAuthenticationCall(_proof));
     }
@@ -169,84 +164,194 @@ abstract contract AtomicInteropProofBuilder is Test {
     }
 
     // ------------------------------------------------------------------------------------------------
-    // messageProof-blob assembler
+    // Real messageProof + interop-root seeding
     // ------------------------------------------------------------------------------------------------
 
-    /// @dev Builds the proof-metadata word (top 4 bytes: version, logLeafProofLen, batchLeafProofLen,
-    /// finalProofNode; remaining bytes zero — the format `MessageHashing.parseProofMetadata` expects).
-    function _composeMetadata(
-        uint256 _logLeafProofLen,
-        uint256 _batchLeafProofLen,
-        bool _finalProofNode
-    ) internal pure returns (bytes32) {
+    function _nextSlBlock() private returns (uint256) {
+        return ++slBlockNonce;
+    }
+
+    /// @dev The root-publishing message the commitment tree emits: sender pinned to the tree, data the
+    /// encoded root. Its inclusion is what {AtomicInteropProof} authenticates.
+    function _commitMessage(uint16 _txNumberInBatch) private view returns (L2Message memory) {
         return
-            bytes32(
-                (uint256(SUPPORTED_PROOF_METADATA_VERSION) << 248) |
-                    (_logLeafProofLen << 240) |
-                    (_batchLeafProofLen << 232) |
-                    ((_finalProofNode ? uint256(1) : uint256(0)) << 224)
-            );
+            L2Message({
+                txNumberInBatch: _txNumberInBatch,
+                sender: L2_INTEROP_COMMITMENT_TREE_ADDR,
+                data: abi.encode(tree.root())
+            });
     }
 
-    /// @dev A minimal, well-formed *non-final* `messageProof` that `MessageHashing._getProofData` parses
-    /// into `(settlementLayerChainId = _slChainId, l1BatchTimestamp = _l1Timestamp)`. The dummy sibling
-    /// words only need to be non-reverting inputs to the internal Merkle hashing; the resulting roots are
-    /// never checked here because the message verifier is mocked.
-    function _messageProof(uint256 _slChainId, uint256 _l1Timestamp) internal pure returns (bytes32[] memory proof) {
-        // Layout: [metadata, logProof(1), l1Timestamp, batchLeafProofMask, batchProof(1), slPackedInfo, slChainId]
-        proof = new bytes32[](7);
-        proof[0] = _composeMetadata({_logLeafProofLen: 1, _batchLeafProofLen: 1, _finalProofNode: false});
-        proof[1] = bytes32(uint256(0xdead)); // dummy log-leaf-proof sibling
-        proof[2] = bytes32(_l1Timestamp);
-        proof[3] = bytes32(uint256(0)); // batchLeafProofMask (leaf at index 0)
-        proof[4] = bytes32(uint256(0xbeef)); // dummy batch-leaf-proof sibling
-        proof[5] = bytes32(uint256(0)); // settlementLayerPackedBatchInfo (slBatchNumber<<128 | mask); unused by callers
-        proof[6] = bytes32(_slChainId);
+    /// @dev Builds a real `messageProof` for the tree's current root and (optionally) seeds the imported
+    /// interop root it resolves to. When `_seed` is false the proof is well-formed but unauthenticated,
+    /// so the real verifier returns false — the "root not included" case.
+    function _buildRootProof(
+        uint256 _sourceChainId,
+        uint256 _batchNumber,
+        uint256 _slChainId,
+        uint256 _l1BatchTimestamp,
+        uint16 _txNumberInBatch,
+        uint256 _messageIndex,
+        bytes32[] memory _logSiblings,
+        bool _seed
+    ) private returns (bytes32[] memory messageProof) {
+        uint256 slBlock = _nextSlBlock();
+        bytes32 interopRoot;
+        (messageProof, interopRoot) = InteropInclusionProofLib.buildInclusionProof(
+            InteropInclusionProofLib.Params({
+                message: _commitMessage(_txNumberInBatch),
+                messageIndex: _messageIndex,
+                logLeafSiblings: _logSiblings,
+                sourceChainId: _sourceChainId,
+                batchNumber: _batchNumber,
+                slChainId: _slChainId,
+                slBlock: slBlock,
+                l1BatchTimestamp: _l1BatchTimestamp
+            })
+        );
+        if (_seed) {
+            _seedInteropRoot(_slChainId, slBlock, interopRoot);
+        }
     }
 
-    /// @dev A *final* `messageProof` (single-level / commit-based) that carries no settlement-layer
-    /// anchor, so `AtomicInteropProof` rejects it with `ProofMissingSettlementLayerAnchor`.
-    function _finalMessageProof() internal pure returns (bytes32[] memory proof) {
-        proof = new bytes32[](2);
-        proof[0] = _composeMetadata({_logLeafProofLen: 1, _batchLeafProofLen: 0, _finalProofNode: true});
-        proof[1] = bytes32(uint256(0xdead)); // dummy log-leaf-proof sibling
+    /// @dev A real, seeded root-authentication `messageProof` (single-leaf, zero coordinates) for callers
+    /// that assemble a bespoke {ImtProof} (e.g. one carrying a hand-picked membership leaf).
+    function _seededRootProof(
+        uint256 _sourceChainId,
+        uint256 _batchNumber,
+        uint256 _slChainId,
+        uint256 _l1BatchTimestamp
+    ) internal returns (bytes32[] memory) {
+        return
+            _buildRootProof(_sourceChainId, _batchNumber, _slChainId, _l1BatchTimestamp, 0, 0, new bytes32[](0), true);
     }
 
     // ------------------------------------------------------------------------------------------------
     // ImtProof assemblers
     // ------------------------------------------------------------------------------------------------
 
-    /// @dev Inclusion proof for a value already inserted at `_leafIndex` in the real tree.
+    /// @dev Inclusion proof for a value already inserted at `_leafIndex`, authenticated by a real,
+    /// seeded root proof so `proveL2MessageInclusionShared` verifies for real.
     function _inclusionProof(
         uint256 _sourceChainId,
         uint256 _batchNumber,
         uint256 _leafIndex,
         uint256 _slChainId,
-        uint256 _l1Timestamp
-    ) internal view returns (ImtProof memory) {
+        uint256 _l1BatchTimestamp
+    ) internal returns (ImtProof memory) {
+        return
+            _assembleInclusion(
+                _sourceChainId,
+                _batchNumber,
+                _leafIndex,
+                _slChainId,
+                _l1BatchTimestamp,
+                0,
+                0,
+                new bytes32[](0),
+                true
+            );
+    }
+
+    /// @dev Like {_inclusionProof} but with caller-chosen message coordinates and a wider log tree, so the
+    /// forwarding of `messageTxNumberInBatch` / `messageIndex` to the verifier is exercised end-to-end.
+    function _inclusionProofWithCoordinates(
+        uint256 _sourceChainId,
+        uint256 _batchNumber,
+        uint256 _leafIndex,
+        uint256 _slChainId,
+        uint256 _l1BatchTimestamp,
+        uint16 _txNumberInBatch,
+        uint256 _messageIndex,
+        bytes32[] memory _logSiblings
+    ) internal returns (ImtProof memory) {
+        return
+            _assembleInclusion(
+                _sourceChainId,
+                _batchNumber,
+                _leafIndex,
+                _slChainId,
+                _l1BatchTimestamp,
+                _txNumberInBatch,
+                _messageIndex,
+                _logSiblings,
+                true
+            );
+    }
+
+    /// @dev Inclusion proof whose imported root is deliberately NOT seeded, so the real verifier cannot
+    /// authenticate it (`proveL2MessageInclusionShared` returns false).
+    function _unresolvedInclusionProof(
+        uint256 _sourceChainId,
+        uint256 _batchNumber,
+        uint256 _leafIndex,
+        uint256 _slChainId,
+        uint256 _l1BatchTimestamp
+    ) internal returns (ImtProof memory) {
+        return
+            _assembleInclusion(
+                _sourceChainId,
+                _batchNumber,
+                _leafIndex,
+                _slChainId,
+                _l1BatchTimestamp,
+                0,
+                0,
+                new bytes32[](0),
+                false
+            );
+    }
+
+    function _assembleInclusion(
+        uint256 _sourceChainId,
+        uint256 _batchNumber,
+        uint256 _leafIndex,
+        uint256 _slChainId,
+        uint256 _l1BatchTimestamp,
+        uint16 _txNumberInBatch,
+        uint256 _messageIndex,
+        bytes32[] memory _logSiblings,
+        bool _seed
+    ) private returns (ImtProof memory) {
+        bytes32[] memory messageProof = _buildRootProof(
+            _sourceChainId,
+            _batchNumber,
+            _slChainId,
+            _l1BatchTimestamp,
+            _txNumberInBatch,
+            _messageIndex,
+            _logSiblings,
+            _seed
+        );
         return
             ImtProof({
                 sourceChainId: _sourceChainId,
                 batchNumber: _batchNumber,
                 chainImtRoot: tree.root(),
-                messageTxNumberInBatch: 0,
-                messageIndex: 0,
-                messageProof: _messageProof(_slChainId, _l1Timestamp),
+                messageTxNumberInBatch: _txNumberInBatch,
+                messageIndex: _messageIndex,
+                messageProof: messageProof,
                 leaf: tree.leafAt(_leafIndex),
                 imtLeafIndex: _leafIndex,
                 imtProof: tree.merklePath(_leafIndex)
             });
     }
 
-    /// @dev Non-inclusion proof for an absent `_absentValue`: uses its low-nullifier (predecessor) leaf.
-    function _nonInclusionProof(
+    /// @dev A *final* (single-hop) proof carrying no settlement-layer anchor, authenticated against the
+    /// direct interop root at `(sourceChainId, batchNumber)`. {AtomicInteropProof} accepts the inclusion
+    /// then rejects the flow with {ProofMissingSettlementLayerAnchor}.
+    function _missingAnchorProof(
         uint256 _sourceChainId,
         uint256 _batchNumber,
-        uint256 _absentValue,
-        uint256 _slChainId,
-        uint256 _l1Timestamp
-    ) internal view returns (ImtProof memory) {
-        uint256 lowIndex = _lowNullifierIndex(_absentValue);
+        uint256 _leafIndex
+    ) internal returns (ImtProof memory) {
+        (bytes32[] memory messageProof, bytes32 interopRoot) = InteropInclusionProofLib.buildFinalNodeProof(
+            _commitMessage(0),
+            0,
+            new bytes32[](0)
+        );
+        // A final node is checked directly against interopRoots[sourceChainId][batchNumber].
+        _seedInteropRoot(_sourceChainId, _batchNumber, interopRoot);
         return
             ImtProof({
                 sourceChainId: _sourceChainId,
@@ -254,7 +359,41 @@ abstract contract AtomicInteropProofBuilder is Test {
                 chainImtRoot: tree.root(),
                 messageTxNumberInBatch: 0,
                 messageIndex: 0,
-                messageProof: _messageProof(_slChainId, _l1Timestamp),
+                messageProof: messageProof,
+                leaf: tree.leafAt(_leafIndex),
+                imtLeafIndex: _leafIndex,
+                imtProof: tree.merklePath(_leafIndex)
+            });
+    }
+
+    /// @dev Non-inclusion proof for an absent `_absentValue`: uses its low-nullifier (predecessor) leaf,
+    /// authenticated by a real, seeded root proof.
+    function _nonInclusionProof(
+        uint256 _sourceChainId,
+        uint256 _batchNumber,
+        uint256 _absentValue,
+        uint256 _slChainId,
+        uint256 _l1BatchTimestamp
+    ) internal returns (ImtProof memory) {
+        uint256 lowIndex = _lowNullifierIndex(_absentValue);
+        bytes32[] memory messageProof = _buildRootProof(
+            _sourceChainId,
+            _batchNumber,
+            _slChainId,
+            _l1BatchTimestamp,
+            0,
+            0,
+            new bytes32[](0),
+            true
+        );
+        return
+            ImtProof({
+                sourceChainId: _sourceChainId,
+                batchNumber: _batchNumber,
+                chainImtRoot: tree.root(),
+                messageTxNumberInBatch: 0,
+                messageIndex: 0,
+                messageProof: messageProof,
                 leaf: tree.leafAt(lowIndex),
                 imtLeafIndex: lowIndex,
                 imtProof: tree.merklePath(lowIndex)
@@ -262,14 +401,24 @@ abstract contract AtomicInteropProofBuilder is Test {
     }
 
     /// @dev A bare root-authentication proof (the timeout `successor` witness). Only its authenticated
-    /// `(sourceChainId, batchNumber, slChainId, l1Timestamp)` matter; its IMT-membership fields are unused
-    /// by `verifyTimeoutAdjacency`, so they are left empty.
+    /// `(sourceChainId, batchNumber, slChainId, l1BatchTimestamp)` matter; its IMT-membership fields are
+    /// unused by `verifyTimeoutAdjacency`, so they are left empty.
     function _rootAuthProof(
         uint256 _sourceChainId,
         uint256 _batchNumber,
         uint256 _slChainId,
-        uint256 _l1Timestamp
-    ) internal view returns (ImtProof memory) {
+        uint256 _l1BatchTimestamp
+    ) internal returns (ImtProof memory) {
+        bytes32[] memory messageProof = _buildRootProof(
+            _sourceChainId,
+            _batchNumber,
+            _slChainId,
+            _l1BatchTimestamp,
+            0,
+            0,
+            new bytes32[](0),
+            true
+        );
         return
             ImtProof({
                 sourceChainId: _sourceChainId,
@@ -277,7 +426,7 @@ abstract contract AtomicInteropProofBuilder is Test {
                 chainImtRoot: tree.root(),
                 messageTxNumberInBatch: 0,
                 messageIndex: 0,
-                messageProof: _messageProof(_slChainId, _l1Timestamp),
+                messageProof: messageProof,
                 leaf: IMTLeaf({value: 0, nextIndex: 0, nextValue: 0}),
                 imtLeafIndex: 0,
                 imtProof: new bytes32[](0)

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/InteropInclusionProof.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/InteropInclusionProof.t.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {InteropVerificationFixture} from "./InteropVerificationFixture.sol";
+import {InteropInclusionProofLib} from "./InteropInclusionProofLib.sol";
+
+import {L2Message} from "contracts/common/Messaging.sol";
+import {L2_MESSAGE_VERIFICATION} from "contracts/common/l2-helpers/L2ContractInterfaces.sol";
+
+/// @notice Tests the cross-chain message-inclusion layer ({L2MessageVerification.proveL2MessageInclusionShared})
+/// directly against the programmatic proof builder ({InteropInclusionProofLib}) and a REAL interop-root
+/// storage — no mocked verifier, no golden vectors.
+///
+/// This pins down the exact contract the atomic-interop proofs rely on: a proof verifies iff it resolves
+/// to the imported interop root seeded for its `(settlementLayerChainId, settlementLayerBlock)`, and any
+/// change to an authenticated field (settlement timestamp, source chain id, membership path) breaks it.
+/// Because {AtomicInteropProof} authenticates roots through this same call, these tests let its unit
+/// suite reuse the builder with confidence instead of mocking the verifier.
+contract InteropInclusionProofTest is InteropVerificationFixture {
+    uint256 internal constant SOURCE_CHAIN_ID = 271;
+    uint256 internal constant SL_CHAIN_ID = 1; // L1
+    uint256 internal constant BATCH_NUMBER = 100;
+    uint256 internal constant SL_BLOCK = 500;
+    uint256 internal constant L1_TIMESTAMP = 1_700_000_000;
+
+    function setUp() public {
+        _deployMessageVerification();
+    }
+
+    /// @dev A representative L2->L1 message; its `sender`/`data` are authenticated into the leaf.
+    function _message() internal pure returns (L2Message memory) {
+        return L2Message({txNumberInBatch: 0, sender: address(0xBEEF), data: abi.encode("payload")});
+    }
+
+    function _params(
+        uint256 _messageIndex,
+        bytes32[] memory _logSiblings,
+        uint256 _l1BatchTimestamp
+    ) internal pure returns (InteropInclusionProofLib.Params memory) {
+        return
+            InteropInclusionProofLib.Params({
+                message: _message(),
+                messageIndex: _messageIndex,
+                logLeafSiblings: _logSiblings,
+                sourceChainId: SOURCE_CHAIN_ID,
+                batchNumber: BATCH_NUMBER,
+                slChainId: SL_CHAIN_ID,
+                slBlock: SL_BLOCK,
+                l1BatchTimestamp: _l1BatchTimestamp
+            });
+    }
+
+    // ============ happy path ============
+
+    function test_realProof_verifiesAgainstSeededInteropRoot() public {
+        (bytes32[] memory proof, bytes32 interopRoot) = InteropInclusionProofLib.buildInclusionProof(
+            _params(0, new bytes32[](0), L1_TIMESTAMP)
+        );
+        _seedInteropRoot(SL_CHAIN_ID, SL_BLOCK, interopRoot);
+
+        bool included = L2_MESSAGE_VERIFICATION.proveL2MessageInclusionShared(
+            SOURCE_CHAIN_ID,
+            BATCH_NUMBER,
+            0,
+            _message(),
+            proof
+        );
+        assertTrue(included, "single-leaf proof should verify against the seeded interop root");
+    }
+
+    /// @dev A wider (>1-leaf) log tree still verifies, exercising a non-zero log-leaf Merkle mask.
+    function test_realProof_multiLeafLogTreeVerifies() public {
+        bytes32[] memory logSiblings = new bytes32[](1);
+        logSiblings[0] = keccak256("sibling-log");
+        uint256 messageIndex = 1; // message sits at index 1 under `logSiblings[0]`
+
+        (bytes32[] memory proof, bytes32 interopRoot) = InteropInclusionProofLib.buildInclusionProof(
+            _params(messageIndex, logSiblings, L1_TIMESTAMP)
+        );
+        _seedInteropRoot(SL_CHAIN_ID, SL_BLOCK, interopRoot);
+
+        bool included = L2_MESSAGE_VERIFICATION.proveL2MessageInclusionShared(
+            SOURCE_CHAIN_ID,
+            BATCH_NUMBER,
+            messageIndex,
+            _message(),
+            proof
+        );
+        assertTrue(included, "multi-leaf log-tree proof should verify");
+    }
+
+    /// @dev A final (single-hop) proof resolves directly against `interopRoots[sourceChainId][batchNumber]`.
+    function test_finalNodeProof_verifiesAgainstDirectInteropRoot() public {
+        (bytes32[] memory proof, bytes32 interopRoot) = InteropInclusionProofLib.buildFinalNodeProof(
+            _message(),
+            0,
+            new bytes32[](0)
+        );
+        _seedInteropRoot(SOURCE_CHAIN_ID, BATCH_NUMBER, interopRoot);
+
+        bool included = L2_MESSAGE_VERIFICATION.proveL2MessageInclusionShared(
+            SOURCE_CHAIN_ID,
+            BATCH_NUMBER,
+            0,
+            _message(),
+            proof
+        );
+        assertTrue(included, "final-node proof should verify against the direct interop root");
+    }
+
+    // ============ negatives ============
+
+    function test_unseededInteropRoot_doesNotVerify() public {
+        (bytes32[] memory proof, ) = InteropInclusionProofLib.buildInclusionProof(
+            _params(0, new bytes32[](0), L1_TIMESTAMP)
+        );
+        // Deliberately do NOT seed the interop root: the verifier finds a zero root and rejects.
+        bool included = L2_MESSAGE_VERIFICATION.proveL2MessageInclusionShared(
+            SOURCE_CHAIN_ID,
+            BATCH_NUMBER,
+            0,
+            _message(),
+            proof
+        );
+        assertFalse(included, "a proof whose interop root was never imported must not verify");
+    }
+
+    /// @dev The settlement timestamp is authenticated into the batch leaf. Seed the root for one
+    /// timestamp, then present a proof carrying a different one: it no longer resolves to that root.
+    function test_tamperedSettlementTimestamp_doesNotVerify() public {
+        (, bytes32 interopRoot) = InteropInclusionProofLib.buildInclusionProof(
+            _params(0, new bytes32[](0), L1_TIMESTAMP)
+        );
+        _seedInteropRoot(SL_CHAIN_ID, SL_BLOCK, interopRoot);
+
+        // Rebuild the proof with a different timestamp but keep the seed for the original one.
+        (bytes32[] memory tamperedProof, ) = InteropInclusionProofLib.buildInclusionProof(
+            _params(0, new bytes32[](0), L1_TIMESTAMP + 1)
+        );
+        bool included = L2_MESSAGE_VERIFICATION.proveL2MessageInclusionShared(
+            SOURCE_CHAIN_ID,
+            BATCH_NUMBER,
+            0,
+            _message(),
+            tamperedProof
+        );
+        assertFalse(included, "a tampered settlement timestamp must not resolve to the imported root");
+    }
+
+    /// @dev The source chain id is authenticated into the chain-id leaf. A proof built for one chain does
+    /// not verify when presented as another chain's message.
+    function test_wrongSourceChainId_doesNotVerify() public {
+        (bytes32[] memory proof, bytes32 interopRoot) = InteropInclusionProofLib.buildInclusionProof(
+            _params(0, new bytes32[](0), L1_TIMESTAMP)
+        );
+        _seedInteropRoot(SL_CHAIN_ID, SL_BLOCK, interopRoot);
+
+        bool included = L2_MESSAGE_VERIFICATION.proveL2MessageInclusionShared(
+            SOURCE_CHAIN_ID + 1, // proof was built for SOURCE_CHAIN_ID
+            BATCH_NUMBER,
+            0,
+            _message(),
+            proof
+        );
+        assertFalse(included, "a proof presented under the wrong source chain id must not verify");
+    }
+}

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/InteropInclusionProofLib.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/InteropInclusionProofLib.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Merkle} from "contracts/common/libraries/Merkle.sol";
+import {MessageHashing} from "contracts/common/libraries/MessageHashing.sol";
+import {L2Message} from "contracts/common/Messaging.sol";
+import {SUPPORTED_PROOF_METADATA_VERSION} from "contracts/common/Config.sol";
+
+/// @notice Builds REAL cross-chain message-inclusion proofs that the production {L2MessageVerification}
+/// accepts — so tests can exercise `proveL2MessageInclusionShared` end-to-end instead of mocking it.
+///
+/// @dev A message-inclusion proof is a chain of Merkle hops the verifier walks
+/// ({L2MessageVerification._proveL2LeafInclusionRecursive}):
+///   hop 0 (non-final): the L2->L1 `_leaf` sits in a batch's local-logs root; that batch root is bound
+///       into a `batchLeaf` (with its batch number + settlement `l1Timestamp`), which sits in the source
+///       chain's chain-id root, yielding a `chainIdLeaf`.
+///   hop 1 (final): the `chainIdLeaf` sits in the settlement layer's imported interop root, i.e.
+///       `interopRoots[slChainId][slBlock]` — the base case the verifier checks against.
+///
+/// We build the *minimal* such proof: every Merkle sub-tree is a single leaf (index 0, empty sibling
+/// path), so each `calculateRootMemory` returns its leaf unchanged and the whole chain collapses to a
+/// deterministic `interopRoot` the caller seeds via `addInteropRoot`. This is a genuine (degenerate)
+/// inclusion proof — the real verifier + real {MessageHashing} run over it — not a mock or a golden
+/// vector, so every field (chain ids, batch number, settlement timestamp) is caller-controlled and the
+/// proof cannot silently drift from production hashing.
+///
+/// The single-leaf shape can be widened per hop by passing non-empty `logLeafSiblings` with a matching
+/// `messageIndex` (used to prove the message-coordinate forwarding path with a real >1-leaf log tree).
+library InteropInclusionProofLib {
+    struct Params {
+        L2Message message; // the L2->L1 message being proven (sender + data authenticated into the leaf)
+        uint256 messageIndex; // log-leaf Merkle mask (0 for a single-log batch)
+        bytes32[] logLeafSiblings; // log-tree siblings (empty for a single-log batch)
+        uint256 sourceChainId; // chain that emitted the message
+        uint256 batchNumber; // source-chain batch the message settled in
+        uint256 slChainId; // settlement layer the batch aggregated on
+        uint256 slBlock; // settlement-layer block the imported interop root is anchored at
+        uint256 l1BatchTimestamp; // settlement timestamp bound into the batch leaf
+    }
+
+    /// @notice Builds a two-hop (non-final -> final) inclusion proof and the interop root it resolves to.
+    /// @return proof The `messageProof` blob accepted by `proveL2MessageInclusionShared`.
+    /// @return interopRoot The value to seed at `interopRoots[slChainId][slBlock]` so the proof verifies.
+    function buildInclusionProof(Params memory _p) internal pure returns (bytes32[] memory proof, bytes32 interopRoot) {
+        bytes32 logLeaf = MessageHashing.getLeafHashFromLog(MessageHashing._l2MessageToLog(_p.message));
+        // hop 0: log leaf -> batch-settlement root -> batch leaf -> chain-id root -> chain-id leaf.
+        bytes32 batchSettlementRoot = Merkle.calculateRootMemory(_p.logLeafSiblings, _p.messageIndex, logLeaf);
+        bytes32 batchLeaf = MessageHashing.batchLeafHash(batchSettlementRoot, _p.batchNumber, _p.l1BatchTimestamp);
+        // Single-leaf batch tree, so the chain-id root equals the batch leaf.
+        bytes32 chainIdLeaf = MessageHashing.chainIdLeafHash(batchLeaf, _p.sourceChainId);
+        // hop 1 (final): single-leaf settlement tree, so the imported interop root equals the chain-id leaf.
+        interopRoot = chainIdLeaf;
+
+        uint256 n = _p.logLeafSiblings.length;
+        // Layout: [meta0, logSiblings(n), l1Timestamp, batchLeafMask, slPackedBatchInfo, slChainId, meta1]
+        proof = new bytes32[](n + 6);
+        proof[0] = _metadata({_logLeafProofLen: n, _batchLeafProofLen: 0, _finalProofNode: false});
+        for (uint256 i = 0; i < n; ++i) {
+            proof[1 + i] = _p.logLeafSiblings[i];
+        }
+        proof[1 + n] = bytes32(_p.l1BatchTimestamp);
+        proof[2 + n] = bytes32(uint256(0)); // batch-leaf Merkle mask (single-leaf batch tree)
+        proof[3 + n] = bytes32(_p.slBlock << 128); // settlementLayerPackedBatchInfo: slBlock<<128 | mask(0)
+        proof[4 + n] = bytes32(_p.slChainId);
+        proof[5 + n] = _metadata({_logLeafProofLen: 0, _batchLeafProofLen: 0, _finalProofNode: true});
+    }
+
+    /// @notice Builds a single-hop *final* proof (no settlement-layer anchor). The verifier checks it
+    /// directly against `interopRoots[sourceChainId][batchNumber]`, which must equal the returned root.
+    /// @dev {AtomicInteropProof} accepts the message inclusion but then rejects the flow for having no
+    /// settlement-layer anchor ({ProofMissingSettlementLayerAnchor}).
+    function buildFinalNodeProof(
+        L2Message memory _message,
+        uint256 _messageIndex,
+        bytes32[] memory _logLeafSiblings
+    ) internal pure returns (bytes32[] memory proof, bytes32 interopRoot) {
+        bytes32 logLeaf = MessageHashing.getLeafHashFromLog(MessageHashing._l2MessageToLog(_message));
+        interopRoot = Merkle.calculateRootMemory(_logLeafSiblings, _messageIndex, logLeaf);
+
+        uint256 n = _logLeafSiblings.length;
+        proof = new bytes32[](n + 1);
+        proof[0] = _metadata({_logLeafProofLen: n, _batchLeafProofLen: 0, _finalProofNode: true});
+        for (uint256 i = 0; i < n; ++i) {
+            proof[1 + i] = _logLeafSiblings[i];
+        }
+    }
+
+    /// @dev Packs the proof-metadata word (top 4 bytes: version, logLeafProofLen, batchLeafProofLen,
+    /// finalProofNode) exactly as {MessageHashing.parseProofMetadata} expects; the rest stays zero.
+    function _metadata(
+        uint256 _logLeafProofLen,
+        uint256 _batchLeafProofLen,
+        bool _finalProofNode
+    ) private pure returns (bytes32) {
+        return
+            bytes32(
+                (uint256(SUPPORTED_PROOF_METADATA_VERSION) << 248) |
+                    (_logLeafProofLen << 240) |
+                    (_batchLeafProofLen << 232) |
+                    ((_finalProofNode ? uint256(1) : uint256(0)) << 224)
+            );
+    }
+}

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/InteropVerificationFixture.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/InteropVerificationFixture.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+
+import {L2MessageVerification} from "contracts/interop/L2MessageVerification.sol";
+import {DummyL2InteropRootStorage} from "contracts/dev-contracts/test/DummyL2InteropRootStorage.sol";
+import {
+    L2_INTEROP_ROOT_STORAGE_ADDR,
+    L2_MESSAGE_VERIFICATION_ADDR
+} from "contracts/common/l2-helpers/L2ContractAddresses.sol";
+
+/// @notice Stands up the REAL cross-chain message-verification stack at its system-contract addresses so
+/// tests can drive `proveL2MessageInclusionShared` for real, and seeds the imported interop roots proofs
+/// resolve against.
+/// @dev The verifier is a plain re-parsing/Merkle contract with no constructor state, and the interop-root
+/// storage is a mapping, so `vm.etch` (code-only, no constructor) is sufficient — the same pattern the
+/// broader L2-in-L1 harness ({L2UtilsBase}) uses for these two contracts. Roots are populated through the
+/// storage's real `addInteropRoot` entry point, not by writing storage slots directly.
+abstract contract InteropVerificationFixture is Test {
+    /// @dev Etches the real verifier + interop-root storage at their canonical addresses.
+    function _deployMessageVerification() internal {
+        vm.etch(L2_MESSAGE_VERIFICATION_ADDR, address(new L2MessageVerification()).code);
+        vm.etch(L2_INTEROP_ROOT_STORAGE_ADDR, address(new DummyL2InteropRootStorage()).code);
+    }
+
+    /// @dev Anchors `_root` as the settlement layer's imported interop root at `(_slChainId, _slBlock)`.
+    /// A message-inclusion proof resolving to `_root` verifies; any other resolved value does not.
+    function _seedInteropRoot(uint256 _slChainId, uint256 _slBlock, bytes32 _root) internal {
+        bytes32[] memory sides = new bytes32[](1);
+        sides[0] = _root;
+        DummyL2InteropRootStorage(L2_INTEROP_ROOT_STORAGE_ADDR).addInteropRoot(_slChainId, _slBlock, sides);
+    }
+}


### PR DESCRIPTION
> **Draft** — opened early for feedback on the de-mock approach; see _Known dependency_ below.

## What

Replaces the mocked cross-chain message verifier in the `AtomicInteropProof` unit tests (landed in #2278) with the **real `L2MessageVerification` + a real interop-root storage**, so `proveL2MessageInclusionShared` runs end-to-end instead of being mocked. This is the follow-up @StanislavBreadless asked for on #2278 (minimize mocks / drive the real inclusion path).

- **`InteropInclusionProofLib`** — builds a minimal, genuinely-verifying two-hop inclusion proof (single leaf per hop) and returns the interop root to seed. Uses the production `MessageHashing` / `Merkle` primitives, so the test proofs can't drift from what the real verifier expects.
- **`InteropVerificationFixture`** — etches the real `L2MessageVerification` + `DummyL2InteropRootStorage` at their system addresses and seeds roots through the real `addInteropRoot` (no storage-slot pokes).
- **`InteropInclusionProof.t.sol`** — exercises the inclusion layer directly: a built proof verifies against its seeded root, and tamper-negatives (unseeded root, tampered settlement timestamp, wrong source chain) fail — asserting the real outcome, in the spirit of the review note on #2281.
- **`AtomicInteropProofBuilder` / `AtomicInteropProof.t.sol`** — de-mocked. Every proof verifies for real against a seeded root; the "root not included" case simply **withholds the seed** (real verifier returns `false`) instead of mocking a `false` return. The only remaining stub is the L2→L1 messenger (an unrelated publish side-effect), justified inline.

## Tests

28 green — 22 `AtomicInteropProofTest` (de-mocked) + 6 `InteropInclusionProofTest`. Test-only; no production or generated-artifact changes.

## Known dependency (why this is a draft)

@StanislavBreadless flagged on #2281 that @AntonD3's upcoming PR will change the publish / interop-root mechanism (insert the interop root from batch start/end via zksync-os; publish leaves' hashes). `InteropInclusionProofLib` builds proofs against the *current* mechanism, so it will likely need adapting once that lands.