### PR TITLE
ci: bind workflow inputs via env before shell

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -19,14 +19,17 @@ jobs:
     steps:
       - name: Resolve tag
         id: vars
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "TAG=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "TAG=${INPUT_TAG}" >> $GITHUB_OUTPUT
           else
             # For push/create on a tag, github.ref looks like 'refs/tags/<tag>'
             echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           fi
-          echo "Resolved TAG=${{ steps.vars.outputs.TAG }}"
+          echo "Resolved TAG will be available from step outputs"
 
       - name: Checkout the repository
         uses: actions/checkout@v4

--- a/.github/workflows/update-hashes-on-demand.yaml
+++ b/.github/workflows/update-hashes-on-demand.yaml
@@ -63,8 +63,11 @@ jobs:
         run: yarn
 
       - name: Run command
+        env:
+          PR_NUMBER: ${{ github.event.inputs.pr_number || inputs.pr_number }}
+          PR_HEAD_REF: ${{ steps.pr.outputs.head_ref }}
         run: |
-          echo "Updating PR #${{ github.event.inputs.pr_number || inputs.pr_number }} on branch ${{ steps.pr.outputs.head_ref }}"
+          echo "Updating PR #${PR_NUMBER} on branch ${PR_HEAD_REF}"
           git submodule update --init --recursive
 
           yarn


### PR DESCRIPTION
## Summary
- Bind `inputs.tag` through `env:` before the Resolve tag shell step in `build-release.yaml`.
- Bind `pr_number` through `env:` before the update-hashes Run command shell step.
- Same class as GitHub’s documented script-injection guidance for interpolating workflow inputs into `run:` scripts.

## Test plan
- [ ] workflow_dispatch build-release still resolves the provided tag
- [ ] tag-push build-release still derives TAG from `GITHUB_REF`
- [ ] update-hashes still logs the target PR number/branch


Made with [Cursor](https://cursor.com)