### PR TITLE
chore(genesis): v0.32.0 genesis on the atomic-imt-interop tip (pin for integration-tests#24)

### DIFF
--- a/configs/genesis/era/latest.json
+++ b/configs/genesis/era/latest.json
@@ -1,7 +1,7 @@
 {
   "protocol_semantic_version": {
     "major": 0,
-    "minor": 31,
+    "minor": 32,
     "patch": 0
   },
   "genesis_root": "0xedaadbbfe3202aabc4de8dfbf1728ea15a2f2d04fb994b9008f01dfaf5a9efa9",

--- a/configs/genesis/era/latest.toml
+++ b/configs/genesis/era/latest.toml
@@ -1,4 +1,4 @@
-protocol_semantic_version = 133143986176
+protocol_semantic_version = 137438953472
 genesis_root = "0xedaadbbfe3202aabc4de8dfbf1728ea15a2f2d04fb994b9008f01dfaf5a9efa9"
 genesis_rollup_leaf_index = 102
 genesis_batch_commitment = "0xb9e048e5ef7f339f7ce5da6fb7ef415bdca94a80371845db337a23e37269a3ae"

--- a/configs/genesis/zksync-os/latest.json
+++ b/configs/genesis/zksync-os/latest.json
@@ -265,7 +265,7 @@
   "genesis_root": "0xb88e3853c7ea652cba0fd9c61fcec65c549d6ac4f67ba4f3c009448a4bd3a44e",
   "protocol_semantic_version": {
     "major": 0,
-    "minor": 31,
+    "minor": 32,
     "patch": 0
   },
   "execution_version": 5,

--- a/l1-contracts/test/foundry/l1/integration/DeploymentTest.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/DeploymentTest.t.sol
@@ -15,6 +15,8 @@ import {IZKChain} from "contracts/state-transition/chain-interfaces/IZKChain.sol
 
 import {AddressesAlreadyGenerated} from "test/foundry/L1TestsErrors.sol";
 import {DataEncoding} from "contracts/common/libraries/DataEncoding.sol";
+import {ChainCreationParamsLib} from "../../../../deploy-scripts/ctm/ChainCreationParamsLib.sol";
+import {Utils} from "../../../../deploy-scripts/utils/Utils.sol";
 
 contract DeploymentTests is L1ContractDeployer, ZKChainDeployer, TokenDeployer, L2TxMocker {
     uint256 constant TEST_USERS_COUNT = 10;
@@ -73,8 +75,14 @@ contract DeploymentTests is L1ContractDeployer, ZKChainDeployer, TokenDeployer, 
         assertEq(chainIds.length, 2);
         assertEq(chainIds[0], chainId);
 
+        // Derived from the same genesis config the CTM was deployed from, rather than hardcoded:
+        // the packed version moves on every protocol bump, and a literal here silently rots.
+        uint256 expectedProtocolVersion = ChainCreationParamsLib
+            .getChainCreationParams(Utils.genesisConfigPath(false), false)
+            .latestProtocolVersion;
+
         uint256 protocolVersion = addresses.chainTypeManager.getProtocolVersion(chainId);
-        assertEq(protocolVersion, 133143986176);
+        assertEq(protocolVersion, expectedProtocolVersion);
     }
 
     function test_registerAlreadyDeployedZKChain() public {

--- a/l1-contracts/test/foundry/l1/integration/UpgradeTestv31_Local.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/UpgradeTestv31_Local.t.sol
@@ -142,8 +142,9 @@ contract UpgradeIntegrationTest_Local is
         return new CTMUpgrade_v31_Test();
     }
 
-    /// @notice Bump the CTM's protocol version from the upgrade input TOML so the local
-    ///         genesis-at-v31 fixture exercises a v31 → v32 upgrade.
+    /// @notice Bump the CTM's protocol version from the upgrade input TOML so the local fixture
+    ///         exercises an upgrade to one minor above the genesis version (currently v32 → v33).
+    ///         See `foundry-upgrade.toml`.
     /// @dev    Replaces the former `overrideProtocolVersionForLocalTesting` hook on the
     ///         deleted `DefaultEcosystemUpgrade` orchestrator.
     function afterInitHook() internal override {

--- a/l1-contracts/upgrade-envs/v0.31.0-interopB/foundry-upgrade.toml
+++ b/l1-contracts/upgrade-envs/v0.31.0-interopB/foundry-upgrade.toml
@@ -1,9 +1,13 @@
-# Foundry-specific upgrade configuration for local testing
-# Since genesis config deploys chains at v31.0.0, we need to upgrade to v32.0.0
+# Foundry-specific upgrade configuration for local testing.
+#
+# The harness deploys at whatever the genesis config declares and then upgrades to
+# `new_protocol_version`, and `DefaultCTMUpgrade.initUpgrade` requires
+# `ctmProtocolVersion != getNewProtocolVersion()` — so this has to stay one minor ahead of genesis.
+# Genesis is at v32.0.0, so the fixture exercises a v32 -> v33 upgrade.
 
-old_protocol_version = 0x1f00000000  # v31.0.0 (current genesis)
+old_protocol_version = 0x2000000000  # v32.0.0 (current genesis)
 v28_protocol_version = 0x1c00000000  # v28.0.0 (for reference)
 
 [contracts]
-new_protocol_version = 0x2000000000  # v32.0.0 (target for upgrade)
-latest_protocol_version = 0x2000000000  # v32.0.0
+new_protocol_version = 0x2100000000  # v33.0.0 (target for upgrade)
+latest_protocol_version = 0x2100000000  # v33.0.0


### PR DESCRIPTION
> **Draft on purpose — not for merging.** This branch exists to be pinned by a downstream `Cargo.toml`, and the same change is being landed properly on the release line by #2379. See "Why this is a draft" below.

## What

`atomic-imt-interop`'s merged tip (`76f40b530`) plus one commit bumping the genesis protocol version from `0.31.0` to `0.32.0`, in both flavours:

| file | before | after |
| --- | --- | --- |
| `configs/genesis/era/latest.json` / `.toml` | 0.31.0 | **0.32.0** |
| `configs/genesis/zksync-os/latest.json` | 0.31.0 | **0.32.0** |

## Why the branch exists

[zksync-os-integration-tests#24](https://github.com/matter-labs/zksync-os-integration-tests/pull/24) drives an L1-settled atomic swap against this contracts revision. Two constraints pin it here:

- **It cannot use `atomic-imt-interop-release`.** The release line moved the atomic leg proof onto the height-3 `ChainBatchRootTree` — IMT begin/end roots as chain-batch-root leaves 2/3 (#2335). zksync-os-server still commits `keccak256(logsRoot ++ multichainRoot)` and exposes no proof for those leaves, so `ImtProof` cannot be constructed against the release contracts at all.
- **It cannot use `76f40b530` unmodified.** The merged form of [zksync-os-server#1413](https://github.com/matter-labs/zksync-os-server/pull/1413) gates L1-backed interop-root imports and `MessageRoot` proofs on `MIN_VERSION_WITH_L1_INTEROP = 0.32.0` — a gate added during review. Every era-contracts line still declared a v0.31.x genesis, so the swap test's first proof fetch was refused with:

```
MessageRoot proofs require protocol version 0.32.0 or newer; batch N uses 0.31.0
```

This branch is the smallest thing that satisfies both: the revision whose proof shapes the server can serve, at a protocol version the server accepts.

## No regenesis needed

`genesis_root`, `genesis_batch_commitment` and `genesis_rollup_leaf_index` are untouched — none of them depend on the protocol version. The server maps both minor 31 and 32 to `ExecutionVersion::V6`, so the VM does not move either. Era and ZKsync OS are bumped together deliberately: the two flavours drifting apart is what tripped `GatewayVotePreparation`'s "CTM protocol version mismatch" require the last time it happened.

## Why this is a draft

**#2379 is the change to review and merge** — it puts the same bump on `atomic-imt-reduced` (#2311), the atomic-interop release base, where it flows to the whole line. This PR is open only so the pinned branch is visible rather than an orphan, and so a `Cargo.toml` `rev` does not point at something nobody can account for.

Close this and delete the branch once #2379 has landed and #24 has repointed at the release line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
