### PR TITLE
ci(regenerate-chain-states): remove RELEASE_TOKEN

### DIFF
--- a/.github/workflows/regenerate-chain-states.yaml
+++ b/.github/workflows/regenerate-chain-states.yaml
@@ -27,7 +27,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.MATTERLABS_BOTS_APP_ID }}
+          app-id: ${{ secrets.MATTERLABS_BOTS_APP_ID }}
           private-key: ${{ secrets.MATTERLABS_BOTS_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: era-contracts

--- a/.github/workflows/regenerate-chain-states.yaml
+++ b/.github/workflows/regenerate-chain-states.yaml
@@ -14,7 +14,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: read
 
 jobs:
@@ -23,12 +23,21 @@ jobs:
     timeout-minutes: 45
 
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.MATTERLABS_BOTS_APP_ID }}
+          private-key: ${{ secrets.MATTERLABS_BOTS_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: era-contracts
+
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Get PR branch info
         id: pr

--- a/.github/workflows/regenerate-chain-states.yaml
+++ b/.github/workflows/regenerate-chain-states.yaml
@@ -14,7 +14,7 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: read
 
 jobs:

--- a/.github/workflows/update-hashes-on-demand.yaml
+++ b/.github/workflows/update-hashes-on-demand.yaml
@@ -26,7 +26,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.MATTERLABS_BOTS_APP_ID }}
+          app-id: ${{ secrets.MATTERLABS_BOTS_APP_ID }}
           private-key: ${{ secrets.MATTERLABS_BOTS_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: era-contracts

--- a/.github/workflows/update-hashes-on-demand.yaml
+++ b/.github/workflows/update-hashes-on-demand.yaml
@@ -22,10 +22,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.MATTERLABS_BOTS_APP_ID }}
+          private-key: ${{ secrets.MATTERLABS_BOTS_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: era-contracts
+
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # we need full history to fetch PR branch
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Get PR branch info
         id: pr

--- a/.github/workflows/update-hashes-on-demand.yaml
+++ b/.github/workflows/update-hashes-on-demand.yaml
@@ -22,20 +22,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Generate app token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.MATTERLABS_BOTS_APP_ID }}
-          private-key: ${{ secrets.MATTERLABS_BOTS_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: era-contracts
-
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # we need full history to fetch PR branch
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Get PR branch info
         id: pr


### PR DESCRIPTION
# What ❔

`regenerate-chain-states.yaml` now pushes using a GitHub App installation token scoped to this repo, replacing `RELEASE_TOKEN`, and declares `contents: write`.

## Why ❔

- Retires a classic PAT with `expires: never` and org-wide `repo` scope from this repo's CI.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated. <!-- n/a: CI config only -->
- [ ] Documentation comments have been added / updated. <!-- n/a -->
