### PR TITLE
feat: add airbender SNARK-wrapper VK hash to the era genesis config

### DIFF
--- a/configs/genesis/era/latest.json
+++ b/configs/genesis/era/latest.json
@@ -12,6 +12,7 @@
   "evm_emulator_hash": "0x01000d8bae37b82f311186426184866498b357f41d7a02ced11f3e3fbfbacd63",
   "prover": {
     "recursion_scheduler_level_vk_hash": "0xb2f50340e0edbe49dc657d4eb298e07f13860c1be0fe2e438e44ef8fad133d84",
-    "fflonk_snark_wrapper_vk_hash": "0x49eae0bf5c7ea580f4979b366e52b386adc5f42e2ce50fc1d3c4de9a86052bff"
+    "fflonk_snark_wrapper_vk_hash": "0x49eae0bf5c7ea580f4979b366e52b386adc5f42e2ce50fc1d3c4de9a86052bff",
+    "airbender_snark_wrapper_vk_hash": "0xd8176dea8eb7277c3c7ac5c40bfce0b59cd6edfcaa9fff3b06cda5e4aebfdf4c"
   }
 }

--- a/configs/genesis/era/latest.toml
+++ b/configs/genesis/era/latest.toml
@@ -9,3 +9,4 @@ evm_emulator_hash = "0x01000d8bae37b82f311186426184866498b357f41d7a02ced11f3e3fb
 [prover]
 recursion_scheduler_level_vk_hash = "0xb2f50340e0edbe49dc657d4eb298e07f13860c1be0fe2e438e44ef8fad133d84"
 fflonk_snark_wrapper_vk_hash = "0x49eae0bf5c7ea580f4979b366e52b386adc5f42e2ce50fc1d3c4de9a86052bff"
+airbender_snark_wrapper_vk_hash = "0xd8176dea8eb7277c3c7ac5c40bfce0b59cd6edfcaa9fff3b06cda5e4aebfdf4c"


### PR DESCRIPTION
## What ❔

Adds `prover.airbender_snark_wrapper_vk_hash` to `configs/genesis/era/latest.json` / `latest.toml`, next to the existing plonk/fflonk VK hashes.

The value (`0xd8176dea8eb7277c3c7ac5c40bfce0b59cd6edfcaa9fff3b06cda5e4aebfdf4c`) is the keccak hash of the Airbender SNARK-wrapper verification key. It was verified to match both the keccak over the `AirbenderVerifierPlonk` VK constants (`verificationKeyHash()`) and `zkos_wrapper::calculate_verification_key_hash` over the v31.1.1 `snark_vk.json` the prover server pins. It must be bumped together with the verifier release.

## Why ❔

zksync-era is moving the airbender prover to key-based protocol version resolution (matter-labs/zksync-era#4920): the server registers per-protocol-version verifier keys at chain genesis from this config, and airbender provers identify themselves by this hash and only receive batches of protocol versions the key is registered for. This file is the canonical source of chain-genesis verifier keys, so fresh chains need the airbender key here like the plonk/fflonk ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)