### PR TITLE
docs: sweep stale comments, contradictions and typos across the interop stack

### DIFF
--- a/l1-contracts/contracts/atomic-interop/IAtomicFlowManager.sol
+++ b/l1-contracts/contracts/atomic-interop/IAtomicFlowManager.sol
@@ -29,7 +29,9 @@ import {LegState, AtomicFlow, ImtProof, AtomicFinalityProof} from "./IAtomicInte
 /// need not be ascending). All legs settle on one `settlementLayerChainId`, so the deadline (a settlement-
 /// layer timestamp) is comparable to each batch's `l1Timestamp`.
 ///
-/// Deployed as an L2 predeploy (no constructor) — wiring is done in `initialize`.
+/// Deployed as an L2 predeploy (no constructor). All collaborators are referenced by canonical
+/// fixed address; the only initialization is `initL2` (the L1 chain id), called by the genesis
+/// upgrade.
 interface IAtomicFlowManager {
     event FlowCommitted(bytes32 indexed flowId, bytes32 indexed bundleHash, uint64 deadline, uint256 leafIndex);
     event FlowRefundAuthorized(bytes32 indexed flowId, bytes32 indexed bundleHash);

--- a/l1-contracts/contracts/atomic-interop/IL2InteropCommitmentTree.sol
+++ b/l1-contracts/contracts/atomic-interop/IL2InteropCommitmentTree.sol
@@ -44,6 +44,6 @@ interface IL2InteropCommitmentTree {
     /// @notice The fixed-depth Merkle path (siblings, leaf level up) for the leaf at `_index`.
     function merklePath(uint256 _index) external view returns (bytes32[] memory);
 
-    /// @notice The address allowed to insert (the escrow).
+    /// @notice The address allowed to insert (the canonical {AtomicFlowManager}).
     function appender() external view returns (address);
 }

--- a/l1-contracts/contracts/atomic-interop/README.md
+++ b/l1-contracts/contracts/atomic-interop/README.md
@@ -76,11 +76,12 @@ The timeout proof relies on three preconditions, each enforced on chain:
 
 1. **Every chain interop can target has at least one batch inside the settlement layer's message
    root.** Enforced at two points:
-   - Freshly created chains (`addNewChain` with starting batch number 0, i.e. the same transaction
-     as the chain's DiamondInit): `MessageRootBase._addNewChain` seeds the chain's genesis batch
-     root (`ChainBatchRootTree.genesisChainBatchRoot()` — batch 0 has no logs and a freshly seeded
-     IMT, so the value is exact and `chainBatchRoots`/`chainBatchRootTimestamp` are recorded
-     consistently with the tree leaf).
+   - Freshly created chains report their genesis batch root right after registration, in the same
+     `createNewChain` transaction: the chain's DiamondInit stores
+     `ChainBatchRootTree.genesisChainBatchRoot()` (batch 0 has no logs and a freshly seeded IMT, so
+     the value is exact) as the batch-0 `l2LogsRootHash`, and the Bridgehub-triggered
+     `ExecutorFacet.reportGenesisRoot` forwards it to `MessageRoot.reportGenesisRoot` (once-only,
+     fresh chains only).
    - Already-deployed chains onboarded with a non-zero starting batch number are NOT seeded (a real
      batch with that number exists elsewhere, and a synthetic leaf would diverge from it); instead
      `ChainRegistrationSender` refuses to register a chain for interop until it has settled at least
@@ -97,12 +98,13 @@ The timeout proof relies on three preconditions, each enforced on chain:
    only be enabled once the chain is registered (has its `sharedTree` leaf) AND has a batch in its
    chain tree (precondition 1) — which is exactly what the `ChainRegistrationSender` gate checks.
 3. **Every batch leaf carries the timestamp at which it entered the shared root.** Enforced by
-   `MessageRoot.addChainBatchRoot`, which folds the settlement-layer `block.timestamp` into the batch
-   leaf (`MessageHashing.batchLeafHash`); the timestamp is therefore proven by the same inclusion
-   proof that authenticates the IMT root. Aggregated roots additionally carry their own creation
-   timestamp (`historicalRootTimestamp` on the settlement layer, imported as
-   `interopRootTimestamps` and double checked at batch execution), which anchors the "root from
-   after the deadline" requirement.
+   `MessageRoot.addChainBatchRootV32`, which folds the settlement-layer `block.timestamp` into the
+   batch leaf (`MessageHashing.batchLeafHash`); the timestamp is therefore proven by the same
+   inclusion proof that authenticates the IMT root. Aggregated roots additionally carry their own
+   creation timestamp — one `(blockNumber, root, timestamp)` tuple, exposed by
+   `MessageRoot.historicalRoot` on the settlement layer, imported into
+   `L2InteropRootStorage.interopRoots` and double checked at batch execution — which anchors the
+   "root from after the deadline" requirement.
 
 ## Contracts
 
@@ -123,13 +125,16 @@ for the timeout recovery, recognising the flow manager by its canonical address.
 
 ## ZKsync OS genesis
 
-The two L2 contracts are predeployed in the ZKsync OS genesis (no `Executor` / core-protocol changes):
+The two L2 contracts are predeployed in the ZKsync OS genesis (settlement-layer support lives in the
+core protocol: the `Executor` pushes batch roots via `addChainBatchRootV32`, verifies imported
+dependency roots, and reports the genesis batch leaf via `reportGenesisRoot`):
 
 - registered in the genesis gen tool (`tools/zksync-os-genesis-gen`) at `0x10012`
   (`L2InteropCommitmentTree`) and `0x10014` (`AtomicFlowManager`) — constants in
   `common/l2-helpers/L2ContractAddresses.sol`;
 - seeded during genesis in `L2GenesisForceDeploymentsHelper._initializeV31Contracts` (ZKsync OS only):
-  the commitment tree's one-time `initialize()` seeds the IMT. No wiring or registration step is needed —
+  the commitment tree's one-time `initialize()` seeds the IMT and the manager's `initL2` records the
+  L1 chain id every flow's settlement layer is checked against. No further wiring is needed —
   every collaborator is referenced by its canonical fixed address: the tree's appender and the manager's
   tree / interop center / interop handler are constant getters, and the AR recognises the manager via
   `_atomicFlowManagerAddr()`. The manager no longer holds an asset-router reference at all — it drives

--- a/l1-contracts/contracts/atomic-interop/libraries/AtomicInteropProof.sol
+++ b/l1-contracts/contracts/atomic-interop/libraries/AtomicInteropProof.sol
@@ -77,8 +77,8 @@ import {
 ///     `t' >= T > deadline`, so the proven batch's end root is the final IMT state reachable in time
 ///     — absence there means the leg can never finalize. This branch restores refund liveness for a
 ///     source chain that HALTS and never settles a post-deadline batch; every chain interop can
-///     target has at least one batch in the shared root (freshly created chains get a genesis batch
-///     leaf at creation — see {MessageRootBase._addNewChain} — and `ChainRegistrationSender` refuses
+///     target has at least one batch in the shared root (freshly created chains report a genesis
+///     batch leaf at creation — see {MessageRootBase.reportGenesisRoot} — and `ChainRegistrationSender` refuses
 ///     to enable interop towards a chain with an empty tree), so the required "last batch" always
 ///     exists.
 ///
@@ -170,9 +170,9 @@ library AtomicInteropProof {
         }
 
         // The aggregated root the proof resolves against must be created strictly after the deadline.
-        // Roots imported without a timestamp (legacy path) read as 0 and are rejected. Without this
-        // bound, an in-time snapshot could pass the "last batch" branch below even though later
-        // in-time batches (which may contain the commit) exist.
+        // A never-imported anchor key reads as timestamp 0 and is rejected. Without this bound, an
+        // in-time snapshot could pass the "last batch" branch below even though later in-time
+        // batches (which may contain the commit) exist.
         uint256 rootTimestamp = L2_INTEROP_ROOT_STORAGE.interopRoots(slChainId, slBlock).timestamp;
         if (rootTimestamp <= _deadline) {
             revert ProofInteropRootNotAfterDeadline(rootTimestamp, _deadline);

--- a/l1-contracts/contracts/bridge/ntv/INativeTokenVaultBase.sol
+++ b/l1-contracts/contracts/bridge/ntv/INativeTokenVaultBase.sol
@@ -29,7 +29,7 @@ interface INativeTokenVaultBase {
     /// @dev This function is used to ensure that the token is registered with the NTV.
     function ensureTokenIsRegistered(address _nativeToken) external returns (bytes32);
 
-    /// @notice Used to get the the ERC20 data for a token
+    /// @notice Used to get the ERC20 data for a token
     function getERC20Getters(address _token, uint256 _originChainId) external view returns (bytes memory);
 
     /// @notice Used to get the token address of an assetId

--- a/l1-contracts/contracts/core/chain-asset-handler/ChainAssetHandlerBase.sol
+++ b/l1-contracts/contracts/core/chain-asset-handler/ChainAssetHandlerBase.sol
@@ -369,7 +369,7 @@ abstract contract ChainAssetHandlerBase is
             // We allow migrating chains that were not previously registered on this settlement layer,
             // so the chain is registered here during bridgeMint.
             IBridgehubBase(_bridgehub()).registerNewZKChain(bridgehubMintData.chainId, zkChain, false);
-            // TODO: a chain registered here (settlement-layer migration, non-zero batch number) gets
+            // IMPORTANT: a chain registered here (settlement-layer migration, non-zero batch number) gets
             // NO genesis batch leaf in this layer's message root — its tree stays empty until its
             // first settlement here. This is fine under the current assumption that only the L1
             // message root is used for atomic-interop timeout proofs (fresh chains are seeded on L1

--- a/l1-contracts/contracts/core/chain-registration/ChainRegistrationSender.sol
+++ b/l1-contracts/contracts/core/chain-registration/ChainRegistrationSender.sol
@@ -82,7 +82,7 @@ contract ChainRegistrationSender is
 
     /// @inheritdoc IL1CrossChainSender
     /// @notice Registers a chain on the L2 via a normal deposit.
-    /// @notice this is can be called by anyone (via the bridgehub), but baseTokens need to be provided.
+    /// @notice This can be called by anyone (via the bridgehub), but base tokens need to be provided.
     // slither-disable-next-line locked-ether
     function bridgehubDeposit(
         uint256 chainRegisteredOn,
@@ -142,7 +142,8 @@ contract ChainRegistrationSender is
         return abi.encodeCall(IL2Bridgehub.registerChainForInterop, (chainToBeRegistered, baseTokenAssetId));
     }
 
-    /// @notice Checks that both chains are settling on the same settlement layer, which must not be the L1
+    /// @notice Checks that both chains are settling on the same settlement layer (settling
+    /// directly on L1 is permitted — see the body note).
     /// @param chainToBeRegistered the chain to be registered
     /// @param chainRegisteredOn the chain to register on
     function _checkSettlementLayers(uint256 chainToBeRegistered, uint256 chainRegisteredOn) internal view {

--- a/l1-contracts/contracts/core/message-root/IMessageRoot.sol
+++ b/l1-contracts/contracts/core/message-root/IMessageRoot.sol
@@ -52,14 +52,16 @@ interface IMessageRootBase is IMessageVerification {
     event NewChainRoot(uint256 indexed chainId, bytes32 chainRoot, bytes32 chainIdLeafHash);
 
     /// @notice Emitted whenever the sharedTree is updated, and the new InteropRoot (root of the sharedTree) is generated.
-    /// @param chainId The ID of the chain where the sharedTree was updated.
+    /// @param chainId The ID of the chain where the sharedTree was updated (the settlement layer's own chain id).
     /// @param blockNumber The block number of the block in which the sharedTree was updated.
-    /// @param logId The ID of the log emitted when a new InteropRoot.
+    /// @param logId The per-block ID of the emission: all NewInteropRoot events within one block share
+    /// the same logId (it increments at most once per block), so off-chain consumers can group them.
     /// @param timestamp The block timestamp at which the root was created — the third element of the
     /// `(blockNumber, root, timestamp)` tuple chains import, so the event reports the full interop
     /// root info.
-    /// @param sides The "sides" of the interop root. In this release which uses proof-based interop the sides is an array
-    /// of length one, which only include the interop root itself. More on that in `L2InteropRootStorage` contract.
+    /// @param sides The "sides" of the interop root. In this release, which uses proof-based interop, the
+    /// sides are an array of length one holding only the interop root itself. More on that in the
+    /// `L2InteropRootStorage` contract.
     event NewInteropRoot(
         uint256 indexed chainId,
         uint256 indexed blockNumber,

--- a/l1-contracts/contracts/core/message-root/MessageRootBase.sol
+++ b/l1-contracts/contracts/core/message-root/MessageRootBase.sol
@@ -152,7 +152,7 @@ abstract contract MessageRootBase is IMessageRootBase, ReentrancyGuard, Initiali
     /// @notice The chain itself appends its batch root, both on L1 and on Gateway. On Gateway the
     /// chain's `Executor` calls this directly while settling (it no longer routes through the asset
     /// tracker). Asset correctness across chains is guaranteed by ZK proofs.
-    /// @dev Note, that at the moment of the v31 upgrade we no chains to settle on top of the old
+    /// @dev Note that at the moment of the v31 upgrade no chains settle on top of the old
     /// Era-based Gateway, and so no special handling is needed for pre-v31 chains.
     modifier addChainBatchRootRestriction(uint256 _chainId) {
         if (msg.sender != IBridgehubBase(_bridgehub()).getZKChain(_chainId)) {
@@ -209,7 +209,8 @@ abstract contract MessageRootBase is IMessageRootBase, ReentrancyGuard, Initiali
     /// @notice Adds a new chainBatchRoot to the chainTree and updates the aggregated shared tree — the
     /// v32 flow.
     /// @dev Runs on both settlement layers: on L1 the chain's DiamondProxy calls it directly during
-    /// batch execution, on Gateway the GW asset tracker calls it (see `addChainBatchRootRestriction`).
+    /// batch execution, and the same holds on Gateway — the chain's `Executor` calls it directly
+    /// while settling (see `addChainBatchRootRestriction`).
     /// In both cases the chainBatchRoot is recorded, pushed to the chain tree, the shared tree leaf is
     /// updated, and a new interop root is emitted — so chains settling on either layer participate in
     /// interop. Only v32 executors call this entry point (v31 chains keep using the record-only

--- a/l1-contracts/contracts/interop/IL2InteropRootStorage.sol
+++ b/l1-contracts/contracts/interop/IL2InteropRootStorage.sol
@@ -15,8 +15,7 @@ interface IL2InteropRootStorage {
 
     /// @notice Returns the imported message root and its creation timestamp (the
     /// `(blockOrBatchNumber, root, timestamp)` tuple) for a chain ID and block or batch number.
-    /// @dev The timestamp is zero when the root was imported through the timestamp-less entry point
-    /// (used by the EraVM bootloader); such roots cannot be used for time-sensitive proofs (e.g. the
-    /// atomic-interop timeout protocol).
+    /// @dev Every import entry point carries the creation timestamp, so stored roots always hold the
+    /// full tuple; a zero timestamp only ever means "nothing imported at this key".
     function interopRoots(uint256 chainId, uint256 blockOrBatchNumber) external view returns (StoredInteropRoot memory);
 }

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Executor.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Executor.sol
@@ -119,8 +119,9 @@ contract ExecutorFacet is ZKChainBase, IExecutor {
             bytes32 correctRootHash;
             uint256 correctTimestamp;
             if (interopRoot.chainId == block.chainid) {
-                // For the same chain we verify using the MessageRoot contract. Note, that in this
-                // release, import and export only happens on GW, so this is the only case we have to cover.
+                // For the same chain we verify using the MessageRoot contract. In this release
+                // interop roots are imported from the settlement layer the chain settles on (L1
+                // only — see the AtomicInteropProof header), so this is the only case to cover.
                 StoredInteropRoot memory recordedRoot = messageRootContract.historicalRoot(
                     uint256(interopRoot.blockOrBatchNumber)
                 );
@@ -154,9 +155,10 @@ contract ExecutorFacet is ZKChainBase, IExecutor {
     /// @notice Appends the batch's chain batch root to the L1 MessageRoot.
     /// @param _batchNumber The number of the batch
     /// @param _messageRoot The root of the merkle tree of the messages to L1.
-    /// @dev We only call this function on L1. `addChainBatchRootV32` records the root (used for L2->L1
-    /// message verification), pushes it to the chain's interop tree, and emits the interop root — so
-    /// chains settling on L1 participate in interop, the same as on Gateway.
+    /// @dev `addChainBatchRootV32` records the root (used for L2->L1 message verification), pushes
+    /// it to the chain's interop tree, and emits the interop root — chains settling on this layer
+    /// participate in interop. Runs on whichever settlement layer the chain settles on (L1 only in
+    /// this release).
     function _appendMessageRoot(uint256 _batchNumber, bytes32 _messageRoot) internal {
         // Once the batch is executed, we include its message to the message root.
         IMessageRootBase messageRootContract = IBridgehubBase(s.bridgehub).messageRoot();

--- a/l1-contracts/contracts/state-transition/libraries/BatchDecoder.sol
+++ b/l1-contracts/contracts/state-transition/libraries/BatchDecoder.sol
@@ -175,7 +175,7 @@ library BatchDecoder {
     /// @notice Decodes proof data from a calldata byte array into the previous batch, an array of proved batches, and a proof array.
     /// @param _proofData The calldata byte array containing the data for proving batches.
     /// @return prevBatch The batch information before the batches to be verified.
-    /// @return provedBatches An array containing the the batches to be verified.
+    /// @return provedBatches An array containing the batches to be verified.
     /// @return proof An array containing the proof for the verifier.
     function _decodeProofData(
         bytes calldata _proofData
@@ -206,7 +206,7 @@ library BatchDecoder {
     /// @param _processBatchFrom The expected batch number of the first batch in the array.
     /// @param _processBatchTo The expected batch number of the last batch in the array.
     /// @return prevBatch The batch information before the batches to be verified.
-    /// @return provedBatches An array containing the the batches to be verified.
+    /// @return provedBatches An array containing the batches to be verified.
     /// @return proof An array containing the proof for the verifier.
     function decodeAndCheckProofData(
         bytes calldata _proofData,


### PR DESCRIPTION
## What

Documentation-only sweep (no bytecode changes — the repo builds with `bytecode_hash = none`, so no fixture regen is involved):

- **`ChainAssetHandlerBase`**: the migrated-chain genesis-leaf caveat is a standing **IMPORTANT** note now, not a TODO (it documents a permanent assumption, not pending work).
- **`IAtomicFlowManager`**: wiring is `initL2` (called by the genesis upgrade), not a nonexistent `initialize`; **`IL2InteropCommitmentTree`**: the appender is the canonical `AtomicFlowManager`, not "the escrow".
- **`IL2InteropRootStorage` / `AtomicInteropProof`**: the timestamp-less import entry point was deleted (#2291); zero timestamps now only mean "nothing imported at this key".
- **`README.md`**: real getter names (`historicalRoot` / `interopRoots` instead of the nonexistent `historicalRootTimestamp` / `interopRootTimestamps`), the v32 push entry point, the genesis-root report flow (#2292), and the Executor's actual role — it *does* change (`addChainBatchRootV32`, dependency-root verification, `reportGenesisRoot`); the `AtomicInteropProof` header now points at `reportGenesisRoot` instead of the removed `_addNewChain` seeding.
- **`ChainRegistrationSender`**: the same-settlement-layer @notice no longer forbids L1 one line above the body permitting it; "this is can be called" grammar.
- **`MessageRootBase`**: "we no chains" grammar; the append path is called by the chain's `Executor` on both layers (the GW asset tracker is gone).
- **`Executor`**: the "import and export only happens on GW" note contradicted the L1-only invariant; `_appendMessageRoot` no longer claims "only on L1" and "same as on Gateway" in the same breath.
- **`BatchDecoder` / `INativeTokenVaultBase`**: "the the" typos; `NewInteropRoot` params fully described (per-block `logId` grouping semantics).

Two items from the audit were already fixed on the base by earlier PRs: the stale `interopRootTimestamps` reference in `predeploys.ts` and the one-use `executorFacetArgs = hex""` inline (both landed via #2292).

## Verification

Comments/docs only: `forge build` clean, targeted suites (MessageRoot / atomic-interop / BatchDecoder / Executing) green, prettier/lint applied. The only test failure in the area is the known FFI-disabled environmental one, identical on base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)