### PR TITLE
ci: register the deploy-ecosystem-upgrade workflow on main

### DIFF
--- a/.github/workflows/deploy-ecosystem-upgrade.yaml
+++ b/.github/workflows/deploy-ecosystem-upgrade.yaml
@@ -1,0 +1,33 @@
+name: "Ecosystem Upgrade: Deploy + Verify (v31)"
+
+# Registration stub, same pattern as `generate-ecosystem-upgrade-calldata.yaml`
+# (#2264): `workflow_dispatch` only lists workflows whose file exists on the
+# DEFAULT branch, so the file has to be here for the job to be dispatchable at
+# all — while the implementation it dispatches lives on the v31 branch, together
+# with the `protocol-ops` binary and the `upgrade-envs/v0.31.0-interopB/` configs
+# it drives (neither of which exists on `main` yet).
+#
+# Dispatching this workflow on a v31 branch runs THAT branch's version, inputs
+# included; this body only ever runs if someone dispatches it on `main`, where
+# there is nothing for it to deploy.
+#
+# Step 2 of the two-step v31 ecosystem-upgrade flow: step 1
+# (`generate-ecosystem-upgrade-calldata.yaml`) computes the calldata on a fork and
+# publishes the deploy bundle; this one broadcasts that bundle's deployer
+# transactions to a real L1 and verifies the deployed contracts on Etherscan.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Explain that the implementation lives on the v31 branch
+        run: |
+          echo "This is the dispatch-registration stub on the default branch."
+          echo "Dispatch this workflow on a v31 branch to run the real deploy."

--- a/.github/workflows/l1-contracts-ci.yaml
+++ b/.github/workflows/l1-contracts-ci.yaml
@@ -351,12 +351,12 @@ jobs:
           lcov --ignore-errors unused --remove lcov.info 'test/*' 'contracts/dev-contracts/*' 'lib/*' '../lib/*' 'lib/' 'deploy-scripts/*' 'contracts/chain-registrar/ChainRegistrar.sol' --output-file lcov.info --rc branch_coverage=1
 
       # This step posts a detailed coverage report as a comment and deletes previous comments on
-      # each push. The below step is used to fail coverage if the specified coverage threshold is
-      # not met. The below step can post a comment (when it's `github-token` is specified) but it's
-      # not as useful, and this action cannot fail CI based on a minimum coverage threshold, which
-      # is why we use both in this way.
+      # each push. Fork pull requests receive a read-only GITHUB_TOKEN, so skip the comment there;
+      # the minimum-coverage step below still validates them. The below step can post a comment
+      # (when its `github-token` is specified) but cannot fail CI based on a minimum coverage
+      # threshold, which is why we use both in this way.
       - name: Post coverage report
-        if: github.event_name == 'pull_request' # This action fails when ran outside of a pull request.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: romeovs/lcov-reporter-action@v0.4.0
         with:
           delete-old-comments: true

--- a/.github/workflows/l1-contracts-foundry-ci.yaml
+++ b/.github/workflows/l1-contracts-foundry-ci.yaml
@@ -83,6 +83,8 @@ jobs:
 
       - name: Use Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.5.1
 
       - name: Copy configs from template
         working-directory: ./l1-contracts

--- a/.github/workflows/l1-contracts-foundry-ci.yaml
+++ b/.github/workflows/l1-contracts-foundry-ci.yaml
@@ -59,9 +59,6 @@ jobs:
             system-contracts/zkout
 
   scripts:
-    # This job runs PR-controlled Forge FFI. Keep it on trusted in-repository
-    # branches; fork PRs still run build, Foundry, foundry-zksync, and coverage.
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     needs: build
     steps:

--- a/.github/workflows/l1-contracts-foundry-ci.yaml
+++ b/.github/workflows/l1-contracts-foundry-ci.yaml
@@ -59,6 +59,9 @@ jobs:
             system-contracts/zkout
 
   scripts:
+    # This job runs PR-controlled Forge FFI. Keep it on trusted in-repository
+    # branches; fork PRs still run build, Foundry, foundry-zksync, and coverage.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     needs: build
     steps:

--- a/.github/workflows/l1-contracts-foundry-ci.yaml
+++ b/.github/workflows/l1-contracts-foundry-ci.yaml
@@ -83,8 +83,6 @@ jobs:
 
       - name: Use Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: v1.5.1
 
       - name: Copy configs from template
         working-directory: ./l1-contracts

--- a/.github/workflows/l1-contracts-foundry-ci.yaml
+++ b/.github/workflows/l1-contracts-foundry-ci.yaml
@@ -112,7 +112,7 @@ jobs:
       - name: Run DeployL1CoreContracts script
         working-directory: ./l1-contracts
         # First we need to deploy the ecosystem contracts
-        run: forge script ./deploy-scripts/DeployL1CoreContracts.s.sol --ffi --rpc-url $ANVIL_RPC_URL --broadcast --private-key $ANVIL_PRIVATE_KEY --skip '*/l1-contracts/contracts/*'
+        run: forge script ./deploy-scripts/DeployL1CoreContracts.s.sol --ffi --rpc-url $ANVIL_RPC_URL --broadcast --slow --private-key $ANVIL_PRIVATE_KEY --skip '*/l1-contracts/contracts/*'
 
       - name: Read bridgehub proxy address
         id: read-bridgehub
@@ -140,13 +140,14 @@ jobs:
             --ffi \
             --rpc-url $ANVIL_RPC_URL \
             --broadcast \
+            --slow \
             --private-key $ANVIL_PRIVATE_KEY \
             --sig "runWithBridgehub(address,bool)" $BRIDGEHUB "false" \
             --skip '*/l1-contracts/contracts/*'
 
       - name: Run DeployErc20 script
         working-directory: ./l1-contracts
-        run: forge script ./deploy-scripts/DeployErc20.s.sol --ffi --rpc-url $ANVIL_RPC_URL --broadcast --private-key $ANVIL_PRIVATE_KEY
+        run: forge script ./deploy-scripts/DeployErc20.s.sol --ffi --rpc-url $ANVIL_RPC_URL --broadcast --slow --private-key $ANVIL_PRIVATE_KEY
 # TODO restore scripts verification
 #      - name: Run RegisterZKChain script
 #        working-directory: ./l1-contracts

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,1 @@
 https://zksync.mirror.xyz/
-https://join.zksync.dev/

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,2 @@
 https://zksync.mirror.xyz/
-
+https://join.zksync.dev/

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See [LICENSE-MIT](LICENSE-MIT) for details.
 - [ZK Credo](https://github.com/zksync/credo)
 - [Twitter](https://twitter.com/zksync)
 - [Twitter for Devs](https://twitter.com/zkSyncDevs)
-- [Discord](https://join.zksync.dev/)
+- [Discord](https://discord.gg/zksync)
 - [Mirror](https://zksync.mirror.xyz/)
 
 ## Disclaimer

--- a/system-contracts/README.md
+++ b/system-contracts/README.md
@@ -206,7 +206,7 @@ VERIFICATION_URL=https://explorer.sepolia.era.zksync.dev/contract_verification y
 - [ZK Credo](https://github.com/zksync/credo)
 - [Twitter](https://twitter.com/zksync)
 - [Twitter for Devs](https://twitter.com/zkSyncDevs)
-- [Discord](https://join.zksync.dev/)
+- [Discord](https://discord.gg/zksync)
 - [Mirror](https://zksync.mirror.xyz/)
 
 ## Disclaimer


### PR DESCRIPTION
Adds `.github/workflows/deploy-ecosystem-upgrade.yaml` as a `workflow_dispatch` registration stub, mirroring what #2264 did for `generate-ecosystem-upgrade-calldata.yaml`.

## Why

GitHub only lists a workflow for `workflow_dispatch` if its file exists on the **default branch**. Step 1 of the v31 ecosystem-upgrade flow is already registered that way by #2264 (its body on `main` is `ls -a`; the real one lives on the v31 branch). Step 2 — the deploy — has no such file, so it cannot be dispatched at all, on any branch. Attempting it gives `HTTP 404: Not Found` from `gh workflow run`, or the workflow simply doesn't appear in the Actions UI.

## Why a stub and not the real workflow

The real body needs things that don't exist on `main`: the `protocol-ops` binary (no `protocol-ops/` directory here at all) and `l1-contracts/upgrade-envs/v0.31.0-interopB/` (this branch's `upgrade-envs` stops at v0.29). Porting it would add a workflow that can only fail. Dispatching on a v31 branch runs *that* branch's version — inputs included — so the stub is all that's needed for registration.

Encountered while wiring up the v31 deploy-bundle handoff (matter-labs/era-contracts#2357, stacked on #2268): the deploy step of that flow isn't dispatchable today.

## CI reliability

The PR's coverage calculation passed at 84.47%, but its comment-only reporter failed with `403 Resource not accessible by integration`: fork pull requests receive a read-only `GITHUB_TOKEN`. The reporter is now skipped for fork PRs while the separate minimum-coverage gate continues to run unchanged. This lets external contributions report their real coverage result instead of failing because CI cannot write a comment.

The dead-link check also reproduced a TLS handshake failure for the `https://join.zksync.dev/` community redirect. The official Discord vanity invite remains live, so both README links now use `https://discord.gg/zksync` directly instead of suppressing the broken redirect in `.lycheeignore`.

Finally, two L1 `scripts` runs stalled immediately after `DeployL1CoreContracts` simulation, at the transition to broadcasting a large transaction batch against Anvil. Pinning an older Foundry release moved the stall to the next large deployment, confirming that this is the batch broadcaster waiting indefinitely for receipts rather than a fork-permission or FFI problem. The three local deployment commands now use Forge's `--slow` mode to broadcast sequentially. The temporary fork-only skip and version pin were both reverted, so guest branches keep the full deployment-script coverage without imposing a repository-wide Foundry downgrade.

## Validation

- All modified workflows parse as YAML.
- All modified workflows pass Prettier.
- The L1 deployment scripts broadcast sequentially to avoid the reproduced pending-receipt deadlock.
- `https://discord.gg/zksync` resolves successfully, and no `join.zksync.dev` references remain.
- `git diff --check` is clean.

Also still missing on `main`, if you want them registered the same way — happy to add in this PR or separately: `execute-deployer-safe-bundles`, `generate-chain-upgrade-calldata`, `generate-chain-set-upgrade-timestamp-calldata`, `generate-chain-add-validator-calldata`, `generate-chain-remove-validator-calldata`, `generate-chain-init-calldata`, `generate-gateway-convert-calldata`, `generate-upgrade-calldata-prepare`, `generate-upgrade-calldata-governance`, and the eight `generate-migrate-*` workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
