### PR TITLE
test(atomic-interop): close a surviving mutant, restore the constant pins, drop the state override

### DIFF
--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerAppend.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerAppend.t.sol
@@ -132,6 +132,14 @@ contract AtomicFlowManagerAppendTest is Test {
         assertEq(tree.leafAt(1).value, _commitValue(flowId, localLeg), "inserted leaf must hold the commit value");
     }
 
+    /// @notice The v1 preimage version literal is pinned. `ATOMIC_FLOW_PREIMAGE_VERSION` is part of
+    /// the flow-id preimage encoding and is mirrored off-chain by hand in
+    /// `test/anvil-interop/src/helpers/imt-engine-lib.ts`, so a bump must be a deliberate, visible
+    /// change here rather than a silent constant edit caught only by the anvil suite.
+    function test_atomicFlowPreimageVersion_isPinnedToV1() public {
+        assertEq(ATOMIC_FLOW_PREIMAGE_VERSION, bytes1(0x01), "v1 preimage version literal must be pinned");
+    }
+
     /// @notice `append` rejects a preimage whose `version` the manager does not support (0x02 here),
     /// so it can never commit a leg. See {ATOMIC_FLOW_PREIMAGE_VERSION}.
     function test_append_RevertWhen_FlowPreimageVersionMismatch() public {

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerAppend.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerAppend.t.sol
@@ -116,6 +116,67 @@ contract AtomicFlowManagerAppendTest is Test {
         manager.append(_bundleHash, 0, _preimage);
     }
 
+    function _appendAsInteropCenterWithLowNullifier(
+        bytes32 _bundleHash,
+        uint256 _lowNullifierIndex,
+        AtomicFlowPreimage memory _preimage
+    ) internal {
+        vm.prank(L2_INTEROP_CENTER_ADDR);
+        manager.append(_bundleHash, _lowNullifierIndex, _preimage);
+    }
+
+    /// @notice Two legs of the SAME flow, both sourced on this chain, can be committed one after the
+    /// other, and the indexed tree links their commit values in value order. Every other case here
+    /// commits a single leg, so this is the only coverage of a second insert (leaf 2) and of the
+    /// low-leaf link being rewritten by it.
+    /// @dev Deliberately NOT a test of `_lowNullifierIndex` forwarding: that argument is only a hint —
+    /// {IndexedMerkleTree.insert} walks the linked list forward from it — so the head index 0 is always
+    /// accepted and no behavioural test can distinguish forwarding it from hard-coding 0. The index is
+    /// passed here in its correct form anyway, as a caller would.
+    function test_append_CommitsSecondLegAndLinksBothCommitValues() public {
+        bytes32 legA = keccak256("nullifier leg A");
+        bytes32 legB = keccak256("nullifier leg B");
+
+        // Both legs are local so both can be committed here; hashes must be strictly ascending.
+        AtomicFlowPreimage memory preimage;
+        preimage.version = ATOMIC_FLOW_PREIMAGE_VERSION;
+        preimage.deadline = DEADLINE;
+        preimage.settlementLayerChainId = L1_CHAIN_ID;
+        preimage.legBundleHashes = new bytes32[](2);
+        preimage.legSourceChainIds = new uint256[](2);
+        (preimage.legBundleHashes[0], preimage.legBundleHashes[1]) = legA < legB ? (legA, legB) : (legB, legA);
+        preimage.legSourceChainIds[0] = block.chainid;
+        preimage.legSourceChainIds[1] = block.chainid;
+        bytes32 flowId = _flowId(preimage);
+
+        // Insert in commit-value order: the smaller value brackets at the head, the larger at leaf 1.
+        uint256 valueFirst = _commitValue(flowId, preimage.legBundleHashes[0]);
+        uint256 valueSecond = _commitValue(flowId, preimage.legBundleHashes[1]);
+        (bytes32 firstLeg, bytes32 secondLeg) = valueFirst < valueSecond
+            ? (preimage.legBundleHashes[0], preimage.legBundleHashes[1])
+            : (preimage.legBundleHashes[1], preimage.legBundleHashes[0]);
+        (uint256 smallerValue, uint256 largerValue) = valueFirst < valueSecond
+            ? (valueFirst, valueSecond)
+            : (valueSecond, valueFirst);
+
+        _appendAsInteropCenterWithLowNullifier(firstLeg, 0, preimage);
+        // Leaf 1 now holds the smaller value and is the larger value's predecessor, so that is the index
+        // a caller would supply as the hint.
+        _appendAsInteropCenterWithLowNullifier(secondLeg, 1, preimage);
+
+        assertEq(tree.leafCount(), 3, "head leaf plus both commit values");
+        assertEq(tree.leafAt(1).value, smallerValue, "first insert holds the smaller commit value");
+        assertEq(tree.leafAt(2).value, largerValue, "second insert holds the larger commit value");
+        // The second insert must splice itself in after the first: leaf 1 now points at leaf 2.
+        assertEq(tree.leafAt(1).nextIndex, 2, "the smaller leaf must link to the larger one");
+        assertEq(tree.leafAt(1).nextValue, largerValue, "the smaller leaf must carry the larger value");
+        assertEq(
+            uint256(manager.legState(flowId, secondLeg)),
+            uint256(LegState.Committed),
+            "the second leg must be Committed"
+        );
+    }
+
     /// @notice Happy path: the leg flips `Unset -> Committed` under the recomputed `flowId` and its
     /// commit value lands in the commitment tree (leaf 1, after the genesis-seeded head).
     function test_append_CommitsLegAndInsertsCommitValue() public {

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerFinalize.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerFinalize.t.sol
@@ -143,6 +143,22 @@ contract AtomicFlowManagerFinalizeTest is AtomicInteropProofBuilder {
         _requireFinalizedAsHandler(legFirst, finality);
     }
 
+    /// @notice ...and SURPLUS proofs are rejected too, not silently ignored. The per-leg loop only
+    /// reads `proofs[0..n)`, so without this case the count check can be weakened from `!=` to `<`
+    /// and every other finalize test still passes — the exact-shape requirement would be unpinned.
+    function test_RevertWhen_ProofCountTooMany() public {
+        AtomicFinalityProof memory finality = _validFinality();
+        ImtProof[] memory threeProofs = new ImtProof[](3);
+        threeProofs[0] = finality.proofs[0];
+        threeProofs[1] = finality.proofs[1];
+        // A third proof for a leg that does not exist: valid in isolation, surplus for this flow.
+        threeProofs[2] = finality.proofs[1];
+        finality.proofs = threeProofs;
+
+        vm.expectRevert(abi.encodeWithSelector(ManagerProofCountMismatch.selector, 2, 3));
+        _requireFinalizedAsHandler(legFirst, finality);
+    }
+
     /// @notice Each proof must be bound to its leg's DECLARED source chain (positional match).
     /// Defense-in-depth on the finalize side, but load-bearing for the symmetric refund path — see
     /// the contract's docs. Swapped proofs (valid on the wrong legs) must not pass.

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerInit.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerInit.t.sol
@@ -12,6 +12,7 @@ import {
 } from "contracts/atomic-interop/IAtomicInterop.sol";
 import {
     ManagerAlreadyInitialized,
+    ManagerL1ChainIdZero,
     ManagerMissingLegIndexOutOfRange,
     ManagerSettlementLayerNotL1
 } from "contracts/atomic-interop/AtomicInteropErrors.sol";
@@ -51,6 +52,19 @@ contract AtomicFlowManagerInitTest is Test {
     function test_RevertWhen_initL2NotUpgrader() public {
         vm.expectRevert(abi.encodeWithSelector(Unauthorized.selector, address(this)));
         manager.initL2(L1_CHAIN_ID);
+    }
+
+    /// @notice Zero is the "not initialized" sentinel, so `initL2(0)` must be rejected — otherwise it
+    /// would appear to succeed while leaving the manager re-initializable by anyone the upgrader later
+    /// delegates to. Uses a FRESH manager, since `setUp` already initialized the shared one.
+    function test_RevertWhen_initL2ZeroChainId() public {
+        AtomicFlowManager fresh = new AtomicFlowManager();
+
+        vm.prank(L2_COMPLEX_UPGRADER_ADDR);
+        vm.expectRevert(ManagerL1ChainIdZero.selector);
+        fresh.initL2(0);
+
+        assertEq(fresh.L1_CHAIN_ID(), 0, "a rejected init must leave the sentinel untouched");
     }
 
     function test_RevertWhen_initL2Twice() public {

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerRecover.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerRecover.t.sol
@@ -4,12 +4,8 @@ pragma solidity 0.8.28;
 import {Test} from "forge-std/Test.sol";
 
 import {AtomicFlowManager} from "contracts/atomic-interop/AtomicFlowManager.sol";
-import {IAtomicFlowManager} from "contracts/atomic-interop/IAtomicFlowManager.sol";
-import {ManagerLegNotRevertable} from "contracts/atomic-interop/AtomicInteropErrors.sol";
-import {LegState} from "contracts/atomic-interop/IAtomicInterop.sol";
 import {IAtomicRecoverable} from "contracts/atomic-interop/IAtomicRecoverable.sol";
 import {IAssetRouterShared} from "contracts/bridge/asset-router/IAssetRouterShared.sol";
-import {InteropDataEncoding} from "contracts/interop/InteropDataEncoding.sol";
 import {L2_ASSET_ROUTER_ADDR, L2_COMPLEX_UPGRADER_ADDR} from "contracts/common/l2-helpers/L2ContractAddresses.sol";
 import {RecoverToL1NotSupported} from "contracts/common/L1ContractErrors.sol";
 import {
@@ -20,15 +16,13 @@ import {
     InteropCall
 } from "contracts/common/Messaging.sol";
 
-/// @dev Exposes {AtomicFlowManager._recoverBundle} for direct dispatch tests and lets a leg be forced
-/// `Revertable` so `claimRefund` can be driven directly.
+/// @dev Exposes {AtomicFlowManager._recoverBundle} so its per-call refund dispatch can be unit tested
+/// in isolation. The surrounding Committed -> Revertable -> Reverted state machine is driven through
+/// the production `append` / `authorizeRefund` / `claimRefund` path in {AtomicFlowManagerRefundTest};
+/// no test forces leg state directly (see AGENTS.md on storage overrides).
 contract AtomicFlowManagerRecoverHarness is AtomicFlowManager {
     function exposedRecoverBundle(InteropBundle memory _bundle) external {
         _recoverBundle(_bundle);
-    }
-
-    function forceRevertable(bytes32 _flowId, bytes32 _bundleHash) external {
-        _state[_flowId][_bundleHash] = LegState.Revertable;
     }
 }
 
@@ -87,7 +81,6 @@ contract AtomicFlowManagerRecoverTest is Test {
 
     bytes32 internal constant SOURCE_BASE_TOKEN_ASSET_ID = keccak256("source-base-token");
     bytes32 internal constant OTHER_BASE_TOKEN_ASSET_ID = keccak256("other-base-token");
-    bytes32 internal constant FLOW_ID = keccak256("recover-flow");
 
     uint256 internal constant DEST_CHAIN_ID = 271;
     address internal constant DEPOSITOR = address(0xD3903170);
@@ -270,96 +263,5 @@ contract AtomicFlowManagerRecoverTest is Test {
 
         assertEq(router.recoverAttempts(), 2, "both router-backed calls are attempted");
         assertEq(router.recoverSuccesses(), 1, "only the second call actually recovers");
-    }
-
-    /// @notice If EVERY router-backed recovery returns `false`, nothing is recovered — and the refund
-    /// must STILL go through: a bundle with no recoverable funds has nothing to return, but flipping the
-    /// leg to `Reverted` is meaningful on its own and must not be blocked (see
-    /// {AtomicFlowManager._recoverBundle}). All calls are attempted, no payout occurs, `FlowRefunded` is
-    /// emitted, and the leg lands terminal `Reverted` (a further claim is rejected).
-    function test_claimRefund_multiCall_allRouterFalseSucceedsWithoutPayout() public {
-        MockRecoveryRouter router = _deployMockRouter();
-        router.scriptReturnsFalse(hex"1111");
-        router.scriptReturnsFalse(hex"2222");
-
-        InteropCall[] memory calls = new InteropCall[](2);
-        calls[0] = _call(L2_ASSET_ROUTER_ADDR, 0, hex"1111"); // recoverAtomicCall -> false
-        calls[1] = _call(L2_ASSET_ROUTER_ADDR, 0, hex"2222"); // recoverAtomicCall -> false
-
-        InteropBundle memory bundle = _multiCallBundle(calls);
-        bytes memory bundleBytes = abi.encode(bundle);
-        bytes32 bundleHash = InteropDataEncoding.encodeInteropBundleHash(bundleBytes);
-        manager.forceRevertable(FLOW_ID, bundleHash);
-
-        vm.expectEmit(true, true, false, true, address(manager));
-        emit IAtomicFlowManager.FlowRefunded(FLOW_ID, bundleHash);
-        manager.claimRefund(FLOW_ID, bundleBytes);
-
-        assertEq(router.recoverAttempts(), 2, "every router-backed call is still attempted");
-        assertEq(router.recoverSuccesses(), 0, "nothing actually recovers");
-        assertEq(router.baseTokenRecoveries(), 0, "no base-token payout occurred");
-        assertEq(
-            uint256(manager.legState(FLOW_ID, bundleHash)),
-            uint256(LegState.Reverted),
-            "the leg is terminally Reverted even though nothing was recoverable"
-        );
-
-        // Terminal: the no-op refund cannot be claimed again.
-        vm.expectRevert(
-            abi.encodeWithSelector(ManagerLegNotRevertable.selector, FLOW_ID, bundleHash, LegState.Reverted)
-        );
-        manager.claimRefund(FLOW_ID, bundleBytes);
-    }
-
-    /// @notice A later call reverting during recovery aborts and rolls back the whole claim. Both calls
-    /// are reached before the abort; after the failing script is cleared, both are retried and the claim
-    /// completes, proving the leg remained `Revertable` and no partial recovery survived.
-    function test_claimRefund_multiCall_laterRevertAbortsClaim() public {
-        MockRecoveryRouter router = _deployMockRouter();
-        router.scriptReverts(hex"baad");
-
-        InteropCall[] memory calls = new InteropCall[](2);
-        calls[0] = _call(L2_ASSET_ROUTER_ADDR, 0, hex"600d"); // would recover successfully...
-        calls[1] = _call(L2_ASSET_ROUTER_ADDR, 0, hex"baad"); // ...but this one reverts
-
-        InteropBundle memory bundle = _multiCallBundle(calls);
-        bytes memory bundleBytes = abi.encode(bundle);
-        bytes32 bundleHash = InteropDataEncoding.encodeInteropBundleHash(bundleBytes);
-        manager.forceRevertable(FLOW_ID, bundleHash);
-
-        // Both recovery calls must be reached once in the failed claim and once in the successful retry.
-        vm.expectCall(
-            L2_ASSET_ROUTER_ADDR,
-            abi.encodeWithSelector(IAtomicRecoverable.recoverAtomicCall.selector, DEST_CHAIN_ID, hex"600d"),
-            2
-        );
-        vm.expectCall(
-            L2_ASSET_ROUTER_ADDR,
-            abi.encodeWithSelector(IAtomicRecoverable.recoverAtomicCall.selector, DEST_CHAIN_ID, hex"baad"),
-            2
-        );
-        vm.expectRevert("recovery boom");
-        manager.claimRefund(FLOW_ID, bundleBytes);
-
-        assertEq(router.recoverAttempts(), 0, "reverted recovery attempts must roll back");
-        assertEq(router.recoverSuccesses(), 0, "the earlier successful recovery must roll back");
-        assertEq(
-            uint256(manager.legState(FLOW_ID, bundleHash)),
-            uint256(LegState.Revertable),
-            "failed claim must leave the refund retryable"
-        );
-
-        router.scriptSucceeds(hex"baad");
-        vm.expectEmit(true, true, false, true, address(manager));
-        emit IAtomicFlowManager.FlowRefunded(FLOW_ID, bundleHash);
-        manager.claimRefund(FLOW_ID, bundleBytes);
-
-        assertEq(router.recoverAttempts(), 2, "retry must process both router-backed calls");
-        assertEq(router.recoverSuccesses(), 2, "both recoveries must succeed on retry");
-        assertEq(
-            uint256(manager.legState(FLOW_ID, bundleHash)),
-            uint256(LegState.Reverted),
-            "successful retry must finish the refund"
-        );
     }
 }

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerRefund.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerRefund.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.28;
 import {Vm} from "forge-std/Vm.sol";
 
 import {AtomicInteropProofBuilder} from "./AtomicInteropProofBuilder.sol";
+import {MockRecoveryRouter} from "./AtomicFlowManagerRecover.t.sol";
 
 import {AtomicFlowManager} from "contracts/atomic-interop/AtomicFlowManager.sol";
 import {IAtomicFlowManager} from "contracts/atomic-interop/IAtomicFlowManager.sol";
@@ -55,6 +56,10 @@ contract AtomicFlowManagerRefundTest is AtomicInteropProofBuilder {
     /// @dev The missing leg's remote source chain — aggregatable in the settlement-layer MessageRoot
     /// (unlike the local chain), so its absence gets a real, unmocked authentication.
     uint256 internal constant MISSING_LEG_CHAIN = 271;
+    /// @dev Destination chain of the recovery bundles below: any chain that is not the settlement
+    /// layer, since `_recoverBundle` rejects L1-destined bundles outright.
+    uint256 internal constant RECOVERY_DEST_CHAIN_ID = 777;
+    address internal constant RECOVERY_CALL_TARGET = address(0xCA11);
 
     AtomicFlowManager internal manager;
 
@@ -409,5 +414,180 @@ contract AtomicFlowManagerRefundTest is AtomicInteropProofBuilder {
             abi.encodeWithSelector(ManagerLegNotRevertable.selector, unknownFlowId, committedLeg, LegState.Unset)
         );
         manager.claimRefund(unknownFlowId, committedLegBundleBytes);
+    }
+
+    // ============ multi-call recovery through the real Revertable path ============
+
+    /// @dev Drives `_bundle`'s leg to `Revertable` entirely through production entry points: a fresh
+    /// two-leg flow, a real `append` of this bundle's leg (pranked canonical InteropCenter), then a real
+    /// `authorizeRefund` against an end-to-end absence proof for the never-committed co-leg. No leg state
+    /// is ever written directly (see AGENTS.md on storage overrides).
+    /// @dev NOT `view`: aggregation + import mutate settlement-layer state. Consumes
+    /// `MISSING_LEG_CHAIN`'s single post-genesis batch, so a test calling this must not also call
+    /// {_validAbsence}. `append` must run before the post-deadline root is imported, hence this order.
+    function _revertableLegFromBundle(
+        InteropBundle memory _bundle
+    ) internal returns (bytes32 recoveryFlowId, bytes32 bundleHash, bytes memory bundleBytes) {
+        bundleBytes = abi.encode(_bundle);
+        bundleHash = InteropDataEncoding.encodeInteropBundleHash(bundleBytes);
+        bytes32 coLeg = keccak256("recovery co-leg");
+
+        AtomicFlowPreimage memory recoveryPreimage;
+        recoveryPreimage.version = ATOMIC_FLOW_PREIMAGE_VERSION;
+        recoveryPreimage.deadline = DEADLINE;
+        recoveryPreimage.settlementLayerChainId = SETTLEMENT_LAYER_CHAIN_ID;
+        recoveryPreimage.legBundleHashes = new bytes32[](2);
+        recoveryPreimage.legSourceChainIds = new uint256[](2);
+        (uint256 localIdx, uint256 coIdx) = bundleHash < coLeg ? (0, 1) : (1, 0);
+        recoveryPreimage.legBundleHashes[localIdx] = bundleHash;
+        recoveryPreimage.legBundleHashes[coIdx] = coLeg;
+        recoveryPreimage.legSourceChainIds[localIdx] = block.chainid;
+        recoveryPreimage.legSourceChainIds[coIdx] = MISSING_LEG_CHAIN;
+        recoveryFlowId = keccak256(abi.encode(recoveryPreimage));
+
+        vm.prank(L2_INTEROP_CENTER_ADDR);
+        manager.append(bundleHash, 0, recoveryPreimage);
+
+        ImtProof memory absence = _realTimeoutBeginProof(
+            MISSING_LEG_CHAIN,
+            _commitValue(recoveryFlowId, coLeg),
+            uint256(DEADLINE) + 1
+        );
+        manager.authorizeRefund(AtomicFlow({flowId: recoveryFlowId, preimage: recoveryPreimage}), coIdx, absence);
+        assertEq(
+            uint256(manager.legState(recoveryFlowId, bundleHash)),
+            uint256(LegState.Revertable),
+            "fixture: the leg must be Revertable through the real authorize path"
+        );
+    }
+
+    /// @dev The stateful asset-router stand-in at its canonical address (shared with
+    /// {AtomicFlowManagerRecoverTest}): unlike `vm.mockCall`, its counters are real storage, so they
+    /// roll back with a reverting `claimRefund` — which is what the abort test below proves.
+    function _deployMockRecoveryRouter() internal returns (MockRecoveryRouter router) {
+        deployCodeTo("AtomicFlowManagerRecover.t.sol:MockRecoveryRouter", L2_ASSET_ROUTER_ADDR);
+        router = MockRecoveryRouter(L2_ASSET_ROUTER_ADDR);
+    }
+
+    function _recoveryCall(
+        address _from,
+        uint256 _value,
+        bytes memory _data
+    ) internal pure returns (InteropCall memory) {
+        return
+            InteropCall({
+                version: INTEROP_CALL_VERSION,
+                shadowAccount: false,
+                to: RECOVERY_CALL_TARGET,
+                from: _from,
+                value: _value,
+                data: _data
+            });
+    }
+
+    function _recoveryBundle(InteropCall[] memory _calls) internal view returns (InteropBundle memory bundle) {
+        bundle = InteropBundle({
+            version: INTEROP_BUNDLE_VERSION,
+            sourceChainId: block.chainid,
+            destinationChainId: RECOVERY_DEST_CHAIN_ID,
+            destinationBaseTokenAssetId: keccak256("recovery destination base token"),
+            interopBundleSalt: keccak256("multi-call recovery salt"),
+            calls: _calls,
+            bundleAttributes: BundleAttributes({
+                executionAddress: bytes(""),
+                unbundlerAddress: bytes(""),
+                useFixedFee: false,
+                salt: bytes32(0)
+            })
+        });
+    }
+
+    /// @notice If EVERY router-backed recovery returns `false`, nothing is recovered — and the refund
+    /// must STILL go through: a bundle with no recoverable funds has nothing to return, but flipping the
+    /// leg to `Reverted` is meaningful on its own and must not be blocked (see
+    /// {AtomicFlowManager._recoverBundle}). All calls are attempted, no payout occurs, `FlowRefunded` is
+    /// emitted, and the leg lands terminal `Reverted` (a further claim is rejected).
+    function test_claimRefund_multiCall_allRouterFalseSucceedsWithoutPayout() public {
+        MockRecoveryRouter router = _deployMockRecoveryRouter();
+        router.scriptReturnsFalse(hex"1111");
+        router.scriptReturnsFalse(hex"2222");
+
+        InteropCall[] memory calls = new InteropCall[](2);
+        calls[0] = _recoveryCall(L2_ASSET_ROUTER_ADDR, 0, hex"1111"); // recoverAtomicCall -> false
+        calls[1] = _recoveryCall(L2_ASSET_ROUTER_ADDR, 0, hex"2222"); // recoverAtomicCall -> false
+
+        (bytes32 recoveryFlowId, bytes32 bundleHash, bytes memory bundleBytes) = _revertableLegFromBundle(
+            _recoveryBundle(calls)
+        );
+
+        vm.expectEmit(true, true, false, true, address(manager));
+        emit IAtomicFlowManager.FlowRefunded(recoveryFlowId, bundleHash);
+        manager.claimRefund(recoveryFlowId, bundleBytes);
+
+        assertEq(router.recoverAttempts(), 2, "every router-backed call is still attempted");
+        assertEq(router.recoverSuccesses(), 0, "nothing actually recovers");
+        assertEq(router.baseTokenRecoveries(), 0, "no base-token payout occurred");
+        assertEq(
+            uint256(manager.legState(recoveryFlowId, bundleHash)),
+            uint256(LegState.Reverted),
+            "the leg is terminally Reverted even though nothing was recoverable"
+        );
+
+        // Terminal: the no-op refund cannot be claimed again.
+        vm.expectRevert(
+            abi.encodeWithSelector(ManagerLegNotRevertable.selector, recoveryFlowId, bundleHash, LegState.Reverted)
+        );
+        manager.claimRefund(recoveryFlowId, bundleBytes);
+    }
+
+    /// @notice A later call reverting during recovery aborts and rolls back the whole claim. Both calls
+    /// are reached before the abort; after the failing script is cleared, both are retried and the claim
+    /// completes, proving the leg remained `Revertable` and no partial recovery survived.
+    function test_claimRefund_multiCall_laterRevertAbortsClaim() public {
+        MockRecoveryRouter router = _deployMockRecoveryRouter();
+        router.scriptReverts(hex"baad");
+
+        InteropCall[] memory calls = new InteropCall[](2);
+        calls[0] = _recoveryCall(L2_ASSET_ROUTER_ADDR, 0, hex"600d"); // would recover successfully...
+        calls[1] = _recoveryCall(L2_ASSET_ROUTER_ADDR, 0, hex"baad"); // ...but this one reverts
+
+        (bytes32 recoveryFlowId, bytes32 bundleHash, bytes memory bundleBytes) = _revertableLegFromBundle(
+            _recoveryBundle(calls)
+        );
+
+        // Both recovery calls must be reached once in the failed claim and once in the successful retry.
+        vm.expectCall(
+            L2_ASSET_ROUTER_ADDR,
+            abi.encodeWithSelector(IAtomicRecoverable.recoverAtomicCall.selector, RECOVERY_DEST_CHAIN_ID, hex"600d"),
+            2
+        );
+        vm.expectCall(
+            L2_ASSET_ROUTER_ADDR,
+            abi.encodeWithSelector(IAtomicRecoverable.recoverAtomicCall.selector, RECOVERY_DEST_CHAIN_ID, hex"baad"),
+            2
+        );
+        vm.expectRevert("recovery boom");
+        manager.claimRefund(recoveryFlowId, bundleBytes);
+
+        assertEq(router.recoverAttempts(), 0, "reverted recovery attempts must roll back");
+        assertEq(router.recoverSuccesses(), 0, "the earlier successful recovery must roll back");
+        assertEq(
+            uint256(manager.legState(recoveryFlowId, bundleHash)),
+            uint256(LegState.Revertable),
+            "failed claim must leave the refund retryable"
+        );
+
+        router.scriptSucceeds(hex"baad");
+        vm.expectEmit(true, true, false, true, address(manager));
+        emit IAtomicFlowManager.FlowRefunded(recoveryFlowId, bundleHash);
+        manager.claimRefund(recoveryFlowId, bundleBytes);
+
+        assertEq(router.recoverAttempts(), 2, "retry must process both router-backed calls");
+        assertEq(router.recoverSuccesses(), 2, "both recoveries must succeed on retry");
+        assertEq(
+            uint256(manager.legState(recoveryFlowId, bundleHash)),
+            uint256(LegState.Reverted),
+            "successful retry must finish the refund"
+        );
     }
 }

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProof.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProof.t.sol
@@ -64,6 +64,14 @@ contract AtomicInteropProofTest is AtomicInteropProofBuilder {
 
     // ============ commitValue ============
 
+    /// @notice The domain tag's LITERAL value is pinned. {testFuzz_commitValue_matchesSpec} below
+    /// derives its expectation from `ATOMIC_COMMIT_LEAF_TAG` itself, so it stays green if the tag
+    /// preimage changes; the commit value is consensus-critical and mirrored by a hand-written
+    /// off-chain implementation, so the constant must not drift silently.
+    function test_commitValueDomainTag_isPinned() public pure {
+        assertEq(ATOMIC_COMMIT_LEAF_TAG, bytes4(0x3445134c), 'keccak("AtomicInterop.commit.v1")[0:4]');
+    }
+
     function testFuzz_commitValue_matchesSpec(bytes32 _flowId, bytes32 _bundleHash) public view {
         assertEq(
             proofLib.commitValue(_flowId, _bundleHash),
@@ -139,6 +147,30 @@ contract AtomicInteropProofTest is AtomicInteropProofBuilder {
         });
         vm.expectRevert(
             abi.encodeWithSelector(ProofInvalidChainBatchRootDepth.selector, ChainBatchRootTree.TREE_DEPTH, wrongDepth)
+        );
+        proofLib.verifyInclusion(proof, committedValue, DEADLINE, SETTLEMENT_LAYER_CHAIN_ID);
+    }
+
+    /// @dev ...and the symmetric direction: a SHORTER section is rejected too. Without this the depth
+    /// equality can be weakened to `>`, which still rejects the over-long path above while accepting
+    /// an undersized one that stops short of the chain batch root.
+    function test_RevertWhen_inclusion_chainBatchRootDepthTooShort() public {
+        ImtProof memory proof = _inclusionProof(
+            SOURCE_CHAIN_ID,
+            BATCH_N,
+            committedIndex,
+            SETTLEMENT_LAYER_CHAIN_ID,
+            SL_BLOCK,
+            DEADLINE - 1
+        );
+        uint256 shortDepth = ChainBatchRootTree.TREE_DEPTH - 1;
+        proof.settlementProof[0] = _composeMetadata({
+            _logLeafProofLen: shortDepth,
+            _batchLeafProofLen: 0,
+            _finalProofNode: false
+        });
+        vm.expectRevert(
+            abi.encodeWithSelector(ProofInvalidChainBatchRootDepth.selector, ChainBatchRootTree.TREE_DEPTH, shortDepth)
         );
         proofLib.verifyInclusion(proof, committedValue, DEADLINE, SETTLEMENT_LAYER_CHAIN_ID);
     }


### PR DESCRIPTION
## What ❔

> **The two commits are independent and can be taken separately.**
> - `52ecf1416` **repairs this PR**: it restores two pieces of coverage #2401 removed (the surplus-proof direction and the `ATOMIC_FLOW_PREIMAGE_VERSION` pin) and replaces the `forceRevertable` storage override. It adds no coverage that #2401 did not already have.
> - `6e1595777` **closes four gaps that pre-date #2401**, found in a second review pass. Nothing in #2401 caused them. Happy to drop this commit into its own PR against the release line if you would rather keep this one scoped to the repair — say so and I will split it.


Review follow-ups on #2401, targeting its branch. Seven changes across four test files; no production code touched.

Every addition below was **mutation-verified**: the mutant survives on #2401's head and dies with the new test. Atomic-interop unit suites go from **102 to 108 passing, 0 failing** (foundry-zksync v0.0.30 / forge 1.3.5-foundry-zksync-v0.1.5).

| Change | Mutant it kills |
| --- | --- |
| `AtomicFlowManagerFinalize`: add `test_RevertWhen_ProofCountTooMany` | `requireFlowFinalized`'s `proofs.length != n` → `< n` |
| `AtomicFlowManagerAppend`: add `test_atomicFlowPreimageVersion_isPinnedToV1` | silent `ATOMIC_FLOW_PREIMAGE_VERSION` bump |
| `AtomicFlowManagerRecover` / `AtomicFlowManagerRefund`: remove `forceRevertable`, move two `claimRefund` tests onto the real path | — (AGENTS.md storage override) |
| `AtomicInteropProof`: add `test_commitValueDomainTag_isPinned` | `ATOMIC_COMMIT_LEAF_TAG` preimage change |
| `AtomicInteropProof`: add `test_RevertWhen_inclusion_chainBatchRootDepthTooShort` | chain-batch-root depth `!=` → `>` |
| `AtomicFlowManagerInit`: add `test_RevertWhen_initL2ZeroChainId` | zero-sentinel guard deleted from `initL2` |
| `AtomicFlowManagerAppend`: add `test_append_CommitsSecondLegAndLinksBothCommitValues` | — (second insert / low-leaf relink untested) |

### The surviving mutant

#2401 removed "the second proof-count direction" as subsumed. It was not: weakening `requireFlowFinalized`'s count check to `<` leaves all 102 tests green, because the per-leg loop only reads `proofs[0..n)`. Not exploitable — surplus proofs are never read — but it is the mutation class this PR exists to close.

### The storage override

`AtomicFlowManagerRecoverHarness.forceRevertable` wrote `_state[flowId][bundleHash] = LegState.Revertable` directly, bypassing `append` + `authorizeRefund` and their flow-id, settlement-layer, index-bound, source-chain-binding and proof checks. AGENTS.md forbids this with no exceptions, and the real path was already available in this PR: the two `claimRefund` multi-call tests move to `AtomicFlowManagerRefundTest`, where the new `_revertableLegFromBundle` helper reaches `Revertable` through a real `append` of the bundle's leg followed by a real `authorizeRefund` against an end-to-end absence proof for the co-leg. Assertions are unchanged and the helper asserts it actually landed in `Revertable`, so the fixture is self-verifying. `MockRecoveryRouter` is now shared across both suites.

### The constant pins

Two pins removed or absent were reinstated. The `ATOMIC_FLOW_PREIMAGE_VERSION` assertion was dropped alongside the post-revert state assertions, but a compile-time constant pin is not a post-revert assertion — the "only restated EVM rollback" rationale is correct for the `tree.leafCount()` / `legState` removals and does not extend to it. Both that literal and `ATOMIC_COMMIT_LEAF_TAG` are mirrored by hand off-chain in `test/anvil-interop/src/helpers/imt-engine-lib.ts`, so a drift should fail fast in the unit suite rather than indirectly in the anvil suite.

## Why ❔

#2401's redundancy cleanup reopened one mutation gap and dropped one constant pin under a rationale that did not cover it, and the recovery suite reached `Revertable` by writing contract storage directly. The remaining additions close mutants an independent second review pass identified.

## Not changed, deliberately

- **`AtomicRecoveryForgery.t.sol` keeps its own `forceRevertable`.** Structurally the same violation, but unlike the one removed here it is documented with a rationale in the suite header, it predates this PR's base, and reaching `Revertable` honestly there requires pulling the whole proof fixture into a suite deliberately scoped to the router-side provenance gate. The clean follow-up lifts `_revertableLegFromBundle` into `AtomicInteropProofBuilder` and shares it — worth doing with the suite's author, not here.
- **No test pins `_lowNullifierIndex` forwarding.** It looks like a gap (every `append` test passes `0`), but `IndexedMerkleTree.insert` documents that argument as a hint and walks the linked list forward from it, so head index `0` is always accepted and `insert(value, 0)` is an equivalent mutant that no behavioural test can distinguish. Confirmed empirically. `test_append_CommitsSecondLegAndLinksBothCommitValues` covers the second insert and the low-leaf relink instead.

### Quoter-decode duplication (raised, not fixed here)

`_predictBundleHashWithAttrs`, added by #2401 in `L2AtomicInteropExecuteTestAbstract`, is the **fourth** copy of the same `previewBundleHash` / `previewMessageHash` quoter decode in the Solidity suites:

| Copy | Where | How it differs |
| --- | --- | --- |
| 1 | `L2AtomicInteropExecuteTestAbstract._predictBundleHashWithAttrs` | takes a full attrs array; no prank |
| 2 | `L2AtomicInteropSendRefundTestAbstract._predictBundleHashFor` | builds attrs internally; pranks `_sender` |
| 3 | `L2AtomicInteropSendRefundTestAbstract._predictMessageHash` | `previewMessageHash`; no prank; the two `require`s merged into one |
| 4 | `L2InteropBundleSaltTestAbstract` | inline in the test body; `assertFalse`/`assertEq` instead of `require`; pranks |

All four end in the same `assembly { predicted := mload(add(ret, 0x24)) }`.

The prank divergence is the load-bearing one. `previewBundleHash` reports the hash "for the same caller and inputs" (per {IInteropCenter}), so a copy that previews as the test contract while the matching send runs under a prank predicts the wrong hash — and that hash feeds `flowId`, so the failure surfaces later as a proof mismatch rather than as a missing prank. Copy 1 is self-consistent today only because its send is unpranked too; nothing holds that invariant.

The off-chain harness already solved this: `test/anvil-interop/src/helpers/interop-helpers.ts` has a single `staticPreviewHash(..., from, fnName, args)` covering both quoters with an explicit sender, used from several specs.

Suggested shape, in `L2InteropTestUtils` (all three abstract suites already inherit it, it already reaches `l2InteropCenter`, and this PR already edits it):

```solidity
/// @dev Shared quoter decode. `previewBundleHash`/`previewMessageHash` always revert with
/// `InteropPreviewHash(bytes32)`. The hash is CALLER-dependent, so `_sender` is never implicit —
/// pass `address(this)` when the matching send is unpranked.
function _decodePreviewHash(address _sender, bytes memory _callData) internal returns (bytes32 predicted) {
    vm.prank(_sender);
    (bool ok, bytes memory ret) = address(l2InteropCenter).call(_callData);
    require(!ok && ret.length == 36 && bytes4(ret) == InteropPreviewHash.selector,
            "preview must revert with InteropPreviewHash");
    assembly { predicted := mload(add(ret, 0x24)) }
}
```

Not done in this PR: three of the four copies live in files #2401 otherwise barely touches, so collapsing them belongs with the suites' author rather than in a review-fix branch. Say the word and I will push it here instead.

## Validation

- Atomic-interop unit suites: **108 passed, 0 failed, 0 skipped** (`forge test --threads 1 --ffi`).
- Seven mutations applied across `AtomicFlowManager.sol`, `AtomicInteropProof.sol` and `IAtomicInterop.sol`, re-running the full selection after each; every new test was confirmed to kill a mutant that survived before it, and contracts were restored afterwards (diff is tests-only).
- Prettier clean. `l1-contracts/test` is in `.solhintignore`, so solhint does not apply.
- **Not run:** the L1-context integration suites (`L2AtomicInteropExecuteL1Test`, `L2AtomicInteropSendRefundL1Test`) — they need `zkout` artifacts this environment lacks and are untouched by this PR.

> **Note:** both commits are unsigned — the signing key was unavailable in the environment that produced them. Re-sign before merging if that matters for this line.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
