### PR TITLE
ci: check out zk-governance in push-triggered docker build

### DIFF
--- a/.github/workflows/build-and-push-docker.yaml
+++ b/.github/workflows/build-and-push-docker.yaml
@@ -23,6 +23,18 @@ jobs:
         with:
           submodules: recursive
 
+      # `docker/protocol/Dockerfile` COPYs `zk-governance` into the image
+      # (PUH/Guardians redeploy forge scripts). Check it out inside the build
+      # context, same as `build-docker.yaml` does — without it the build fails
+      # with `"/zk-governance": not found`.
+      - name: Checkout zk-governance
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: zksync-association/zk-governance
+          ref: kl/v31-puh-guardians-redeploy
+          submodules: recursive
+          path: zk-governance
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 


### PR DESCRIPTION
## What

Adds the missing `Checkout zk-governance` step to `.github/workflows/build-and-push-docker.yaml` (the push-triggered "Build and Push Docker Image for zksync-os-integration-tests" workflow), mirroring the step already present in `build-docker.yaml`.

## Why

`docker/protocol/Dockerfile` does `COPY zk-governance /zk-governance` (needed for the PUH/Guardians redeploy forge scripts), but this workflow never checked the repo out into the build context. As a result, every push build on `draft-v31` fails with:

```
failed to compute cache key: failed to calculate checksum of ref ...: "/zk-governance": not found
```

e.g. https://github.com/matter-labs/era-contracts/actions/runs/28799837508

The PR/dispatch workflow `build-docker.yaml` builds the same Dockerfile successfully because it checks out `zksync-association/zk-governance` @ `kl/v31-puh-guardians-redeploy` into the context first — this PR copies that exact step.

## Verification

- `kl/v31-puh-guardians-redeploy` exists on `zksync-association/zk-governance`
- `.dockerignore` does not exclude `zk-governance`
- `prettier --check` passes on the edited workflow