### PR TITLE
fix(ci): check out zk-governance in build-and-push-docker workflow

### DIFF
--- a/.github/workflows/build-and-push-docker.yaml
+++ b/.github/workflows/build-and-push-docker.yaml
@@ -23,6 +23,17 @@ jobs:
         with:
           submodules: recursive
 
+      # The protocol Dockerfile bakes zk-governance into the image
+      # (`COPY zk-governance /zk-governance`), so it must be present in the
+      # build context. Same checkout as in build-docker.yaml.
+      - name: Checkout zk-governance
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: zksync-association/zk-governance
+          ref: kl/v31-puh-guardians-redeploy
+          submodules: recursive
+          path: zk-governance
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 


### PR DESCRIPTION
## What ❔
  Adds the missing `Checkout zk-governance` step to `.github/workflows/build-and-push-docker.yaml`, mirroring the one in `build-docker.yaml`.

  ## Why ❔
  `docker/protocol/Dockerfile` does `COPY zk-governance /zk-governance` (added in #2172), but only the PR-triggered `build-docker.yaml` checks out that repo into the build context. The push-triggered
  `build-and-push-docker.yaml` builds the same Dockerfile without it, so every push to `draft-v31` fails with `"/zk-governance": not found` ([failing
  run](https://github.com/matter-labs/era-contracts/actions/runs/29497763092/job/87618734437)).