### PR TITLE
chore(genesis): bump the genesis protocol version to v0.32.0 (draft-v32)

### DIFF
--- a/configs/genesis/era/latest.json
+++ b/configs/genesis/era/latest.json
@@ -1,8 +1,8 @@
 {
   "protocol_semantic_version": {
     "major": 0,
-    "minor": 31,
-    "patch": 1
+    "minor": 32,
+    "patch": 0
   },
   "genesis_root": "0x165530549ee8b02b6ab6c703c00dd4965065413c64ee7dd109a9988816148407",
   "genesis_rollup_leaf_index": 102,

--- a/configs/genesis/era/latest.toml
+++ b/configs/genesis/era/latest.toml
@@ -1,4 +1,4 @@
-protocol_semantic_version = 133143986177
+protocol_semantic_version = 137438953472
 genesis_root = "0x165530549ee8b02b6ab6c703c00dd4965065413c64ee7dd109a9988816148407"
 genesis_rollup_leaf_index = 102
 genesis_batch_commitment = "0x1aece7b49008c333ba094046be34d5858284ef6101cee1c30f1cecbfce75768f"

--- a/configs/genesis/zksync-os/latest.json
+++ b/configs/genesis/zksync-os/latest.json
@@ -241,8 +241,8 @@
   "genesis_root": "0x1a4ce8f15e4e9bc1041715f42560b85b3b84cb43f3471d8f98d4b84b49045147",
   "protocol_semantic_version": {
     "major": 0,
-    "minor": 31,
-    "patch": 1
+    "minor": 32,
+    "patch": 0
   },
   "prover": {
     "fflonk_snark_wrapper_vk_hash": "0x49eae0bf5c7ea580f4979b366e52b386adc5f42e2ce50fc1d3c4de9a86052bff",

--- a/l1-contracts/test/anvil-interop/README.md
+++ b/l1-contracts/test/anvil-interop/README.md
@@ -36,9 +36,11 @@ yarn test:hardhat:interop --keep-chains
 
 ## Pregenerated Chain States
 
-Tests load pregenerated Anvil snapshots from `chain-states/v0.31.1/` by default. This skips the full deployment and cuts test time from ~5 min to ~85s.
+Tests load pregenerated Anvil snapshots from `chain-states/<protocol-version>/` by default, where `<protocol-version>` is the `vMAJOR.MINOR.PATCH` declared by `configs/genesis/era/latest.json`. This skips the full deployment and cuts test time from ~5 min to ~85s.
 
 The runner auto-detects pregenerated state by checking for `chain-states/<protocol-version>/addresses.json`. If found, it decompresses the dumped state and starts each Anvil process with `--load-state`. If not found (or `FRESH_DEPLOY=1`), it runs the full 5-step deployment.
+
+Because the directory is keyed by protocol version, a genesis version bump makes the previous snapshots unreachable and tests silently fall back to the full deployment until they are regenerated (see below, or the "Regenerate Anvil Interop Chain States" workflow). The older `v0.29.0` / `v0.30.0` snapshots are kept deliberately — the fork-upgrade tests use them as the pre-upgrade source state.
 
 To regenerate pregenerated state after contract changes:
 
@@ -171,7 +173,7 @@ test/anvil-interop/
 │   ├── permanent-values.toml      # Immutable protocol values
 │   └── chain-{10,11,12,13}.toml   # Per-chain deployment params (generated)
 ├── chain-states/
-│   └── v0.31.1/                   # Pregenerated Anvil state snapshots
+│   └── v<major>.<minor>.<patch>/  # Pregenerated Anvil state snapshots, keyed by genesis protocol version
 │       ├── 31337.json             # L1 state dump
 │       ├── {10,11,12,13}.json     # L2 chain state dumps
 │       └── addresses.json         # All contract addresses + test tokens

--- a/l1-contracts/test/foundry/l1/integration/UpgradeTestv31_Local.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/UpgradeTestv31_Local.t.sol
@@ -143,7 +143,8 @@ contract UpgradeIntegrationTest_Local is
     }
 
     /// @notice Bump the CTM's protocol version from the upgrade input TOML so the local
-    ///         genesis-at-v31 fixture exercises a v31 → v32 upgrade.
+    ///         fixture exercises an upgrade to one minor above the genesis version
+    ///         (currently v32 -> v33). See `foundry-upgrade.toml`.
     /// @dev    Replaces the former `overrideProtocolVersionForLocalTesting` hook on the
     ///         deleted `DefaultEcosystemUpgrade` orchestrator.
     function afterInitHook() internal override {

--- a/l1-contracts/upgrade-envs/v0.31.0-interopB/foundry-upgrade.toml
+++ b/l1-contracts/upgrade-envs/v0.31.0-interopB/foundry-upgrade.toml
@@ -1,9 +1,13 @@
-# Foundry-specific upgrade configuration for local testing
-# Since genesis config deploys chains at v31.0.0, we need to upgrade to v32.0.0
+# Foundry-specific upgrade configuration for local testing.
+#
+# The local harness deploys at whatever `configs/genesis/era/latest.json` declares and then
+# upgrades to `new_protocol_version`, so this must stay one minor ahead of the genesis version:
+# `DefaultCTMUpgrade.initUpgrade` requires `ctmProtocolVersion != getNewProtocolVersion()`.
+# Genesis is at v32.0.0, so the fixture exercises a v32 -> v33 upgrade.
 
-old_protocol_version = 0x1f00000000  # v31.0.0 (current genesis)
+old_protocol_version = 0x2000000000  # v32.0.0 (current genesis)
 v28_protocol_version = 0x1c00000000  # v28.0.0 (for reference)
 
 [contracts]
-new_protocol_version = 0x2000000000  # v32.0.0 (target for upgrade)
-latest_protocol_version = 0x2000000000  # v32.0.0
+new_protocol_version = 0x2100000000  # v33.0.0 (target for upgrade)
+latest_protocol_version = 0x2100000000  # v33.0.0


### PR DESCRIPTION
## What

Bumps both genesis configs from `0.31.1` to `0.32.0` on `draft-v32`:

| file | before | after |
| --- | --- | --- |
| `configs/genesis/era/latest.json` / `.toml` | 0.31.1 | **0.32.0** |
| `configs/genesis/zksync-os/latest.json` | 0.31.1 | **0.32.0** |

This is the `draft-v32` counterpart of #2368, which does the same against `draft-v31`.

## Why

`draft-v32` still deploys chains at protocol version 0.31.1, and downstream consumers have already moved to v32. Concretely: zksync-os-server gates L1-backed interop-root imports and `MessageRoot` proofs on `MIN_VERSION_WITH_L1_INTEROP = 0.32.0` (matter-labs/zksync-os-server#1413, merged), so a chain deployed from these configs is refused with

```
MessageRoot proofs require protocol version 0.32.0 or newer; batch N uses 0.31.0
```

Everything else that needs the version reads it from these two files — `ChainCreationParamsLib`, `DefaultCoreUpgrade.loadProtocolVersionFromGenesis()`, and the anvil-interop runners — so bumping them here is the whole change.

## No regenesis needed

`genesis_root`, `genesis_batch_commitment` and `genesis_rollup_leaf_index` are untouched: none of them depend on the protocol version. The earlier `0.31.0 -> 0.31.1` bump landed the same way, touching only the version field.

Era and ZKsync OS move together deliberately — the two flavours drifting apart is what tripped `GatewayVotePreparation`'s "CTM protocol version mismatch" require the last time it happened.

## Follow-on fixes

Two places keyed off the genesis version move with it:

- **`upgrade-envs/v0.31.0-interopB/foundry-upgrade.toml`** — `UpgradeTestv31_Local.t.sol` feeds `$.contracts.new_protocol_version` to `setNewProtocolVersion`, and `DefaultCTMUpgrade.initUpgrade` requires `ctmProtocolVersion != getNewProtocolVersion()`. The fixture has to stay one minor ahead of genesis, so it now exercises v32 -> v33.
- **`test/anvil-interop/README.md`** — the pregenerated-state directory is keyed by genesis protocol version (`chain-states/v<major>.<minor>.<patch>/`), which the README previously hardcoded as `v0.31.1`.

## Chain states

The bump makes `chain-states/v0.31.1/` unreachable, so the anvil-interop tests fall back to a full deployment (correct, just slower) until `v0.32.0` snapshots are generated by the "Regenerate Anvil Interop Chain States" workflow. The older `v0.29.0` / `v0.30.0` snapshots stay — the fork-upgrade tests use them as pre-upgrade source state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
