### PR TITLE
perf(ci): shard the Anvil interop coverage run across parallel workers

### DIFF
--- a/.github/workflows/l1-contracts-ci.yaml
+++ b/.github/workflows/l1-contracts-ci.yaml
@@ -364,8 +364,10 @@ jobs:
 
       # --- 1. Foundry coverage (unchanged) ---
 
+      # `forge coverage` runs the suite itself, and the `test-foundry` job already gates
+      # on the full (unfiltered) `yarn test:foundry`, so there is no separate test run here.
       - name: Run Foundry coverage
-        run: yarn test:foundry --no-match-path 'test/foundry/l1/unit/concrete/Executor/*' && yarn coverage:foundry --report summary --report lcov
+        run: yarn coverage:foundry --report summary --report lcov
 
       # Installing the specific version of `lcov` because of
       # the `genhtml: ERROR: line ... of ... has branchcov but no linecov data` error.
@@ -414,14 +416,27 @@ jobs:
         working-directory: l1-contracts/test/anvil-interop
         run: yarn install
 
+      # run-coverage.ts shards the specs across workers, each with its own 6 Anvil chains,
+      # and unions the per-shard LCOV afterwards. Same cap and reasoning as the
+      # integration-test job in anvil-interop-ci.yaml: a worker is 6 Anvil chains plus a
+      # hardhat process, so running all 10 shards at once oversubscribes the 4-core runner
+      # and causes load-dependent RPC flakes. Coverage mode adds --steps-tracing on top,
+      # so if this job starts flaking, lower the cap before anything else.
       - name: Run Anvil interop coverage
         working-directory: l1-contracts/test/anvil-interop
+        env:
+          ANVIL_INTEROP_MAX_PARALLEL_WORKERS: "4"
         run: ANVIL_COVERAGE_MODE=1 yarn ts-node run-coverage.ts
 
+      # cleanup.sh is scoped to one port offset, so a cancelled run would otherwise leave
+      # the shard workers' chains behind. Sweep every offset a shard can use.
       - name: Cleanup Anvil
         if: always()
         working-directory: l1-contracts/test/anvil-interop
-        run: yarn cleanup
+        run: |
+          for offset in 0 100 200 300 400 500 600 700 800 900; do
+            ANVIL_INTEROP_PORT_OFFSET=$offset ANVIL_INTEROP_RUN_SUFFIX="-p$offset" yarn cleanup
+          done
 
       # Merge produces two outputs:
       #   coverage/merged-lcov.info        — Foundry hits + Anvil hits
@@ -480,6 +495,7 @@ jobs:
             l1-contracts/lcov.info
             l1-contracts/coverage/anvil/anvil-lcov.info
             l1-contracts/coverage/anvil/anvil-coverage-summary.txt
+            l1-contracts/coverage/anvil/shards/*/anvil-lcov.info
             l1-contracts/coverage/anvil-rebased-lcov.info
             l1-contracts/coverage/ANVIL_UNTESTED_LINES_REPORT.md
             l1-contracts/coverage/merged-lcov.info

--- a/.github/workflows/l1-contracts-ci.yaml
+++ b/.github/workflows/l1-contracts-ci.yaml
@@ -416,6 +416,12 @@ jobs:
         working-directory: l1-contracts/test/anvil-interop
         run: yarn install
 
+      # Guards the union that combines the per-shard LCOV reports below. Pure string/map
+      # logic, no chains involved, runs in seconds.
+      - name: Unit-test the shard LCOV merge
+        working-directory: l1-contracts/test/anvil-interop
+        run: yarn test:lcov-merge
+
       # run-coverage.ts shards the specs across workers, each with its own 6 Anvil chains,
       # and unions the per-shard LCOV afterwards. Same cap and reasoning as the
       # integration-test job in anvil-interop-ci.yaml: a worker is 6 Anvil chains plus a

--- a/l1-contracts/test/anvil-interop/README.md
+++ b/l1-contracts/test/anvil-interop/README.md
@@ -138,7 +138,7 @@ replays the collected traces through the Forge source maps to produce an LCOV re
 yarn coverage
 
 # Single process, one set of chains, all specs (the pre-sharding behavior)
-yarn ts-node run-coverage.ts --serial
+yarn coverage:serial
 
 # One spec only (implies single process)
 yarn ts-node run-coverage.ts --spec test/anvil-interop/test/hardhat/07-interop-bundles.spec.ts
@@ -152,7 +152,9 @@ reports into `l1-contracts/coverage/anvil/anvil-lcov.info`, which is what
 
 Shards resolve only the contracts their own specs touched, so their file and line sets differ;
 the union takes the max hit count per line and per function. Denominators do not matter here —
-`scripts/merge-coverage.ts` rebases everything onto the Foundry LCOV.
+`scripts/merge-coverage.ts` rebases everything onto the Foundry LCOV. The union itself is
+covered by `yarn test:lcov-merge` (`test/unit/lcov-merge.test.ts`), which CI runs before the
+coverage pipeline.
 
 Tracing multiplies Anvil's memory and CPU cost, so cap the concurrency on small machines with
 `ANVIL_INTEROP_MAX_PARALLEL_WORKERS` (CI uses 4). If coverage runs start failing with RPC

--- a/l1-contracts/test/anvil-interop/README.md
+++ b/l1-contracts/test/anvil-interop/README.md
@@ -128,16 +128,48 @@ Live environment variables:
 | `05-gateway-bridge`          | L1->L2A ETH deposit + L2A->L1 ETH withdrawal on chain 12 (via GW)                                                                                            |
 | `06-gateway-interop`         | L2A<->L2B interop transfers between GW-settled L2 chains                                                                                                     |
 
+## Coverage
+
+`run-coverage.ts` runs the specs against Anvil chains started with `--steps-tracing`, then
+replays the collected traces through the Forge source maps to produce an LCOV report.
+
+```bash
+# From this directory — shard the specs across parallel workers (default)
+yarn coverage
+
+# Single process, one set of chains, all specs (the pre-sharding behavior)
+yarn ts-node run-coverage.ts --serial
+
+# One spec only (implies single process)
+yarn ts-node run-coverage.ts --spec test/anvil-interop/test/hardhat/07-interop-bundles.spec.ts
+```
+
+Each shard is a child process that owns its own six Anvil chains (own port offset, own run
+suffix, own state dir), runs its slice of the specs, and collects coverage from its own chains
+into `l1-contracts/coverage/anvil/shards/p<offset>/`. The parent then unions the per-shard
+reports into `l1-contracts/coverage/anvil/anvil-lcov.info`, which is what
+`yarn l1 coverage:merge` reads when combining Anvil hits with the Foundry report.
+
+Shards resolve only the contracts their own specs touched, so their file and line sets differ;
+the union takes the max hit count per line and per function. Denominators do not matter here —
+`scripts/merge-coverage.ts` rebases everything onto the Foundry LCOV.
+
+Tracing multiplies Anvil's memory and CPU cost, so cap the concurrency on small machines with
+`ANVIL_INTEROP_MAX_PARALLEL_WORKERS` (CI uses 4). If coverage runs start failing with RPC
+errors mid-spec, lower it before looking anywhere else.
+
 ## Environment Variables
 
-| Variable                       | Effect                                                            |
-| ------------------------------ | ----------------------------------------------------------------- |
-| `ANVIL_INTEROP_SKIP_SETUP=1`   | Skip deployment, run only tests (requires chains already running) |
-| `ANVIL_INTEROP_SKIP_CLEANUP=1` | Don't kill Anvil processes after tests                            |
-| `ANVIL_INTEROP_KEEP_CHAINS=1`  | Same as `--keep-chains` flag                                      |
-| `ANVIL_INTEROP_FRESH_DEPLOY=1` | Force full deployment even if pregenerated state exists           |
-| `ANVIL_INTEROP_PORT_OFFSET=N`  | Offset all chain ports by N (useful for parallel runs)            |
-| `ANVIL_INTEROP_RUN_SUFFIX=X`   | Suffix for output dirs (set automatically by parallel workers)    |
+| Variable                               | Effect                                                                  |
+| -------------------------------------- | ----------------------------------------------------------------------- |
+| `ANVIL_INTEROP_SKIP_SETUP=1`           | Skip deployment, run only tests (requires chains already running)       |
+| `ANVIL_INTEROP_SKIP_CLEANUP=1`         | Don't kill Anvil processes after tests                                  |
+| `ANVIL_INTEROP_KEEP_CHAINS=1`          | Same as `--keep-chains` flag                                            |
+| `ANVIL_INTEROP_FRESH_DEPLOY=1`         | Force full deployment even if pregenerated state exists                 |
+| `ANVIL_INTEROP_PORT_OFFSET=N`          | Offset all chain ports by N (useful for parallel runs)                  |
+| `ANVIL_INTEROP_RUN_SUFFIX=X`           | Suffix for output dirs (set automatically by parallel workers)          |
+| `ANVIL_INTEROP_MAX_PARALLEL_WORKERS=N` | Cap concurrent test/coverage workers (0 or unset = one per spec)        |
+| `ANVIL_COVERAGE_MODE=1`                | Start Anvil with `--steps-tracing` so traces can be collected afterward |
 
 ### CLI Parameters
 

--- a/l1-contracts/test/anvil-interop/package.json
+++ b/l1-contracts/test/anvil-interop/package.json
@@ -10,7 +10,9 @@
     "deploy:test-token": "ts-node src/helpers/deploy-test-token.ts",
     "setup-and-dump": "ts-node setup-and-dump-state.ts",
     "test:v31-to-v32": "ts-node run-v31-to-v32-upgrade-test.ts",
+    "test:lcov-merge": "ts-node test/unit/lcov-merge.test.ts",
     "coverage": "ANVIL_COVERAGE_MODE=1 ts-node run-coverage.ts",
+    "coverage:serial": "ANVIL_COVERAGE_MODE=1 ts-node run-coverage.ts --serial",
     "coverage:html": "ANVIL_COVERAGE_MODE=1 ts-node run-coverage.ts --html",
     "coverage:collect": "ts-node collect-coverage.ts",
     "coverage:collect:html": "ts-node collect-coverage.ts --html"

--- a/l1-contracts/test/anvil-interop/run-coverage.ts
+++ b/l1-contracts/test/anvil-interop/run-coverage.ts
@@ -3,33 +3,49 @@
 /**
  * Runs the full Anvil interop test + coverage pipeline.
  *
- * This is the primary entry point for coverage collection. It:
- * 1. Runs cleanup
- * 2. Starts Anvil chains WITH --steps-tracing enabled
- * 3. Deploys contracts (or loads pre-generated state)
- * 4. Runs the interop tests
- * 5. Collects execution traces from the running Anvil chains
- * 6. Generates LCOV coverage report
- * 7. Cleans up Anvil chains
+ * By default the specs are sharded across parallel workers, mirroring
+ * `run-hardhat-interop-test.ts`: each worker is a child of this script that owns
+ * its own set of Anvil chains (own port offset, own run suffix, own state dir),
+ * runs its slice of the specs, and collects coverage from its own chains. The
+ * parent then unions the per-shard LCOV files into
+ * `coverage/anvil/anvil-lcov.info`, which is what `yarn coverage:merge` reads.
+ *
+ * Sharding is what makes this affordable in CI: the specs run against Anvil with
+ * `--steps-tracing`, which is several times slower than a normal run, so running
+ * all 10 specs in one serial process dominated the coverage job.
+ *
+ * Modes:
+ *   default            shard specs across workers (see MAX_PARALLEL_WORKERS)
+ *   --spec <path>      run only the given spec(s) in this process (no sharding)
+ *   --serial           run every spec in this process, one Anvil set (old behavior)
  *
  * Usage:
- *   ts-node run-coverage.ts [--html] [--l1-only] [--fresh-deploy]
+ *   ts-node run-coverage.ts [--html] [--l1-only] [--fresh-deploy] [--serial]
+ *                           [--spec <path>]... [--port-offset <N>]
  *
  * Environment variables:
- *   ANVIL_INTEROP_FRESH_DEPLOY=1  Force full deployment instead of pregenerated state
- *   ANVIL_INTEROP_PORT_OFFSET=N   Offset all ports by N
+ *   ANVIL_INTEROP_FRESH_DEPLOY=1           Force full deployment instead of pregenerated state
+ *   ANVIL_INTEROP_PORT_OFFSET=N            Offset all ports by N
+ *   ANVIL_INTEROP_MAX_PARALLEL_WORKERS=N   Cap concurrent workers (0/unset = one per spec)
+ *   ANVIL_INTEROP_COVERAGE_WORKER=1        Internal: marks a sharded child process
  */
 
-import { spawnSync } from "child_process";
+import { spawn, spawnSync } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import { AnvilManager } from "./src/daemons/anvil-manager";
 import { DeploymentRunner } from "./src/deployment-runner";
 import { collectCoverage } from "./src/coverage/coverage-runner";
+import { formatMergeSummary, mergeLcovFiles } from "./src/coverage/lcov-merge";
 
 const anvilInteropDir = __dirname;
 const l1ContractsDir = path.resolve(__dirname, "../..");
+const coverageRootDir = path.join(l1ContractsDir, "coverage/anvil");
+const shardsDir = path.join(coverageRootDir, "shards");
 const totalStart = Date.now();
+
+/** Ports are spaced this far apart so each worker's 6 chains never collide. */
+const PORT_OFFSET_PER_WORKER = 100;
 
 function elapsedSince(start: number): string {
   const ms = Date.now() - start;
@@ -62,81 +78,287 @@ function timedRun(label: string, command: string, args: string[], cwd: string, e
   console.log(`⏱️  [TIMING] Finished: ${label} in ${elapsedSince(start)} (total elapsed: ${elapsedSince(totalStart)})`);
 }
 
+function parseRequestedSpecs(argv: string[]): string[] {
+  const specArgs: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--spec") {
+      const spec = argv[i + 1];
+      if (!spec) {
+        throw new Error("--spec requires a file path");
+      }
+      specArgs.push(spec);
+      i += 1;
+    }
+  }
+  return specArgs;
+}
+
+function discoverSpecFiles(): string[] {
+  const specDir = path.join(anvilInteropDir, "test/hardhat");
+  return fs
+    .readdirSync(specDir)
+    .filter((f) => /^\d+-.*\.spec\.ts$/.test(f))
+    .sort()
+    .map((f) => `test/anvil-interop/test/hardhat/${f}`);
+}
+
+function readLogTail(logPath: string, maxLines = 120): string {
+  if (!fs.existsSync(logPath)) {
+    return "log file not found";
+  }
+  const lines = fs.readFileSync(logPath, "utf-8").trimEnd().split("\n");
+  return lines.slice(-maxLines).join("\n");
+}
+
+/** Where a worker with the given port offset writes its LCOV. */
+function shardCoverageDir(portOffset: number): string {
+  return path.join(shardsDir, `p${portOffset}`);
+}
+
+async function runShardWorker(
+  label: string,
+  specs: string[],
+  portOffset: number,
+  passthroughArgs: string[]
+): Promise<void> {
+  const runSuffix = `-p${portOffset}`;
+  const logsDir = path.join(anvilInteropDir, `outputs/logs${runSuffix}`);
+  fs.mkdirSync(logsDir, { recursive: true });
+  const logPath = path.join(logsDir, `${label.replace(/\s+/g, "-")}-coverage.log`);
+  const logStream = fs.createWriteStream(logPath, { flags: "w" });
+
+  const specNames = specs.map((s) => path.basename(s, ".spec.ts"));
+  console.log(
+    `\n⏱️  [TIMING] Starting: ${label} [${specNames.join(", ")}] (offset ${portOffset}, total elapsed: ${elapsedSince(totalStart)})`
+  );
+  console.log(`   log: ${logPath}`);
+
+  const workerArgs = [
+    "run-coverage.ts",
+    "--port-offset",
+    portOffset.toString(),
+    ...specs.flatMap((spec) => ["--spec", spec]),
+    ...passthroughArgs,
+  ];
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn("ts-node", workerArgs, {
+      cwd: anvilInteropDir,
+      env: {
+        ...process.env,
+        ANVIL_INTEROP_COVERAGE_WORKER: "1",
+        ANVIL_INTEROP_RUN_SUFFIX: runSuffix,
+        ANVIL_INTEROP_PORT_OFFSET: portOffset.toString(),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    child.stdout?.pipe(logStream);
+    child.stderr?.pipe(logStream);
+
+    child.once("error", (error) => {
+      logStream.end();
+      reject(new Error(`Failed to start ${label}: ${error.message}. Log: ${logPath}`));
+    });
+    child.once("exit", (code) => {
+      logStream.end();
+      if (code === 0) {
+        console.log(
+          `✅ ${label} [${specNames.join(", ")}] passed (offset ${portOffset}, total elapsed: ${elapsedSince(totalStart)})`
+        );
+        resolve();
+      } else {
+        console.log(
+          `❌ ${label} [${specNames.join(", ")}] failed (offset ${portOffset}, total elapsed: ${elapsedSince(totalStart)})`
+        );
+        reject(
+          new Error(
+            `${label} failed with exit code ${code ?? "unknown"}. Log: ${logPath}\n` +
+              `--- ${label} log tail ---\n${readLogTail(logPath)}\n--- end log tail ---`
+          )
+        );
+      }
+    });
+  });
+}
+
+function generateHtmlReport(lcovPath: string): void {
+  const htmlDir = path.join(coverageRootDir, "html");
+  const result = spawnSync(
+    "genhtml",
+    [lcovPath, "-o", htmlDir, "--branch-coverage", "--ignore-errors", "category", "--ignore-errors", "inconsistent"],
+    { stdio: "inherit" }
+  );
+  if (result.status === 0) {
+    console.log(`  🌐 HTML report generated: ${htmlDir}/index.html`);
+  } else {
+    console.warn("  ⚠️  genhtml failed (is lcov installed?). Skipping HTML report.");
+  }
+}
+
+/**
+ * Parent process: shard the specs across workers, then union their LCOV files.
+ */
+async function runSharded(specs: string[], basePortOffset: number, passthroughArgs: string[], html: boolean) {
+  // One shard per spec. Each shard runs 6 Anvil chains with --steps-tracing plus a
+  // hardhat process, so running all shards at once oversubscribes small runners and
+  // causes load-dependent RPC flakes. ANVIL_INTEROP_MAX_PARALLEL_WORKERS caps the
+  // concurrency; unset (or 0) runs one worker per spec.
+  const shardGroups = specs.map((spec) => [spec]);
+  const maxWorkers = Number(process.env.ANVIL_INTEROP_MAX_PARALLEL_WORKERS || 0) || shardGroups.length;
+
+  // Drop stale per-shard reports so a shard that fails to produce one cannot be
+  // silently merged from a previous run.
+  fs.rmSync(shardsDir, { recursive: true, force: true });
+
+  console.log(`\n📊 Sharding ${specs.length} specs across up to ${maxWorkers} concurrent workers`);
+
+  await timedAsync("parallel anvil coverage workers", async () => {
+    const queue = shardGroups.map((group, index) => ({ group, index }));
+    const failures: Error[] = [];
+    const runNext = async (): Promise<void> => {
+      const item = queue.shift();
+      if (!item) return;
+      try {
+        await runShardWorker(
+          `shard ${item.index + 1}`,
+          item.group,
+          basePortOffset + item.index * PORT_OFFSET_PER_WORKER,
+          passthroughArgs
+        );
+      } catch (e) {
+        failures.push(e as Error);
+      }
+      await runNext();
+    };
+    await Promise.all(Array.from({ length: Math.min(maxWorkers, queue.length) }, () => runNext()));
+    if (failures.length > 0) {
+      for (const failure of failures) {
+        console.error(`\n${failure.message}`);
+      }
+      throw new Error(`${failures.length} of ${shardGroups.length} coverage shards failed`);
+    }
+  });
+
+  // Union the shard reports into the path `yarn coverage:merge` expects.
+  const shardLcovPaths = shardGroups.map((_, index) =>
+    path.join(shardCoverageDir(basePortOffset + index * PORT_OFFSET_PER_WORKER), "anvil-lcov.info")
+  );
+  const missing = shardLcovPaths.filter((p) => !fs.existsSync(p));
+  if (missing.length > 0) {
+    throw new Error(`Coverage shards produced no LCOV:\n  ${missing.join("\n  ")}`);
+  }
+
+  const lcovPath = path.join(coverageRootDir, "anvil-lcov.info");
+  const { stats } = mergeLcovFiles(shardLcovPaths, lcovPath);
+  const summary = formatMergeSummary(stats, shardLcovPaths.length);
+  const summaryPath = path.join(coverageRootDir, "anvil-coverage-summary.txt");
+  fs.writeFileSync(summaryPath, summary);
+
+  console.log(`\n${summary}`);
+  console.log(`  📄 Merged LCOV written to: ${lcovPath}`);
+  console.log(`  📄 Summary written to: ${summaryPath}`);
+
+  if (html) {
+    generateHtmlReport(lcovPath);
+  }
+}
+
+/**
+ * Single-process run: start one set of chains, run the given specs, collect
+ * coverage from those chains. This is both the `--serial` path and the body of
+ * every sharded worker.
+ */
+async function runSingleProcess(
+  specs: string[],
+  freshDeploy: boolean,
+  coverageDir: string,
+  html: boolean,
+  l1Only: boolean
+) {
+  timedRun("cleanup", "yarn", ["cleanup"], anvilInteropDir);
+
+  const runner = new DeploymentRunner();
+  const anvilManager = new AnvilManager();
+
+  if (!freshDeploy && runner.hasChainStates()) {
+    const stateDir = runner.getChainStatesDir();
+    console.log(`\nFound pre-generated chain states at ${stateDir}`);
+    await timedAsync("load chain states (coverage mode)", () => runner.loadChainStates(anvilManager, stateDir));
+  } else {
+    console.log("\nNo pre-generated chain states found, running full deployment...");
+    await timedAsync("full deployment + test tokens + TBM", () => runner.deployAndSetupWithTBM(anvilManager));
+  }
+
+  // Tests run with --no-compile since compilation is already done.
+  timedRun(
+    `hardhat test - ${specs.length} interop spec${specs.length === 1 ? "" : "s"}`,
+    "yarn",
+    ["hardhat", "test", ...specs, "--network", "hardhat", "--no-compile"],
+    l1ContractsDir,
+    {
+      ...process.env,
+      ANVIL_INTEROP_SKIP_SETUP: "1",
+      ANVIL_INTEROP_SKIP_CLEANUP: "1",
+    }
+  );
+
+  // Collect coverage while the chains are still running.
+  const runSuffix = process.env.ANVIL_INTEROP_RUN_SUFFIX || "";
+  await timedAsync("coverage collection", () =>
+    collectCoverage({
+      projectRoot: l1ContractsDir,
+      outDir: path.join(l1ContractsDir, "out"),
+      statePath: path.join(anvilInteropDir, `outputs/state${runSuffix}/chains.json`),
+      coverageDir,
+      html,
+      l1Only,
+    })
+  );
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const html = args.includes("--html");
   const l1Only = args.includes("--l1-only");
+  const serial = args.includes("--serial");
   const freshDeploy = args.includes("--fresh-deploy") || process.env.ANVIL_INTEROP_FRESH_DEPLOY === "1";
+  const workerMode = process.env.ANVIL_INTEROP_COVERAGE_WORKER === "1";
+  const requestedSpecs = parseRequestedSpecs(args);
 
-  const portOffset = (() => {
-    const idx = args.indexOf("--port-offset");
-    return idx !== -1 ? parseInt(args[idx + 1], 10) : 0;
-  })();
+  const portOffsetIdx = args.indexOf("--port-offset");
+  const portOffset = portOffsetIdx !== -1 ? parseInt(args[portOffsetIdx + 1], 10) : 0;
   if (portOffset) {
     process.env.ANVIL_INTEROP_PORT_OFFSET = portOffset.toString();
   }
 
-  // Enable steps tracing for all Anvil chains started by this process
+  // Enable steps tracing for all Anvil chains started by this process (and, via
+  // inheritance, by any worker it spawns).
   process.env.ANVIL_COVERAGE_MODE = "1";
 
   console.log("📊 Anvil Interop Test + Coverage Pipeline");
   console.log("=".repeat(50));
 
-  // Auto-discover spec files
-  const specDir = path.join(anvilInteropDir, "test/hardhat");
-  const allSpecFiles = fs
-    .readdirSync(specDir)
-    .filter((f) => /^\d+-.*\.spec\.ts$/.test(f))
-    .sort()
-    .map((f) => `test/anvil-interop/test/hardhat/${f}`);
+  const specs = requestedSpecs.length > 0 ? requestedSpecs : discoverSpecFiles();
+
+  // A fresh deployment per shard would multiply the deploy cost, so `--fresh-deploy`
+  // stays serial. Explicit `--spec` selection and worker processes are single-process
+  // by definition.
+  const shouldShard = !workerMode && !serial && !freshDeploy && requestedSpecs.length === 0;
 
   try {
-    // Step 1: Cleanup
-    timedRun("cleanup", "yarn", ["cleanup"], anvilInteropDir);
-
-    // Step 2: Start chains and deploy
-    const runner = new DeploymentRunner();
-    const anvilManager = new AnvilManager();
-
-    if (!freshDeploy && runner.hasChainStates()) {
-      const stateDir = runner.getChainStatesDir();
-      console.log(`\nFound pre-generated chain states at ${stateDir}`);
-      await timedAsync("load chain states (coverage mode)", () => runner.loadChainStates(anvilManager, stateDir));
+    if (shouldShard) {
+      const passthroughArgs = l1Only ? ["--l1-only"] : [];
+      await runSharded(specs, portOffset, passthroughArgs, html);
     } else {
-      console.log("\nNo pre-generated chain states found, running full deployment...");
-      await timedAsync("full deployment + test tokens + TBM", () => runner.deployAndSetupWithTBM(anvilManager));
+      const coverageDir = workerMode ? shardCoverageDir(portOffset) : coverageRootDir;
+      await runSingleProcess(specs, freshDeploy, coverageDir, html && !workerMode, l1Only);
     }
-
-    // Step 3: Run tests (coverage-invisible — we collect traces afterward)
-    // Tests run with --no-compile since compilation is already done
-    timedRun(
-      `hardhat test - ${allSpecFiles.length} interop specs`,
-      "yarn",
-      ["hardhat", "test", ...allSpecFiles, "--network", "hardhat", "--no-compile"],
-      l1ContractsDir,
-      {
-        ...process.env,
-        ANVIL_INTEROP_SKIP_SETUP: "1",
-        ANVIL_INTEROP_SKIP_CLEANUP: "1",
-      }
-    );
-
-    // Step 4: Collect coverage while chains are still running
-    const runSuffix = process.env.ANVIL_INTEROP_RUN_SUFFIX || "";
-    await timedAsync("coverage collection", () =>
-      collectCoverage({
-        projectRoot: l1ContractsDir,
-        outDir: path.join(l1ContractsDir, "out"),
-        statePath: path.join(anvilInteropDir, `outputs/state${runSuffix}/chains.json`),
-        coverageDir: path.join(l1ContractsDir, "coverage/anvil"),
-        html,
-        l1Only,
-      })
-    );
 
     console.log(`\n⏱️  [TIMING] Total coverage run: ${elapsedSince(totalStart)}`);
   } finally {
-    // Always cleanup
+    // Each worker cleans up its own offset-scoped chains; this clears whatever ran
+    // in this process (and any offset-0 leftovers in the parent).
     runOrThrow("yarn", ["cleanup"], anvilInteropDir);
   }
 }

--- a/l1-contracts/test/anvil-interop/src/coverage/lcov-merge.ts
+++ b/l1-contracts/test/anvil-interop/src/coverage/lcov-merge.ts
@@ -1,0 +1,177 @@
+/**
+ * Unions several Anvil LCOV tracefiles into one.
+ *
+ * Used to combine the per-shard reports produced by parallel `run-coverage.ts`
+ * workers into the single `coverage/anvil/anvil-lcov.info` that
+ * `scripts/merge-coverage.ts` consumes.
+ *
+ * Shards do not all see the same contracts: a shard only resolves the addresses
+ * its own specs actually touched, and `getExecutableLines` derives the line
+ * universe from those resolved contracts. So the file/line sets differ between
+ * shards and the merge takes the union of the line universe and the max hit
+ * count per line and per function. That is the correct reading: a line was
+ * covered by the suite if any shard hit it.
+ *
+ * The union denominator (LF) only affects the standalone "Anvil (raw)" summary.
+ * `merge-coverage.ts` rebases hits onto the Foundry LCOV, so the merged and
+ * rebased reports keep Foundry's denominator regardless of what shards saw.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+interface FileRecord {
+  /** line number -> max hit count across shards */
+  lines: Map<number, number>;
+  /** function qualified name -> declaration line */
+  functionLines: Map<string, number>;
+  /** function qualified name -> max hit count across shards */
+  functionHits: Map<string, number>;
+}
+
+export interface MergeStats {
+  files: number;
+  lines: number;
+  linesHit: number;
+  functions: number;
+  functionsHit: number;
+}
+
+function parseInto(content: string, files: Map<string, FileRecord>): void {
+  let current: FileRecord | null = null;
+
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.trim();
+
+    if (line.startsWith("SF:")) {
+      const filePath = line.substring(3);
+      let record = files.get(filePath);
+      if (!record) {
+        record = { lines: new Map(), functionLines: new Map(), functionHits: new Map() };
+        files.set(filePath, record);
+      }
+      current = record;
+    } else if (!current) {
+      continue;
+    } else if (line.startsWith("DA:")) {
+      const [lineNumRaw, hitsRaw] = line.substring(3).split(",");
+      const lineNum = parseInt(lineNumRaw, 10);
+      const hits = parseInt(hitsRaw, 10);
+      if (!Number.isNaN(lineNum) && !Number.isNaN(hits)) {
+        current.lines.set(lineNum, Math.max(current.lines.get(lineNum) ?? 0, hits));
+      }
+    } else if (line.startsWith("FN:")) {
+      const parts = line.substring(3).split(",");
+      const declLine = parseInt(parts[0], 10);
+      const name = parts.slice(1).join(",");
+      if (name && !Number.isNaN(declLine)) {
+        current.functionLines.set(name, declLine);
+        // Ensure every declared function has an entry, so a function declared in
+        // one shard but never hit in any still shows up as FNDA:0.
+        if (!current.functionHits.has(name)) {
+          current.functionHits.set(name, 0);
+        }
+      }
+    } else if (line.startsWith("FNDA:")) {
+      const parts = line.substring(5).split(",");
+      const hits = parseInt(parts[0], 10);
+      const name = parts.slice(1).join(",");
+      if (name && !Number.isNaN(hits)) {
+        current.functionHits.set(name, Math.max(current.functionHits.get(name) ?? 0, hits));
+      }
+    } else if (line === "end_of_record") {
+      current = null;
+    }
+  }
+}
+
+function serialize(files: Map<string, FileRecord>, testName: string): { content: string; stats: MergeStats } {
+  const output: string[] = [];
+  const stats: MergeStats = { files: 0, lines: 0, linesHit: 0, functions: 0, functionsHit: 0 };
+
+  const sortedFiles = Array.from(files.entries()).sort(([a], [b]) => a.localeCompare(b));
+
+  for (const [filePath, record] of sortedFiles) {
+    stats.files++;
+    output.push(`TN:${testName}`);
+    output.push(`SF:${filePath}`);
+
+    const sortedFns = Array.from(record.functionLines.entries()).sort(([, a], [, b]) => a - b);
+    for (const [name, declLine] of sortedFns) {
+      output.push(`FN:${declLine},${name}`);
+    }
+    let functionsHit = 0;
+    for (const [name] of sortedFns) {
+      const hits = record.functionHits.get(name) ?? 0;
+      if (hits > 0) functionsHit++;
+      output.push(`FNDA:${hits},${name}`);
+    }
+    if (sortedFns.length > 0) {
+      output.push(`FNF:${sortedFns.length}`);
+      output.push(`FNH:${functionsHit}`);
+    }
+    stats.functions += sortedFns.length;
+    stats.functionsHit += functionsHit;
+
+    const sortedLines = Array.from(record.lines.entries()).sort(([a], [b]) => a - b);
+    let linesFound = 0;
+    let linesHit = 0;
+    for (const [lineNum, hits] of sortedLines) {
+      output.push(`DA:${lineNum},${hits}`);
+      linesFound++;
+      if (hits > 0) linesHit++;
+    }
+    output.push(`LF:${linesFound}`);
+    output.push(`LH:${linesHit}`);
+    output.push("end_of_record");
+
+    stats.lines += linesFound;
+    stats.linesHit += linesHit;
+  }
+
+  return { content: output.join("\n") + "\n", stats };
+}
+
+/**
+ * Reads every given LCOV path and writes their union to `outputPath`.
+ *
+ * Missing paths are skipped (a shard that produced no report is reported by the
+ * caller, which fails the run on a non-zero worker exit before we get here).
+ */
+export function mergeLcovFiles(
+  inputPaths: string[],
+  outputPath: string,
+  testName = "anvil_interop"
+): { stats: MergeStats; mergedPaths: string[] } {
+  const files = new Map<string, FileRecord>();
+  const mergedPaths: string[] = [];
+
+  for (const inputPath of inputPaths) {
+    if (!fs.existsSync(inputPath)) continue;
+    parseInto(fs.readFileSync(inputPath, "utf-8"), files);
+    mergedPaths.push(inputPath);
+  }
+
+  const { content, stats } = serialize(files, testName);
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, content);
+
+  return { stats, mergedPaths };
+}
+
+/** Renders the same shape of summary that `lcov-generator.generateSummary` produces. */
+export function formatMergeSummary(stats: MergeStats, shardCount: number): string {
+  const linePct = stats.lines > 0 ? ((stats.linesHit / stats.lines) * 100).toFixed(2) : "0.00";
+  const fnPct = stats.functions > 0 ? ((stats.functionsHit / stats.functions) * 100).toFixed(2) : "0.00";
+
+  return [
+    "Anvil Interop Coverage Summary (merged across shards)",
+    "=".repeat(52),
+    `Shards:    ${shardCount}`,
+    `Files:     ${stats.files}`,
+    `Lines:     ${stats.linesHit}/${stats.lines} (${linePct}%)`,
+    `Functions: ${stats.functionsHit}/${stats.functions} (${fnPct}%)`,
+    "",
+  ].join("\n");
+}

--- a/l1-contracts/test/anvil-interop/test/unit/lcov-merge.test.ts
+++ b/l1-contracts/test/anvil-interop/test/unit/lcov-merge.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Unit tests for the shard LCOV union used by `run-coverage.ts`.
+ *
+ * Plain ts-node + node:assert: this package has no test runner of its own, and the
+ * logic under test is pure string/map manipulation with no chain involved.
+ *
+ * Run with: yarn test:lcov-merge
+ */
+
+import * as assert from "assert/strict";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { formatMergeSummary, mergeLcovFiles } from "../../src/coverage/lcov-merge";
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "lcov-merge-test-"));
+
+function writeShard(name: string, content: string): string {
+  const shardPath = path.join(tmpRoot, name, "anvil-lcov.info");
+  fs.mkdirSync(path.dirname(shardPath), { recursive: true });
+  fs.writeFileSync(shardPath, content);
+  return shardPath;
+}
+
+/** Extracts the records of one SF: block as a list of lines. */
+function recordFor(lcov: string, sourceFile: string): string[] {
+  const blocks = lcov.split("end_of_record");
+  const block = blocks.find((b) => b.includes(`SF:${sourceFile}\n`));
+  assert.ok(block, `no record for ${sourceFile} in:\n${lcov}`);
+  return block
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+}
+
+const tests: Array<[string, () => void]> = [];
+function test(name: string, fn: () => void): void {
+  tests.push([name, fn]);
+}
+
+// A line hit by any shard counts as hit, and the highest hit count wins. Shards
+// disagree in both directions here: shard A hit line 11, shard B hit line 21, and
+// both hit line 41 — that last case is what distinguishes max from a sum.
+test("unions line hits across shards, taking the max", () => {
+  const a = writeShard(
+    "p0",
+    [
+      "TN:anvil_interop",
+      "SF:contracts/bridge/A.sol",
+      "DA:11,1",
+      "DA:12,0",
+      "DA:21,0",
+      "DA:41,2",
+      "LF:4",
+      "LH:2",
+      "end_of_record",
+      "",
+    ].join("\n")
+  );
+  const b = writeShard(
+    "p100",
+    [
+      "TN:anvil_interop",
+      "SF:contracts/bridge/A.sol",
+      "DA:11,0",
+      "DA:21,5",
+      "DA:41,3",
+      "LF:3",
+      "LH:2",
+      "end_of_record",
+      "",
+    ].join("\n")
+  );
+
+  const out = path.join(tmpRoot, "merged-lines.info");
+  const { stats } = mergeLcovFiles([a, b], out);
+  const record = recordFor(fs.readFileSync(out, "utf-8"), "contracts/bridge/A.sol");
+
+  assert.ok(record.includes("DA:11,1"), "line 11 keeps shard A's hit");
+  assert.ok(record.includes("DA:21,5"), "line 21 keeps shard B's higher hit count");
+  assert.ok(record.includes("DA:41,3"), "a line both shards hit takes the max, not the sum");
+  assert.ok(record.includes("DA:12,0"), "line 12 stays uncovered");
+  assert.ok(record.includes("LF:4"), "LF counts the union of the line universe");
+  assert.ok(record.includes("LH:3"), "LH counts lines hit by any shard");
+  assert.equal(stats.lines, 4);
+  assert.equal(stats.linesHit, 3);
+});
+
+// Shards resolve different contract sets, so one shard can see executable lines and
+// functions the other never resolved. Those must survive the merge rather than being
+// dropped or double-counted.
+test("keeps lines, files and functions that only one shard resolved", () => {
+  const a = writeShard(
+    "only-a",
+    [
+      "TN:anvil_interop",
+      "SF:contracts/bridge/A.sol",
+      "FN:10,A.foo",
+      "FNDA:1,A.foo",
+      "FNF:1",
+      "FNH:1",
+      "DA:11,1",
+      "LF:1",
+      "LH:1",
+      "end_of_record",
+      "TN:anvil_interop",
+      "SF:contracts/only-in-a/C.sol",
+      "DA:6,1",
+      "LF:1",
+      "LH:1",
+      "end_of_record",
+      "",
+    ].join("\n")
+  );
+  const b = writeShard(
+    "only-b",
+    [
+      "TN:anvil_interop",
+      "SF:contracts/bridge/A.sol",
+      "FN:10,A.foo",
+      "FN:30,A.qux",
+      "FNDA:0,A.foo",
+      "FNDA:0,A.qux",
+      "FNF:2",
+      "FNH:0",
+      "DA:11,0",
+      "DA:31,0",
+      "LF:2",
+      "LH:0",
+      "end_of_record",
+      "",
+    ].join("\n")
+  );
+
+  const out = path.join(tmpRoot, "merged-union.info");
+  const { stats } = mergeLcovFiles([a, b], out);
+  const merged = fs.readFileSync(out, "utf-8");
+  const record = recordFor(merged, "contracts/bridge/A.sol");
+
+  assert.ok(merged.includes("SF:contracts/only-in-a/C.sol"), "a file only one shard saw is kept");
+  assert.ok(record.includes("DA:31,0"), "an executable line only shard B resolved is kept, uncovered");
+  assert.ok(record.includes("FN:30,A.qux"), "a function only shard B resolved is declared");
+  assert.ok(record.includes("FNDA:0,A.qux"), "that function reports no hits");
+  assert.ok(record.includes("FNDA:1,A.foo"), "a function hit by shard A stays hit");
+  assert.ok(record.includes("FNF:2"), "FNF counts the union of declared functions");
+  assert.ok(record.includes("FNH:1"), "FNH counts functions hit by any shard");
+  assert.equal(stats.files, 2);
+  assert.equal(stats.functions, 2);
+  assert.equal(stats.functionsHit, 1);
+});
+
+// Function declarations may arrive without a matching FNDA, and hit counts must not be
+// summed — a function hit 3 times by two shards is still one hit function.
+test("does not sum function hit counts, and defaults undeclared hits to zero", () => {
+  const a = writeShard(
+    "fn-a",
+    ["TN:anvil_interop", "SF:contracts/A.sol", "FN:10,A.foo", "FNDA:3,A.foo", "FN:20,A.bar", "end_of_record", ""].join(
+      "\n"
+    )
+  );
+  const b = writeShard(
+    "fn-b",
+    ["TN:anvil_interop", "SF:contracts/A.sol", "FN:10,A.foo", "FNDA:2,A.foo", "end_of_record", ""].join("\n")
+  );
+
+  const out = path.join(tmpRoot, "merged-fns.info");
+  const { stats } = mergeLcovFiles([a, b], out);
+  const record = recordFor(fs.readFileSync(out, "utf-8"), "contracts/A.sol");
+
+  assert.ok(record.includes("FNDA:3,A.foo"), "max hit count wins, counts are not summed");
+  assert.ok(record.includes("FNDA:0,A.bar"), "a function declared without FNDA reports zero");
+  assert.equal(stats.functionsHit, 1);
+  assert.equal(stats.functions, 2);
+});
+
+// The parent fails the run on a non-zero worker exit and on a missing shard report, so
+// mergeLcovFiles only has to skip absent paths rather than invent data for them.
+test("skips missing shard reports and reports which paths were merged", () => {
+  const a = writeShard("present", ["SF:contracts/A.sol", "DA:1,1", "end_of_record", ""].join("\n"));
+  const missing = path.join(tmpRoot, "absent", "anvil-lcov.info");
+
+  const out = path.join(tmpRoot, "merged-missing.info");
+  const { stats, mergedPaths } = mergeLcovFiles([a, missing], out);
+
+  assert.deepEqual(mergedPaths, [a]);
+  assert.equal(stats.files, 1);
+  assert.equal(stats.linesHit, 1);
+});
+
+test("writes records sorted by source path so output is stable", () => {
+  const a = writeShard(
+    "sort",
+    [
+      "SF:contracts/z/Z.sol",
+      "DA:1,1",
+      "end_of_record",
+      "SF:contracts/a/A.sol",
+      "DA:1,1",
+      "end_of_record",
+      "SF:contracts/m/M.sol",
+      "DA:1,0",
+      "end_of_record",
+      "",
+    ].join("\n")
+  );
+
+  const out = path.join(tmpRoot, "merged-sorted.info");
+  mergeLcovFiles([a], out);
+  const order = fs
+    .readFileSync(out, "utf-8")
+    .split("\n")
+    .filter((l) => l.startsWith("SF:"));
+
+  assert.deepEqual(order, ["SF:contracts/a/A.sol", "SF:contracts/m/M.sol", "SF:contracts/z/Z.sol"]);
+});
+
+test("summary reports shard count and percentages", () => {
+  const summary = formatMergeSummary({ files: 2, lines: 5, linesHit: 3, functions: 4, functionsHit: 3 }, 2);
+
+  assert.match(summary, /Shards: {4}2/);
+  assert.match(summary, /Lines: {5}3\/5 \(60\.00%\)/);
+  assert.match(summary, /Functions: 3\/4 \(75\.00%\)/);
+});
+
+test("empty input produces an empty report rather than throwing", () => {
+  const out = path.join(tmpRoot, "merged-empty.info");
+  const { stats, mergedPaths } = mergeLcovFiles([], out);
+
+  assert.deepEqual(mergedPaths, []);
+  assert.equal(stats.files, 0);
+  assert.equal(fs.readFileSync(out, "utf-8").trim(), "");
+});
+
+let failed = 0;
+for (const [name, fn] of tests) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (error) {
+    failed++;
+    console.error(`  ✗ ${name}`);
+    console.error(`    ${(error as Error).message}`);
+  }
+}
+
+fs.rmSync(tmpRoot, { recursive: true, force: true });
+
+console.log(`\n${tests.length - failed}/${tests.length} lcov-merge tests passed`);
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
# What ❔

Shards the Anvil interop coverage run across parallel workers, so the `coverage` job stops being the critical path of `L1 contracts CI`.

Measured on the latest run of a PR into this base (#2352, run [16856…](https://github.com/matter-labs/era-contracts/actions/workflows/l1-contracts-ci.yaml)), the `coverage` job took **19m** out of a 26m workflow, split as:

| Step                        | Time  |
| --------------------------- | ----- |
| Run Anvil interop coverage  | 789s  |
| Run Foundry coverage        | 203s  |
| Install LCOV                | 64s   |
| checkout / yarn / cache     | ~150s |

and the 789s broke down as 529s of `hardhat test` (10 specs, one serial mocha process, one set of Anvil chains) plus 249s of trace collection.

The plain interop run already solved exactly this problem: `run-hardhat-interop-test.ts` shards the same 10 specs across workers, each owning its own 6 Anvil chains, and the `integration-test` job finishes in **~4m**. This PR gives `run-coverage.ts` the same shape:

- each shard is a child `run-coverage.ts` with its own port offset, run suffix and state dir — the same isolation the plain runner uses, so `cleanup.sh`, `AnvilManager` and `DeploymentRunner` are already offset-aware;
- each shard runs its slice of the specs and collects coverage from its own chains into `coverage/anvil/shards/p<offset>/`;
- the parent unions the per-shard LCOV into `coverage/anvil/anvil-lcov.info` — the exact path `yarn coverage:merge` already reads, so the merge, the rebased report, the step summaries and the artifact upload are unchanged;
- concurrency is capped by `ANVIL_INTEROP_MAX_PARALLEL_WORKERS`, set to `4` in CI, the same value (and for the same reason) as `integration-test`.

New `src/coverage/lcov-merge.ts` does the union. Shards only resolve the contracts their own specs touched, and `getExecutableLines` derives the line universe from those contracts, so shard file/line sets differ; the merge takes the union of the line universe and the **max** hit count per line and per function. Denominators are not load-bearing here — `scripts/merge-coverage.ts` rebases hits onto the Foundry LCOV, so the merged and rebased reports keep Foundry's denominator regardless of what any shard saw.

Escape hatches: `--serial` restores the old single-process run, and `--spec` / `--fresh-deploy` stay single-process as before (a fresh deployment per shard would multiply the deploy cost).

New `src/coverage/lcov-merge.ts` is covered by `yarn test:lcov-merge` (`test/unit/lcov-merge.test.ts`, plain ts-node + `node:assert` — this package has no test runner and the logic needs no chains). CI runs it in the `coverage` job ahead of the pipeline it guards. It asserts max-not-sum on both lines and functions, files/lines/functions that only one shard resolved, `FN` without a matching `FNDA`, missing shard reports, stable record order, and the empty-input case; the assertions were checked against three mutants of the merger (summing `DA` hits, summing `FNDA` hits, overwriting a file record instead of unioning it), each of which fails the suite.

Two smaller items in the same job:

- **Dropped the redundant `yarn test:foundry`** that ran before `yarn coverage:foundry` in the `Run Foundry coverage` step. `forge coverage` runs the suite itself, and the `test-foundry` job already gates on the full, unfiltered `yarn test:foundry` — the pre-run here was a strict subset of it (`--no-match-path .../Executor/*`). Isolated to one line if a reviewer wants it back.
- **`Cleanup Anvil` now sweeps every shard offset.** `cleanup.sh` is scoped to a single port offset, so a cancelled run would otherwise leave the workers' chains behind.

## Why ❔

`coverage` is the longest job in the repo's slowest workflow, and ~70% of it was one serial mocha process. Sharding is the same fix that is already proven on the plain interop run, on the same runner size, with the same isolation primitives.

Expected shape after this change, from the per-spec durations the parallel plain run reports (28s, 28s, 39s, 46s, 51s, 84s, 86s, 89s, 153s, 158s — 238s wall clock at cap 4): the coverage test phase should land near that 238s plus the `--steps-tracing` slowdown, with each shard's trace collection now overlapping other shards' tests instead of running once at the end over the whole suite. That should take the job from ~19m to roughly 10m; CI on this PR is the real measurement.

Coverage numbers themselves should not move — same specs, same chains, same collector, unioned instead of pooled. Worth diffing the `Anvil Interop Coverage Report` summary on this PR against #2352's (`262/6006` rebased, `+12` lines and `+2` functions over Foundry) to confirm.

Not included, but the next things worth doing to this workflow:

- every artifact cache key is `artifacts-l1-${{ github.sha }}` with `fail-on-cache-miss: true` and no `restore-keys`, so `cache-forge` is never restored from a previous commit and `build` recompiles all 881 files every push (402s);
- `check-zkstack-out` (532s) repeats the l1 `forge build` that `build` already ran (420s of it), and `build:foundry` already ends in `copy-to-zkstack-out` — the check collapses to a `git status --porcelain -- zkstack-out` inside `build`;
- `check-verifier-generator-l1` spends 324s on a cold `cargo run --release` with no `Swatinem/rust-cache`;
- the shard queue is FIFO by spec name, so the two longest specs (`07`, `09`) start last; a longest-first order would shave more.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)