### PR TITLE
chore: port v29.5 L1 verifier keys to main (pre-v31 layout)

### DIFF
--- a/AllContractsHashes.json
+++ b/AllContractsHashes.json
@@ -1025,11 +1025,11 @@
   },
   {
     "contractName": "l1-contracts/GatewayCTMDeployer",
-    "zkBytecodeHash": "0x010003ed0328f73047e2c3bca2ac9af4ece24772153f666a9c6568e493d1f02c",
+    "zkBytecodeHash": "0x010003edbf18ad82282ab4a3b0269f52bacfb0dc977c41921fdef000dd5f7b51",
     "zkBytecodePath": "/l1-contracts/zkout/GatewayCTMDeployer.sol/GatewayCTMDeployer.json",
-    "evmBytecodeHash": "0x55cf0de553cf10f383263adceb02e068280edfff65aa4c359b8e6c139d18eb47",
+    "evmBytecodeHash": "0xd2824a8bc3688f078537c9521bba6e6c06be42bf10301252d820aecd0a055d7b",
     "evmBytecodePath": "/l1-contracts/out/GatewayCTMDeployer.sol/GatewayCTMDeployer.json",
-    "evmDeployedBytecodeHash": "0xdf908010709350759b7aab8d5c187153d17750e1a0145a8c26bdb383a988ca69"
+    "evmDeployedBytecodeHash": "0xa8d382f6fac7436adce9b0b4a80947b6dfc889fec37e1a85c3721da51706fc91"
   },
   {
     "contractName": "l1-contracts/GatewayTransactionFilterer",
@@ -1121,19 +1121,19 @@
   },
   {
     "contractName": "l1-contracts/L1VerifierFflonk",
-    "zkBytecodeHash": "0x010009bfc9b2c85cc2c1af741ae8ca02de365ad3b1fad5e42fc2f8d44c76ecec",
+    "zkBytecodeHash": "0x010009bf620fe845fb288737862a06386695e0ae472563e6a4b6423e67675283",
     "zkBytecodePath": "/l1-contracts/zkout/L1VerifierFflonk.sol/L1VerifierFflonk.json",
-    "evmBytecodeHash": "0x40fd4575ae04a93d0e6fe12f89fef3af8e8aecbce1503248f90fd31093c6f456",
+    "evmBytecodeHash": "0xe8c6e3cc1cd7a1edb130fa24fbc13e65a5c86ae3e8797a7defa4e33818948dff",
     "evmBytecodePath": "/l1-contracts/out/L1VerifierFflonk.sol/L1VerifierFflonk.json",
-    "evmDeployedBytecodeHash": "0x44abae369fb56334e7b857959612c91e5972234a75a0d9bfb69e34fb3409edb8"
+    "evmDeployedBytecodeHash": "0xbd1f5534fe98aeba00c55abe0589cb91d0d4e7a42bc9420e4780cfefd3c37050"
   },
   {
     "contractName": "l1-contracts/L1VerifierPlonk",
-    "zkBytecodeHash": "0x01000dbbbebde7470759f88baab428b70166b7936527bede16de060ee479510b",
+    "zkBytecodeHash": "0x01000dbb34db014481424079cbc172107b5386166236707b832de84b4115da25",
     "zkBytecodePath": "/l1-contracts/zkout/L1VerifierPlonk.sol/L1VerifierPlonk.json",
-    "evmBytecodeHash": "0x71d8a84e977055a3b7f4438c6a90513c87a2cfc35c271ec1d462795637eb54ab",
+    "evmBytecodeHash": "0xef89c68d16c850ea4efb124afe0855fc54987a12d34fd84ceb03f924f6eacf5b",
     "evmBytecodePath": "/l1-contracts/out/L1VerifierPlonk.sol/L1VerifierPlonk.json",
-    "evmDeployedBytecodeHash": "0x6ef2ef9807a818c7d65702c7183ec402bacc2b74c0cce48014808bce4d222e62"
+    "evmDeployedBytecodeHash": "0x4acdb241420b60d34813e40e5a5f569fe8922fde2c393ee3c467294f42df60e9"
   },
   {
     "contractName": "l1-contracts/L2AdminFactory",

--- a/l1-contracts/contracts/state-transition/verifiers/L1VerifierFflonk.sol
+++ b/l1-contracts/contracts/state-transition/verifiers/L1VerifierFflonk.sol
@@ -9,7 +9,7 @@ import {IVerifierV2} from "../chain-interfaces/IVerifierV2.sol";
 /// @notice FFT inspired version of PlonK to optimize on-chain gas cost
 /// @dev For better understanding of the protocol follow the below papers:
 /// * Fflonk Paper: https://eprint.iacr.org/2021/1167
-/// @dev Contract was generated from a verification key with a hash of 0xc8cd705a0db89577146137de78eba6bd1f1c9c3f66dc52f7627e7c2df30895b2
+/// @dev Contract was generated from a verification key with a hash of 0x34e7f769253b128e4ac6fbf71b3f8471d507c4f93bc50dcf26509ed1bae25122
 /// @custom:security-contact security@matterlabs.dev
 contract L1VerifierFflonk is IVerifierV2 {
     // ================Constants================
@@ -24,8 +24,8 @@ contract L1VerifierFflonk is IVerifierV2 {
     // ================Verification Key================
     uint256 internal constant VK_NUM_INPUTS = 1;
     // [C0]1 = qL(X^8)+ X*qR(X^8)+ X^2*qO(X^8)+ X^3*qM(X^8)+ X^4*qC(X^8)+ X^5*Sσ1(X^8)+ X^6*Sσ2(X^8)+ X^7*Sσ3(X^8)
-    uint256 internal constant VK_C0_G1_X = 0x0e2ded5cfc9ea295ca630aed1ed641e12a89d83e60e59bd9b467ad5668b5357d;
-    uint256 internal constant VK_C0_G1_Y = 0x2940e9a4985d775fba0bf93338a86999e56fc13bdde4078ad549dee2fad1dbf7;
+    uint256 internal constant VK_C0_G1_X = 0x24887f5bbaa6556233f4ba2af4e22fa38db3f2a9bbac61a01af83f42d7e7527e;
+    uint256 internal constant VK_C0_G1_Y = 0x2c489209352fc405da45116921eb5609abd755935f27373e42b2457e5b803c1b;
 
     // k1 = 5, k2 = 7
     uint256 internal constant VK_NON_RESIDUES_0 = 0x05;

--- a/l1-contracts/contracts/state-transition/verifiers/L1VerifierPlonk.sol
+++ b/l1-contracts/contracts/state-transition/verifiers/L1VerifierPlonk.sol
@@ -9,7 +9,7 @@ import {IVerifier} from "../chain-interfaces/IVerifier.sol";
 /// @notice Modified version of the Permutations over Lagrange-bases for Oecumenical Noninteractive arguments of
 /// Knowledge (PLONK) verifier.
 /// Modifications have been made to optimize the proof system for ZK chain circuits.
-/// @dev Contract was generated from a verification key with a hash of 0xb2f50340e0edbe49dc657d4eb298e07f13860c1be0fe2e438e44ef8fad133d84
+/// @dev Contract was generated from a verification key with a hash of 0x18bdc7272350532ca7c3d4d613f0f22aa4100bcddd06722b2f8c6896ca5f5ad3
 /// @dev It uses a custom memory layout inside the inline assembly block. Each reserved memory cell is declared in the
 /// constants below.
 /// @dev For a better understanding of the verifier algorithm please refer to the following papers:
@@ -284,8 +284,8 @@ contract L1VerifierPlonk is IVerifier {
     function _loadVerificationKey() internal pure virtual {
         assembly {
             // gate setup commitments
-            mstore(VK_GATE_SETUP_0_X_SLOT, 0x007ab3b6eb38bcb3d387e923a00c9a0e76181545797111e9920869e95413f8b2)
-            mstore(VK_GATE_SETUP_0_Y_SLOT, 0x1ccb98df0d44a0f2ea377131d4ebdf771d7cfd9cec5adbdcaf5657cc9c012dd3)
+            mstore(VK_GATE_SETUP_0_X_SLOT, 0x0805ad84333b15bd919009194e9dabc8e76e9341b949af4c2e2ebe73deb573ab)
+            mstore(VK_GATE_SETUP_0_Y_SLOT, 0x0c7af779baf31f88ba1d41decfb845213689f547960348f64e796aa7728bd26b)
             mstore(VK_GATE_SETUP_1_X_SLOT, 0x04659caf7b05471ba5ba85b1ab62267aa6c456836e625f169f7119d55b9462d2)
             mstore(VK_GATE_SETUP_1_Y_SLOT, 0x0ea63403692148d2ad22189a1e5420076312f4d46e62036a043a6b0b84d5b410)
             mstore(VK_GATE_SETUP_2_X_SLOT, 0x0e6696d09d65fce1e42805be03fca1f14aea247281f688981f925e77d4ce2291)
@@ -296,8 +296,8 @@ contract L1VerifierPlonk is IVerifier {
             mstore(VK_GATE_SETUP_4_Y_SLOT, 0x22e404bc91350f3bc7daad1d1025113742436983c85eac5ab7b42221a181b81e)
             mstore(VK_GATE_SETUP_5_X_SLOT, 0x0d9b29613037a5025655c82b143d2b7449c98f3aea358307c8529249cc54f3b9)
             mstore(VK_GATE_SETUP_5_Y_SLOT, 0x15b3c4c946ad1babfc4c03ff7c2423fd354af3a9305c499b7fb3aaebe2fee746)
-            mstore(VK_GATE_SETUP_6_X_SLOT, 0x29990ff80ff0b5a35a177f8e461ed72b5f80c81af5348bcde0a14d74dbf1b321)
-            mstore(VK_GATE_SETUP_6_Y_SLOT, 0x164e998cb7ae3ae5f39b9a96c52464cbe24224fecef541d6a5edd0dd7a1c0c9c)
+            mstore(VK_GATE_SETUP_6_X_SLOT, 0x07cd32dacf7d296ac341a69e45b9389312ea116dc757c04929088d2bbf5dd5b1)
+            mstore(VK_GATE_SETUP_6_Y_SLOT, 0x0765dbb618ba220e2b2df772a9a8096d3e14f216b8bef1a77e2e3a9c158a4b73)
             mstore(VK_GATE_SETUP_7_X_SLOT, 0x283344a1ab3e55ecfd904d0b8e9f4faea338df5a4ead2fa9a42f0e103da40abc)
             mstore(VK_GATE_SETUP_7_Y_SLOT, 0x223b37b83b9687512d322993edd70e508dd80adb10bcf7321a3cc8a44c269521)
 


### PR DESCRIPTION
## What ❔

Ports the regenerated v29.5 verification-key constants to `main`'s pre-v31 verifier layout (`L1VerifierFflonk.sol` / `L1VerifierPlonk.sol`).

The key constants are taken from #2321 (commit `ddfe9329`), which carries the same keys in the v31 layout (`EraVerifierFflonk`/`EraVerifierPlonk`) on `draft-v31`.

## Why ❔

This is the exact source the **v29.5 mainnet verifier-only upgrade** contracts were built and deployed from (commit `669b9c93` was the recorded build commit — previously local-only). Publishing it makes the deployment independently verifiable: [protocol-upgrade-verification-tool `vb-v0.29.5`](https://github.com/matter-labs/protocol-upgrade-verification-tool/pull/44) resolves the deployed bytecode via `AllContractsHashes.json` at a public commit.

Deployed contracts (mainnet, block 25590598, all Etherscan-verified):
| Contract | Address |
|----------|---------|
| L1VerifierFflonk | `0x9f5C39a2790f38542065E7854b90407371923375` |
| L1VerifierPlonk | `0xd22cA89e8991FCE568456914c616d303e3142395` |
| DualVerifier | `0x47fC5273145E053A18C0BBF6d88F8d6d573C3d0e` |

`AllContractsHashes.json` is intentionally left to be regenerated by the **Update Hashes in PR** workflow so the hashes commit is CI-authored.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.