### PR TITLE
refactor: remove @matterlabs/zksync-contracts submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,6 +12,3 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
-[submodule "lib/@matterlabs/zksync-contracts"]
-	path = lib/@matterlabs/zksync-contracts
-	url = https://github.com/matter-labs/zksync-contracts

--- a/AllContractsHashes.json
+++ b/AllContractsHashes.json
@@ -601,7 +601,7 @@
   },
   {
     "contractName": "l2-contracts/AddressAliasHelper",
-    "zkBytecodeHash": "0x01000007b2403c553ee340ec6b899a8d78ee0407b6313d3d4a6c0b26c24d07a2",
+    "zkBytecodeHash": "0x01000007fb50ba603c351244db9d3bdb66fa9af16a4aa732e5c34fcaffc2ee3c",
     "zkBytecodePath": "/l2-contracts/zkout/AddressAliasHelper.sol/AddressAliasHelper.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -611,7 +611,7 @@
   },
   {
     "contractName": "l2-contracts/AddressUpgradeable",
-    "zkBytecodeHash": "0x0100000703adf732b95e5109ef5921ea394281a7de36f0308fa66bbf83e2a2f4",
+    "zkBytecodeHash": "0x010000075cee346c59383017fcbb22e5e6be22e09e2276db4a5e563fded83880",
     "zkBytecodePath": "/l2-contracts/zkout/AddressUpgradeable.sol/AddressUpgradeable.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -621,7 +621,7 @@
   },
   {
     "contractName": "l2-contracts/ConsensusRegistry",
-    "zkBytecodeHash": "0x0100046f89e3b75c3e3572cd9b228c950b13c18df1419cad1b7afe7b1adf7e20",
+    "zkBytecodeHash": "0x0100046faad435920287d7e13ce84ec962e75d0e18292c02e074d562c95bcd8f",
     "zkBytecodePath": "/l2-contracts/zkout/ConsensusRegistry.sol/ConsensusRegistry.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -631,7 +631,7 @@
   },
   {
     "contractName": "l2-contracts/ForceDeployUpgrader",
-    "zkBytecodeHash": "0x0100005b1f4981e974afa980f3e8c278f8988affe7e06ecf558b92386279faa8",
+    "zkBytecodeHash": "0x0100005be42b941d563e143fe83be92c412656f943d3ee6128d502e6643bf069",
     "zkBytecodePath": "/l2-contracts/zkout/ForceDeployUpgrader.sol/ForceDeployUpgrader.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -641,7 +641,7 @@
   },
   {
     "contractName": "l2-contracts/L2ContractHelper",
-    "zkBytecodeHash": "0x010000079e3e4a4d316974c1787814355ded47b4fe58fc22a13a1410638eac52",
+    "zkBytecodeHash": "0x010000076087c680d688436b892abeacbea2ee5d4af648a05d2e6b0c16df53c6",
     "zkBytecodePath": "/l2-contracts/zkout/L2ContractHelper.sol/L2ContractHelper.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -651,7 +651,7 @@
   },
   {
     "contractName": "l2-contracts/Multicall3",
-    "zkBytecodeHash": "0x010001f5738337def234b88042dd1430606c9a9880df281d88c18508e4fcd4b5",
+    "zkBytecodeHash": "0x010001f58b7a0cbb699bb9f0720e57b291f4d8183114cbcec6155e530626f835",
     "zkBytecodePath": "/l2-contracts/zkout/Multicall3.sol/Multicall3.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -661,7 +661,7 @@
   },
   {
     "contractName": "l2-contracts/SystemContractsCaller",
-    "zkBytecodeHash": "0x0100000715a20339978a38b15943f62ac094214452003c0bbaf7333c759bc011",
+    "zkBytecodeHash": "0x01000007be4fa087cdffa602435d4b12f849519d5c91dd77a24b9e25356ed6fa",
     "zkBytecodePath": "/l2-contracts/zkout/SystemContractsCaller.sol/SystemContractsCaller.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -671,7 +671,7 @@
   },
   {
     "contractName": "l2-contracts/Utils",
-    "zkBytecodeHash": "0x010000079ff98ee98ce6369f775af7bf8c83ae2d53e0943e189bb558ed79e9ff",
+    "zkBytecodeHash": "0x01000007ba17aea3f651a7a94ce2833018934c4e8a39b54c7093e3fa83c09886",
     "zkBytecodePath": "/l2-contracts/zkout/SystemContractsCaller.sol/Utils.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -681,7 +681,7 @@
   },
   {
     "contractName": "l2-contracts/TestnetPaymaster",
-    "zkBytecodeHash": "0x010000b71463e63f8fe07f6e9c5da31223a1b5751953bf265c3a6b65d0caf2f7",
+    "zkBytecodeHash": "0x010000b796cd992a6779900d5c8b237f90e47616c07949c7d201961229d4aebb",
     "zkBytecodePath": "/l2-contracts/zkout/TestnetPaymaster.sol/TestnetPaymaster.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,
@@ -691,7 +691,7 @@
   },
   {
     "contractName": "l2-contracts/TimestampAsserter",
-    "zkBytecodeHash": "0x0100001b4df332dc3ed3542533f4da1804c01fe86e8e9b6575c5c286404d2229",
+    "zkBytecodeHash": "0x0100001b61f262e48b0d75e55cb9ca0fc5bfb8836d5898478bedbc78cd8a9ca4",
     "zkBytecodePath": "/l2-contracts/zkout/TimestampAsserter.sol/TimestampAsserter.json",
     "evmBytecodeHash": null,
     "evmBytecodePath": null,

--- a/l2-contracts/contracts/ForceDeployUpgrader.sol
+++ b/l2-contracts/contracts/ForceDeployUpgrader.sol
@@ -3,10 +3,7 @@
 pragma solidity 0.8.28;
 
 import {DEPLOYER_SYSTEM_CONTRACT} from "./L2ContractHelper.sol";
-import {
-    ForceDeployment,
-    IContractDeployer
-} from "@matterlabs/zksync-contracts/contracts/system-contracts/interfaces/IContractDeployer.sol";
+import {ForceDeployment, IContractDeployer} from "./interfaces/IContractDeployer.sol";
 
 /// @custom:security-contact security@matterlabs.dev
 /// @notice The contract that calls force deployment during the L2 system contract upgrade.

--- a/l2-contracts/foundry.toml
+++ b/l2-contracts/foundry.toml
@@ -14,7 +14,6 @@ remappings = [
     "foundry-test/=test/foundry/",
     "@openzeppelin/contracts-v4/=lib/openzeppelin-contracts-v4/contracts/",
     "@openzeppelin/contracts-upgradeable-v4/=lib/openzeppelin-contracts-upgradeable-v4/contracts/",
-    "@matterlabs/zksync-contracts/=lib/@matterlabs/zksync-contracts/",
 ]
 fs_permissions = [
     { access = "read", path = "zkout" },

--- a/l2-contracts/lib/@matterlabs
+++ b/l2-contracts/lib/@matterlabs
@@ -1,1 +1,0 @@
-../../lib/@matterlabs

--- a/l2-contracts/package.json
+++ b/l2-contracts/package.json
@@ -7,7 +7,6 @@
     "@matterlabs/hardhat-zksync-solc": "^0.3.15",
     "@matterlabs/hardhat-zksync-verify": "^0.4.0",
     "@matterlabs/hardhat-zksync-node": "^1.2.0",
-    "@matterlabs/zksync-contracts": "^0.6.1",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.6",
     "@nomicfoundation/hardhat-ethers": "^3.0.4",
     "@nomicfoundation/hardhat-verify": "^1.1.0",


### PR DESCRIPTION
## What ❔

Removes the `lib/@matterlabs/zksync-contracts` git submodule.

`ForceDeployUpgrader` was its only consumer — it imported `ForceDeployment` and
`IContractDeployer` from
`@matterlabs/zksync-contracts/contracts/system-contracts/interfaces/IContractDeployer.sol`.
Both are already declared in `l2-contracts/contracts/interfaces/IContractDeployer.sol`
(previously unused, identical `ForceDeployment` layout and `forceDeployOnAddresses`
signature), so the import now points there and nothing had to be duplicated.

Also removed along with the submodule:

- the `@matterlabs/zksync-contracts/` remapping in `l2-contracts/foundry.toml`;
- the `l2-contracts/lib/@matterlabs` symlink;
- the now-unused `@matterlabs/zksync-contracts` devDependency in
  `l2-contracts/package.json` (`gas-bound-caller` still depends on the npm package,
  so `yarn.lock` is unchanged).

`AllContractsHashes.json` is updated for all 10 `l2-contracts` entries: dropping a
remapping changes the metadata hash appended to every artifact in the project. The
bytecode is byte-identical apart from that 32-byte metadata tail (verified by
diffing `zkout` artifacts before/after — `same_prefix == len - 64` hex chars for
every contract). `ForceDeployUpgrader`'s ABI is unchanged.

## Why ❔

One fewer submodule to sync, and the interface it provided is already maintained in
this repo.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated. (n/a — no behavioural change; `ForceDeployUpgrader`'s ABI and bytecode-minus-metadata are unchanged)
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `yarn lint:fix`.