### PR TITLE
[N06][Note] Read legacy shared bridge address once in _updateAllContracts

### DIFF
--- a/l1-contracts/contracts/l2-upgrades/L2GenesisForceDeploymentsHelper.sol
+++ b/l1-contracts/contracts/l2-upgrades/L2GenesisForceDeploymentsHelper.sol
@@ -345,12 +345,14 @@ library L2GenesisForceDeploymentsHelper {
             _fixedForceDeploymentsData.maxNumberOfZKChains
         );
 
+        address legacySharedBridge = _getLegacySharedBridge();
+
         // solhint-disable-next-line func-named-parameters
         L2AssetRouter(L2_ASSET_ROUTER_ADDR).updateL2(
             _fixedForceDeploymentsData.l1ChainId,
             _fixedForceDeploymentsData.eraChainId,
             IL1AssetRouter(_fixedForceDeploymentsData.l1AssetRouter),
-            IL2SharedBridgeLegacy(_getLegacySharedBridge()),
+            IL2SharedBridgeLegacy(legacySharedBridge),
             _additionalForceDeploymentsData.baseTokenBridgingData.assetId,
             _fixedForceDeploymentsData.aliasedL1Governance
         );
@@ -362,7 +364,7 @@ library L2GenesisForceDeploymentsHelper {
             // Legacy Era chains exposed this via an immutable. After the v31 code replacement,
             // reading it back from storage returns zero, so the L1-provided value is authoritative.
             _fixedForceDeploymentsData.l2TokenProxyBytecodeHash,
-            _getLegacySharedBridge(),
+            legacySharedBridge,
             _wrappedBaseTokenAddress,
             _additionalForceDeploymentsData.baseTokenBridgingData,
             _additionalForceDeploymentsData.baseTokenMetadata


### PR DESCRIPTION
## OpenZeppelin audit finding N06 (Note): Redundant Read of the Legacy Shared Bridge Address

In `L2GenesisForceDeploymentsHelper._updateAllContracts`, the legacy shared bridge address was obtained through two separate `_getLegacySharedBridge()` calls — one passed to `L2AssetRouter.updateL2` and one passed to `L2NativeTokenVault.updateL2`. Both read `L2_LEGACY_SHARED_BRIDGE` from the L2AssetRouter, and the second read happens after `L2AssetRouter.updateL2` has already rewritten that variable. The two reads only agree because `updateL2` writes back verbatim the address it was given — the code silently relied on this round trip being an identity.

## Fix

Read the address once into a local variable (`legacySharedBridge`) before the two `updateL2` calls and pass it to both, so the L2AssetRouter and the L2NativeTokenVault are guaranteed to be configured with the same address by construction. The per-call-site typing is preserved: the L2AssetRouter call still wraps it in `IL2SharedBridgeLegacy`, the L2NativeTokenVault call still takes the raw `address`.

## Behavior preservation

`L2AssetRouter.updateL2` assigns `L2_LEGACY_SHARED_BRIDGE = _legacySharedBridge;` with no transformation, so the removed second read could only ever return the same value as the first. No functional change.

## Bytecode note

This does change the compiled bytecode of `L2GenesisForceDeploymentsHelper` (one external call replaced by a stack read), so `AllContractsHashes.json` / zkstack-out artifacts need to be regenerated by CI — not regenerated locally per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)