### PR TITLE
[N03][Note] Break out of parseAtomicSend loop once the atomicBundle attribute is found

### DIFF
--- a/l1-contracts/contracts/interop/InteropAttributeParser.sol
+++ b/l1-contracts/contracts/interop/InteropAttributeParser.sol
@@ -89,6 +89,8 @@ contract InteropAttributeParser is IInteropAttributeParser {
                     _attributes[i]
                 );
                 atomicSend.isAtomic = true;
+                // The attribute may appear at most once (`parseAttributes` rejects duplicates), so stop scanning.
+                break;
             }
         }
     }


### PR DESCRIPTION
## Finding (OpenZeppelin N03, Note)

`InteropAttributeParser.parseAtomicSend` iterated over all attributes even after finding the `atomicBundle` entry: with no early exit, it kept reading and comparing every remaining selector. Since the attribute may appear at most once (`parseAttributes` reverts `AttributeAlreadySet` on duplicates, and both call sites — `InteropCenter.sendMessage` and `InteropCenter.sendBundle` via `_parseBundleInputs` — run `parseAttributes` over the same array), those extra iterations cannot change the result. The extra cost was paid on every interop send.

## Fix

Add a `break` once the `atomicBundle` attribute is matched and decoded. The loop body has no other side effects (non-matching selectors are skipped, not validated, in this helper), so the change is behavior-preserving — and it makes the returned value independent of the duplicate check performed by `parseAttributes`.

No hashes/artifacts regenerated: the change only affects an L2 built-in system contract helper's bytecode, artifact regeneration is left to the standard CI flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)