### PR TITLE
fix(atomic-interop): stale ExecutorFacet constructor callers, TS encoding-version bytes, waitForInteropRootNonZero loop

### DIFF
--- a/l1-contracts/deploy-scripts/ctm/DeployCTML1OrGateway.sol
+++ b/l1-contracts/deploy-scripts/ctm/DeployCTML1OrGateway.sol
@@ -94,7 +94,7 @@ library DeployCTML1OrGateway {
         } else if (_contractName == CTMContract.ValidatorTimelock) {
             return abi.encode(_config.bridgehubProxy);
         } else if (_contractName == CTMContract.ExecutorFacet) {
-            return abi.encode(_config.l1ChainId);
+            return abi.encode();
         } else if (_contractName == CTMContract.MigratorFacet) {
             return abi.encode(_config.l1ChainId, _config.testnetVerifier);
         } else if (_contractName == CTMContract.CommitterFacet) {

--- a/l1-contracts/src.ts/deploy.ts
+++ b/l1-contracts/src.ts/deploy.ts
@@ -650,12 +650,7 @@ export class Deployer {
   }
 
   public async deployExecutorFacet(create2Salt: string, ethTxOptions: ethers.providers.TransactionRequest) {
-    const contractAddress = await this.deployViaCreate2(
-      "ExecutorFacet",
-      [await this.getL1ChainId()],
-      create2Salt,
-      ethTxOptions
-    );
+    const contractAddress = await this.deployViaCreate2("ExecutorFacet", [], create2Salt, ethTxOptions);
 
     if (this.verbose) {
       console.log(`CONTRACTS_EXECUTOR_FACET_ADDR=${contractAddress}`);

--- a/l1-contracts/test/anvil-interop/src/helpers/temp-sdk.ts
+++ b/l1-contracts/test/anvil-interop/src/helpers/temp-sdk.ts
@@ -440,7 +440,7 @@ async function waitForInteropRootNonZero(
   const start = Date.now();
   const gwChainId = (await getGatewayProvider().getNetwork()).chainId;
   const interopRootStorage = new Contract(L2_INTEROP_ROOT_STORAGE_ADDR, getAbi("L2InteropRootStorage"), destProvider);
-  const currentRoot = ethers.constants.HashZero;
+  let currentRoot = ethers.constants.HashZero;
 
   while (currentRoot === ethers.constants.HashZero) {
     if (Date.now() - start > timeoutMs) {
@@ -452,7 +452,8 @@ async function waitForInteropRootNonZero(
     }
 
     const interopRootInfo = await interopRootStorage.interopRoots(gwChainId, gwBlockNumber);
-    if (interopRootInfo.root === ethers.constants.HashZero) {
+    currentRoot = interopRootInfo.root;
+    if (currentRoot === ethers.constants.HashZero) {
       await sleep(destProvider.pollingInterval);
     }
   }

--- a/l1-contracts/test/unit_tests/utils.ts
+++ b/l1-contracts/test/unit_tests/utils.ts
@@ -560,7 +560,8 @@ export function encodeCommitBatchesData(
     [STORED_BATCH_INFO_ABI_STRING, `${COMMIT_BATCH_INFO_ABI_STRING}[]`],
     [storedBatchInfo, commitBatchInfos]
   );
-  const commitData = hexConcat(["0x00", encodedCommitDataWithoutVersion]);
+  // Commit wire encoding version (BatchDecoder.SUPPORTED_ENCODING_VERSION).
+  const commitData = hexConcat(["0x01", encodedCommitDataWithoutVersion]);
   return [commitBatchInfos[0].batchNumber, commitBatchInfos[commitBatchInfos.length - 1].batchNumber, commitData];
 }
 
@@ -573,7 +574,8 @@ export function encodeProveBatchesData(
     [STORED_BATCH_INFO_ABI_STRING, `${STORED_BATCH_INFO_ABI_STRING}[]`, "uint256[]"],
     [prevBatch, committedBatches, proof]
   );
-  const proveData = hexConcat(["0x00", encodedProveDataWithoutVersion]);
+  // Prove wire encoding version (BatchDecoder.SUPPORTED_ENCODING_VERSION).
+  const proveData = hexConcat(["0x01", encodedProveDataWithoutVersion]);
   return [committedBatches[0].batchNumber, committedBatches[committedBatches.length - 1].batchNumber, proveData];
 }
 
@@ -599,6 +601,7 @@ export function encodeExecuteBatchesData(
       },
     ]
   );
-  const executeData = hexConcat(["0x01", encodedExecuteDataWithoutVersion]);
+  // Execute wire encoding version (BatchDecoder.SUPPORTED_ENCODING_VERSION_EXECUTE).
+  const executeData = hexConcat(["0x02", encodedExecuteDataWithoutVersion]);
   return [batchesData[0].batchNumber, batchesData[batchesData.length - 1].batchNumber, executeData];
 }


### PR DESCRIPTION
# What ❔

Fixes the three review comments from the 07-17 round on #2279:

- **Stale `ExecutorFacet` constructor callers** ([comment](https://github.com/matter-labs/era-contracts/pull/2279#discussion_r3599336063)): the `ExecutorFacet` constructor was removed earlier, but `DeployCTML1OrGateway.getCreationCalldata` still appended `abi.encode(l1ChainId)` to its creation code and `src.ts/deploy.ts#deployExecutorFacet` still passed `[l1ChainId]`. Both now use empty constructor args (matching `GatewayCTMDeployerHelper`, which already used `hex""`).
- **Execute encoding version in TS test utils** ([comment](https://github.com/matter-labs/era-contracts/pull/2279#discussion_r3599341924)): `test/unit_tests/utils.ts#encodeExecuteBatchesData` now prefixes the wire data with `0x02` (`SUPPORTED_ENCODING_VERSION_EXECUTE`). While auditing the rest of the file, the commit/prove encoders were also carrying a stale `0x00` prefix — updated to `0x01` (`SUPPORTED_ENCODING_VERSION`).
- **`waitForInteropRootNonZero` never exits** ([comment](https://github.com/matter-labs/era-contracts/pull/2279#discussion_r3599345989)): the helper polled the struct-returning `interopRoots` getter but never assigned the result to the loop variable, so it either busy-spun or timed out even after the root became non-zero. The loop variable is now updated from `interopRootInfo.root` each iteration.

## Why ❔

Review feedback on #2279 (atomic interop).

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `zkstack dev fmt` and `zkstack dev lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

