### PR TITLE
chore(genesis): bump the genesis protocol version to v0.32.0

### DIFF
--- a/configs/genesis/era/latest.json
+++ b/configs/genesis/era/latest.json
@@ -1,8 +1,8 @@
 {
   "protocol_semantic_version": {
     "major": 0,
-    "minor": 31,
-    "patch": 1
+    "minor": 32,
+    "patch": 0
   },
   "genesis_root": "0x165530549ee8b02b6ab6c703c00dd4965065413c64ee7dd109a9988816148407",
   "genesis_rollup_leaf_index": 102,

--- a/configs/genesis/era/latest.toml
+++ b/configs/genesis/era/latest.toml
@@ -1,4 +1,4 @@
-protocol_semantic_version = 133143986177
+protocol_semantic_version = 137438953472
 genesis_root = "0x165530549ee8b02b6ab6c703c00dd4965065413c64ee7dd109a9988816148407"
 genesis_rollup_leaf_index = 102
 genesis_batch_commitment = "0x1aece7b49008c333ba094046be34d5858284ef6101cee1c30f1cecbfce75768f"

--- a/configs/genesis/zksync-os/latest.json
+++ b/configs/genesis/zksync-os/latest.json
@@ -241,8 +241,8 @@
   "genesis_root": "0x1a4ce8f15e4e9bc1041715f42560b85b3b84cb43f3471d8f98d4b84b49045147",
   "protocol_semantic_version": {
     "major": 0,
-    "minor": 31,
-    "patch": 1
+    "minor": 32,
+    "patch": 0
   },
   "prover": {
     "fflonk_snark_wrapper_vk_hash": "0x49eae0bf5c7ea580f4979b366e52b386adc5f42e2ce50fc1d3c4de9a86052bff",

--- a/l1-contracts/test/anvil-interop/README.md
+++ b/l1-contracts/test/anvil-interop/README.md
@@ -36,9 +36,11 @@ yarn test:hardhat:interop --keep-chains
 
 ## Pregenerated Chain States
 
-Tests load pregenerated Anvil snapshots from `chain-states/v0.31.1/` by default. This skips the full deployment and cuts test time from ~5 min to ~85s.
+Tests load pregenerated Anvil snapshots from `chain-states/<protocol-version>/` by default, where `<protocol-version>` is the `vMAJOR.MINOR.PATCH` declared by `configs/genesis/era/latest.json`. This skips the full deployment and cuts test time from ~5 min to ~85s.
 
 The runner auto-detects pregenerated state by checking for `chain-states/<protocol-version>/addresses.json`. If found, it decompresses the dumped state and starts each Anvil process with `--load-state`. If not found (or `FRESH_DEPLOY=1`), it runs the full 5-step deployment.
+
+Because the directory is keyed by protocol version, a genesis version bump makes the previous snapshots unreachable and tests silently fall back to the full deployment until they are regenerated (see below, or the "Regenerate Anvil Interop Chain States" workflow). The older `v0.29.0` / `v0.30.0` snapshots are kept deliberately — the fork-upgrade tests use them as the pre-upgrade source state.
 
 To regenerate pregenerated state after contract changes:
 
@@ -171,7 +173,7 @@ test/anvil-interop/
 │   ├── permanent-values.toml      # Immutable protocol values
 │   └── chain-{10,11,12,13}.toml   # Per-chain deployment params (generated)
 ├── chain-states/
-│   └── v0.31.1/                   # Pregenerated Anvil state snapshots
+│   └── v<major>.<minor>.<patch>/  # Pregenerated Anvil state snapshots, keyed by genesis protocol version
 │       ├── 31337.json             # L1 state dump
 │       ├── {10,11,12,13}.json     # L2 chain state dumps
 │       └── addresses.json         # All contract addresses + test tokens

--- a/l1-contracts/test/foundry/l1/integration/UpgradeTestv31_Local.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/UpgradeTestv31_Local.t.sol
@@ -143,7 +143,8 @@ contract UpgradeIntegrationTest_Local is
     }
 
     /// @notice Bump the CTM's protocol version from the upgrade input TOML so the local
-    ///         genesis-at-v31 fixture exercises a v31 → v32 upgrade.
+    ///         fixture exercises an upgrade to one minor above the genesis version
+    ///         (currently v32 -> v33). See `foundry-upgrade.toml`.
     /// @dev    Replaces the former `overrideProtocolVersionForLocalTesting` hook on the
     ///         deleted `DefaultEcosystemUpgrade` orchestrator.
     function afterInitHook() internal override {

--- a/l1-contracts/upgrade-envs/v0.31.0-interopB/foundry-upgrade.toml
+++ b/l1-contracts/upgrade-envs/v0.31.0-interopB/foundry-upgrade.toml
@@ -1,9 +1,13 @@
-# Foundry-specific upgrade configuration for local testing
-# Since genesis config deploys chains at v31.0.0, we need to upgrade to v32.0.0
+# Foundry-specific upgrade configuration for local testing.
+#
+# The local harness deploys at whatever `configs/genesis/era/latest.json` declares and then
+# upgrades to `new_protocol_version`, so this must stay one minor ahead of the genesis version:
+# `DefaultCTMUpgrade.initUpgrade` requires `ctmProtocolVersion != getNewProtocolVersion()`.
+# Genesis is at v32.0.0, so the fixture exercises a v32 -> v33 upgrade.
 
-old_protocol_version = 0x1f00000000  # v31.0.0 (current genesis)
+old_protocol_version = 0x2000000000  # v32.0.0 (current genesis)
 v28_protocol_version = 0x1c00000000  # v28.0.0 (for reference)
 
 [contracts]
-new_protocol_version = 0x2000000000  # v32.0.0 (target for upgrade)
-latest_protocol_version = 0x2000000000  # v32.0.0
+new_protocol_version = 0x2100000000  # v33.0.0 (target for upgrade)
+latest_protocol_version = 0x2100000000  # v33.0.0


### PR DESCRIPTION
## What

Bumps both genesis configs from `0.31.1` to `0.32.0`:

| file | before | after |
| --- | --- | --- |
| `configs/genesis/era/latest.json` / `.toml` | 0.31.1 | **0.32.0** |
| `configs/genesis/zksync-os/latest.json` | 0.31.1 | **0.32.0** |

## Why

The node already treats v32 as the current protocol version — `ProtocolVersionId::latest() == Version32` in `zksync-era` — so the genesis configs are the missing half. `zksync_node_genesis` compares the CTM's on-chain protocol version against the config and refuses to start on a mismatch, and everything downstream (`ChainCreationParamsLib`, `DefaultCoreUpgrade.loadProtocolVersionFromGenesis()`, `DeploymentTest.t.sol`, the anvil-interop runners) reads the version from these two files.

Both flavours move together deliberately. Era and ZKsync OS drifting apart is what tripped `GatewayVotePreparation`'s "CTM protocol version mismatch" require the last time it happened (see 55f469d5), so they stay in lockstep.

## No regenesis needed

`genesis_root`, `genesis_batch_commitment` and `genesis_rollup_leaf_index` are unchanged, because none of them depend on the protocol version:

- `get_system_smart_contracts()` takes no version argument, so the initial storage tree — and therefore the root — is version-independent.
- `CommitmentInput::for_genesis_batch` threads the version through only to pick `is_pre_boojum` and `num_blobs_required`, both identical for v31 and v32.

The earlier `0.31.0 -> 0.31.1` bump (9d1eeb5e) landed the same way, touching only the version field.

## Follow-on fixes

Two places keyed off the genesis version needed to move with it.

**`upgrade-envs/v0.31.0-interopB/foundry-upgrade.toml` — this one was a real breakage.** `UpgradeTestv31_Local.t.sol` reads `$.contracts.new_protocol_version` from this fixture and feeds it to `setNewProtocolVersion`, while `DefaultCTMUpgrade.initUpgrade` requires `ctmProtocolVersion != getNewProtocolVersion()`. The fixture targeted v32.0.0 precisely because genesis deployed at v31.0.0; with genesis now at v32.0.0 the target equals the deployed version and the require fails with *"The new protocol version is already present on the ChainTypeManager"*. Moved to a v32 -> v33 upgrade, and documented the invariant that the fixture must stay one minor ahead of genesis so the next bump doesn't rediscover this.

**`test/anvil-interop/README.md`** named `chain-states/v0.31.1/` literally. That directory is keyed by the genesis protocol version, so this bump makes the committed snapshots unreachable — `hasChainStates()` returns false and the runner falls back to a full deployment. Tests stay correct, they just go from ~85s to ~5min. The README now describes the mechanism rather than a number that goes stale every bump, in the spirit of 55f469d5.

## Audit of remaining v31 references

Everything else that mentions v31 was checked and is correct as-is:

- **Thresholds/floors, v32 falls on the right side:** `GatewayVotePreparation.MIN_V31_PROTOCOL_VERSION` (used with `>=`), `AddressIntrospector.shouldUseV29Introspection` (`< 0.31.0`), `DefaultCTMUpgrade`'s `oldProtocolVersionMinor < 31` selector choice.
- **Correctly frozen, version-specific artifacts:** `protocol-ops/.../versions/v31/` incl. `EXPECTED_NEW_PROTOCOL_VERSION_STR = "0.31.0"`, `L1MessageRoot.v31UpgradeChainBatchNumber` / `initializeL1V31Upgrade` (protocol state, not a version selector), `upgrade-envs/v0.31.0-interopB/output/`, `tools/upgrade-readiness-checker`.
- **Dead inputs, left alone:** `test/anvil-interop/config/v29-to-v31-upgrade.toml`'s `latest_protocol_version` / `new_protocol_version` / `old_protocol_version` are read by no `.sol` or `.ts`. The upgrade takes its target from `loadProtocolVersionFromGenesis()` and `verifyProtocolVersions` reads the same source, so that test now performs v29 -> v32 and stays self-consistent — only the filename misleads.

## Companion change in zksync-era

`prepare_upgrade_call` gated the per-chain `getL2UpgradeTxData` rewrite on `version == Version31`; widened to `>= Version31` so v32 and later reuse the same `SettlementLayerV31UpgradeBase` machinery. Safe because `gateway_upgrade()` is `Version26`, below the threshold, so the later gateway branch is unshadowed.

## Testing

- `yarn prettier:fix` and `yarn lint:sol --fix --noPrompt` clean, no changes produced.
- Anvil-interop chain states still need regenerating for `v0.32.0` via the "Regenerate Anvil Interop Chain States" workflow. Until then those tests fall back to a full deployment — correct, just slower.

🤖 Generated with [Claude Code](https://claude.com/claude-code)