### PR TITLE
chore: merge atomic-imt-interop into ad-atomic-interop

### DIFF
--- a/protocol-ops/src/common/forge/scripts/deploy_ecosystem.rs
+++ b/protocol-ops/src/common/forge/scripts/deploy_ecosystem.rs
@@ -131,8 +131,9 @@ pub struct L1BridgehubOutput {
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct L1BridgesOutput {
-    pub erc20_bridge_implementation_addr: Address,
-    pub erc20_bridge_proxy_addr: Address,
+    // The legacy L1ERC20Bridge was removed on the atomic/v32 branch, so the deploy script no longer
+    // emits `erc20_bridge_*`. The `l1_interop_handler_*` addresses it now emits are ignored here
+    // (serde skips unknown fields) since protocol-ops doesn't consume them.
     pub shared_bridge_implementation_addr: Address,
     pub shared_bridge_proxy_addr: Address,
     pub l1_nullifier_implementation_addr: Address,

--- a/tools/zksync-os-genesis-gen/src/consts.rs
+++ b/tools/zksync-os-genesis-gen/src/consts.rs
@@ -208,7 +208,7 @@ pub const INITIAL_CONTRACTS: [(Address, ContractDeployment); 24] = [
     ),
     (
         L2_INTEROP_HANDLER_ADDR,
-        ContractDeployment::SystemProxy(ContractSource::L1ContractName("InteropHandler")),
+        ContractDeployment::SystemProxy(ContractSource::L1ContractName("L2InteropHandler")),
     ),
     (
         L2_BASE_TOKEN_HOLDER_ADDR,


### PR DESCRIPTION
## What

Syncs `ad-atomic-interop` with its parent `atomic-imt-interop` (two incoming commits: `5dbf7341` genesis-gen L2InteropHandler force-deploy, `76f40b53` protocol-ops `erc20_bridge_*` removal — both independent duplicates of the fixes #2290 already landed here).

**Conflicts and resolutions:**
- `tools/zksync-os-genesis-gen/src/consts.rs`: no conflict — both sides made the byte-identical `InteropHandler` → `L2InteropHandler` change; git merged it silently.
- `protocol-ops/src/common/forge/scripts/deploy_ecosystem.rs` (`L1BridgesOutput`): the only real conflict. Both sides dropped `erc20_bridge_*`; ours additionally **declares** the `l1_interop_handler_*` fields (mirroring the deploy script's output exactly), while theirs left them undeclared and added a comment saying serde ignores them. Kept our declared-fields shape (it's what merged and was e2e-tested on this branch) and the informative half of their comment, minus the now-wrong "ignored via serde" claim. Net diff of the whole merge vs `ad-atomic-interop`: +3 comment lines.

## Verification

`cargo check` green for `protocol-ops` and `zksync-os-genesis-gen`; `forge build` clean (no Solidity changes came in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)