### PR TITLE
test(atomic-interop): collapse the duplicated fixtures into one shared set

### DIFF
--- a/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2AtomicInteropExecuteTestAbstract.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2AtomicInteropExecuteTestAbstract.t.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.20;
 // solhint-disable gas-custom-errors
 
-import {Vm} from "forge-std/Vm.sol";
+import {AtomicFlowFixtures} from "../../unit/concrete/atomic-interop/AtomicFlowFixtures.sol";
 
 import {L2InteropTestUtils} from "./L2InteropTestUtils.sol";
 import {AtomicInteropProofBuilder} from "../../unit/concrete/atomic-interop/AtomicInteropProofBuilder.sol";
@@ -32,8 +32,6 @@ import {BundleStatus, CallStatus, InteropBundle, InteropCallStarter} from "contr
 import {InteroperableAddress} from "contracts/vendor/draft-InteroperableAddress.sol";
 import {
     L2_ASSET_ROUTER_ADDR,
-    L2_ATOMIC_FLOW_MANAGER_ADDR,
-    L2_COMPLEX_UPGRADER_ADDR,
     L2_INTEROP_COMMITMENT_TREE_ADDR,
     L2_INTEROP_HANDLER_ADDR
 } from "contracts/common/l2-helpers/L2ContractAddresses.sol";
@@ -118,10 +116,6 @@ abstract contract L2AtomicInteropExecuteTestAbstract is L2InteropTestUtils, Atom
         );
     }
 
-    function _flowIdOf(AtomicFlowPreimage memory _preimage) internal pure returns (bytes32) {
-        return keccak256(abi.encode(_preimage));
-    }
-
     /// @dev Cross-phase context (storage rather than locals to stay under the stack limit; each test
     /// overwrites it fully).
     struct ExecCtx {
@@ -165,7 +159,7 @@ abstract contract L2AtomicInteropExecuteTestAbstract is L2InteropTestUtils, Atom
         preimage.legSourceChainIds[localIndex] = block.chainid;
         preimage.legSourceChainIds[remoteIndex] = destinationChainId;
         ectxPreimage = preimage;
-        ectx.flowId = _flowIdOf(preimage);
+        ectx.flowId = AtomicFlowFixtures.flowId(preimage);
 
         // The real send carries the atomic metadata out-of-band plus the same bundle attributes.
         bytes[] memory attrs = new bytes[](predictionAttrs.length + 1);
@@ -192,7 +186,7 @@ abstract contract L2AtomicInteropExecuteTestAbstract is L2InteropTestUtils, Atom
     /// @dev Phase 2: commit the remote peer leg in its (oracle) source tree and assemble the per-leg
     /// finality proofs, positionally aligned with the preimage. Both batches settled in time.
     function _commitRemoteLegAndBuildFinality() internal returns (AtomicFinalityProof memory finality) {
-        uint256 remoteIndex = _insertCommit(_commitValue(ectx.flowId, REMOTE_LEG));
+        uint256 remoteIndex = _insertCommit(AtomicFlowFixtures.commitValue(ectx.flowId, REMOTE_LEG));
         finality = _buildFinality(
             _inclusionProof(destinationChainId, REMOTE_BATCH_NUMBER, remoteIndex, L1_CHAIN_ID, SL_BLOCK, DEADLINE - 1)
         );
@@ -297,7 +291,11 @@ abstract contract L2AtomicInteropExecuteTestAbstract is L2InteropTestUtils, Atom
         AtomicFinalityProof memory finality = _buildFinality(bogusRemoteProof);
 
         vm.expectRevert(
-            abi.encodeWithSelector(IMTLeafValueMismatch.selector, _commitValue(ectx.flowId, REMOTE_LEG), 0)
+            abi.encodeWithSelector(
+                IMTLeafValueMismatch.selector,
+                AtomicFlowFixtures.commitValue(ectx.flowId, REMOTE_LEG),
+                0
+            )
         );
         _executeOnDestination(finality);
     }
@@ -407,7 +405,11 @@ abstract contract L2AtomicInteropExecuteTestAbstract is L2InteropTestUtils, Atom
         vm.chainId(destinationChainId);
 
         vm.expectRevert(
-            abi.encodeWithSelector(IMTLeafValueMismatch.selector, _commitValue(ectx.flowId, REMOTE_LEG), 0)
+            abi.encodeWithSelector(
+                IMTLeafValueMismatch.selector,
+                AtomicFlowFixtures.commitValue(ectx.flowId, REMOTE_LEG),
+                0
+            )
         );
         L2InteropHandler(L2_INTEROP_HANDLER_ADDR).verifyAtomicBundle(ectxBundleBytes, finality);
     }

--- a/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2AtomicInteropExecuteTestAbstract.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2AtomicInteropExecuteTestAbstract.t.sol
@@ -9,7 +9,6 @@ import {L2InteropTestUtils} from "./L2InteropTestUtils.sol";
 import {AtomicInteropProofBuilder} from "../../unit/concrete/atomic-interop/AtomicInteropProofBuilder.sol";
 import {InteropLibrary} from "deploy-scripts/InteropLibrary.sol";
 
-import {AtomicFlowManager} from "contracts/atomic-interop/AtomicFlowManager.sol";
 import {L2InteropCommitmentTree} from "contracts/atomic-interop/L2InteropCommitmentTree.sol";
 import {L2InteropHandler} from "contracts/interop/interop-handler/L2InteropHandler.sol";
 import {IInteropHandlerBase} from "contracts/interop/interop-handler/IInteropHandlerBase.sol";
@@ -23,7 +22,6 @@ import {
 import {
     BundleAlreadyProcessed,
     ExecutingNotAllowed,
-    InteropPreviewHash,
     WrongDestinationChainId
 } from "contracts/interop/InteropErrors.sol";
 import {IMTLeafValueMismatch} from "contracts/common/L1ContractErrors.sol";

--- a/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2AtomicInteropExecuteTestAbstract.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2AtomicInteropExecuteTestAbstract.t.sol
@@ -73,12 +73,7 @@ abstract contract L2AtomicInteropExecuteTestAbstract is L2InteropTestUtils, Atom
     /// does not include them) and the proof fixtures. Called at the start of each test rather than in
     /// `setUp` to stay independent of the deployer's own setUp chain.
     function _setUpAtomicStack() internal {
-        deployCodeTo("AtomicFlowManager.sol:AtomicFlowManager", L2_ATOMIC_FLOW_MANAGER_ADDR);
-        deployCodeTo("L2InteropCommitmentTree.sol:L2InteropCommitmentTree", L2_INTEROP_COMMITMENT_TREE_ADDR);
-        vm.prank(L2_COMPLEX_UPGRADER_ADDR);
-        AtomicFlowManager(L2_ATOMIC_FLOW_MANAGER_ADDR).initL2(L1_CHAIN_ID);
-        vm.prank(L2_COMPLEX_UPGRADER_ADDR);
-        L2InteropCommitmentTree(L2_INTEROP_COMMITMENT_TREE_ADDR).initL2();
+        _deployAtomicPredeploys(L1_CHAIN_ID, true);
         // Proof fixtures from the builder: `tree` acts as the REMOTE chain's IMT oracle, plus the
         // real L2InteropRootStorage etched at its canonical address.
         _setUpAtomicFixtures();
@@ -113,23 +108,14 @@ abstract contract L2AtomicInteropExecuteTestAbstract is L2InteropTestUtils, Atom
         InteropCallStarter[] memory _calls,
         bytes[] memory _predictionAttrs
     ) internal returns (bytes32 predicted) {
-        // solhint-disable-next-line avoid-low-level-calls
-        (bool ok, bytes memory ret) = address(l2InteropCenter).call(
+        // The matching send below is unpranked, so preview as this contract.
+        predicted = _decodePreviewHash(
+            address(this),
             abi.encodeCall(
                 l2InteropCenter.previewBundleHash,
                 (InteroperableAddress.formatEvmV1(destinationChainId), _calls, _predictionAttrs)
             )
         );
-        require(!ok, "previewBundleHash must revert with InteropPreviewHash (quoter pattern)");
-        require(
-            ret.length == 36 && bytes4(ret) == InteropPreviewHash.selector,
-            "preview must revert with InteropPreviewHash"
-        );
-        // ret layout: 4-byte selector followed by the abi-encoded bytes32 hash.
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            predicted := mload(add(ret, 0x24))
-        }
     }
 
     function _flowIdOf(AtomicFlowPreimage memory _preimage) internal pure returns (bytes32) {

--- a/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2AtomicInteropSendRefundTestAbstract.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2AtomicInteropSendRefundTestAbstract.t.sol
@@ -143,12 +143,7 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
     function _mockAtomicFlowManager() internal virtual override {}
 
     function _setUpAtomicStack() internal {
-        deployCodeTo("AtomicFlowManager.sol:AtomicFlowManager", L2_ATOMIC_FLOW_MANAGER_ADDR);
-        deployCodeTo("L2InteropCommitmentTree.sol:L2InteropCommitmentTree", L2_INTEROP_COMMITMENT_TREE_ADDR);
-        vm.prank(L2_COMPLEX_UPGRADER_ADDR);
-        AtomicFlowManager(L2_ATOMIC_FLOW_MANAGER_ADDR).initL2(L1_CHAIN_ID);
-        vm.prank(L2_COMPLEX_UPGRADER_ADDR);
-        L2InteropCommitmentTree(L2_INTEROP_COMMITMENT_TREE_ADDR).initL2();
+        _deployAtomicPredeploys(L1_CHAIN_ID, true);
         // Proof fixtures from the builder: `tree` below acts as the REMOTE chain's IMT oracle (only
         // its genesis head leaf — the invalid leg is never committed there), plus the real
         // L2InteropRootStorage etched at its canonical address for the timeout clock, and a real
@@ -193,24 +188,13 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
         attrs[0] = abi.encodeCall(IERC7786Attributes.interopBundleSalt, (_salt));
         // `previewBundleHash` runs the real assembly (including the burning indirect call) but ALWAYS
         // reverts with `InteropPreviewHash(bytes32)`, unwinding the burn — read the hash out of the revert.
-        vm.prank(_sender);
-        // solhint-disable-next-line avoid-low-level-calls
-        (bool ok, bytes memory ret) = address(l2InteropCenter).call(
+        predicted = _decodePreviewHash(
+            _sender,
             abi.encodeCall(
                 l2InteropCenter.previewBundleHash,
                 (InteroperableAddress.formatEvmV1(_destinationChainId), _calls, attrs)
             )
         );
-        require(!ok, "previewBundleHash must revert with InteropPreviewHash (quoter pattern)");
-        require(
-            ret.length == 36 && bytes4(ret) == InteropPreviewHash.selector,
-            "preview must revert with InteropPreviewHash"
-        );
-        // ret layout: 4-byte selector followed by the abi-encoded bytes32 hash.
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            predicted := mload(add(ret, 0x24))
-        }
     }
 
     /// @dev Two-leg preimage: local leg on this chain + `INVALID_REMOTE_LEG` on the destination chain,
@@ -812,18 +796,11 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
     ) internal returns (bytes32 predicted) {
         bytes[] memory previewAttrs = new bytes[](1);
         previewAttrs[0] = abi.encodeCall(IERC7786Attributes.interopBundleSalt, (_salt));
-        // solhint-disable-next-line avoid-low-level-calls
-        (bool ok, bytes memory ret) = address(l2InteropCenter).call(
+        // The matching `sendMessage` below is unpranked, so preview as this contract.
+        predicted = _decodePreviewHash(
+            address(this),
             abi.encodeCall(l2InteropCenter.previewMessageHash, (_recipient7930, _payload, previewAttrs))
         );
-        require(
-            !ok && ret.length == 36 && bytes4(ret) == InteropPreviewHash.selector,
-            "preview must revert with InteropPreviewHash"
-        );
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            predicted := mload(add(ret, 0x24))
-        }
     }
 
     /// @notice The single-message atomic entry point `sendMessage` (distinct from `sendBundle`): it

--- a/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2AtomicInteropSendRefundTestAbstract.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2AtomicInteropSendRefundTestAbstract.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 // solhint-disable gas-custom-errors
 
 import {Vm} from "forge-std/Vm.sol";
+import {AtomicFlowFixtures} from "../../unit/concrete/atomic-interop/AtomicFlowFixtures.sol";
 
 import {L2InteropTestUtils} from "./L2InteropTestUtils.sol";
 import {AtomicInteropProofBuilder} from "../../unit/concrete/atomic-interop/AtomicInteropProofBuilder.sol";
@@ -33,7 +34,6 @@ import {
     L2_ASSET_ROUTER_ADDR,
     L2_ATOMIC_FLOW_MANAGER_ADDR,
     L2_BASE_TOKEN_HOLDER_ADDR,
-    L2_COMPLEX_UPGRADER_ADDR,
     L2_INTEROP_COMMITMENT_TREE_ADDR
 } from "contracts/common/l2-helpers/L2ContractAddresses.sol";
 import {L2_NATIVE_TOKEN_VAULT} from "contracts/common/l2-helpers/L2ContractInterfaces.sol";
@@ -215,10 +215,6 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
         missingLegIndex = remoteIndex;
     }
 
-    function _flowIdOf(AtomicFlowPreimage memory _preimage) internal pure returns (bytes32) {
-        return keccak256(abi.encode(_preimage));
-    }
-
     function _atomicAttributes(
         AtomicFlowPreimage memory _preimage,
         bytes32 _salt
@@ -321,7 +317,7 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
         (AtomicFlowPreimage memory preimage, uint256 missingLegIndex) = _preimageWithInvalidRemoteLeg(predicted);
         ctxPreimage = preimage;
         ctx.missingLegIndex = missingLegIndex;
-        ctx.flowId = _flowIdOf(preimage);
+        ctx.flowId = AtomicFlowFixtures.flowId(preimage);
         ctx.balanceBefore = IERC20(ctx.l2Token).balanceOf(address(this));
 
         vm.recordLogs();
@@ -353,7 +349,7 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
         );
         assertEq(
             L2InteropCommitmentTree(L2_INTEROP_COMMITMENT_TREE_ADDR).leafAt(1).value,
-            _commitValue(ctx.flowId, ctx.bundleHash),
+            AtomicFlowFixtures.commitValue(ctx.flowId, ctx.bundleHash),
             "the leg's commit value must be inserted into the canonical IMT"
         );
     }
@@ -369,7 +365,7 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
         // the idempotency tests (the first-post-genesis proof builder rejects a second aggregation).
         ImtProof memory absence = _realTimeoutBeginProof(
             destinationChainId,
-            _commitValue(ctx.flowId, INVALID_REMOTE_LEG),
+            AtomicFlowFixtures.commitValue(ctx.flowId, INVALID_REMOTE_LEG),
             uint256(DEADLINE) + 1
         );
         _invalidRemoteAbsence = absence;
@@ -427,7 +423,11 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
         uint256 balanceBefore = IERC20(l2Token).balanceOf(address(this));
 
         vm.expectRevert(
-            abi.encodeWithSelector(ManagerCommittedBundleNotInFlow.selector, _flowIdOf(preimage), predicted)
+            abi.encodeWithSelector(
+                ManagerCommittedBundleNotInFlow.selector,
+                AtomicFlowFixtures.flowId(preimage),
+                predicted
+            )
         );
         l2InteropCenter.sendBundle(
             InteroperableAddress.formatEvmV1(destinationChainId),
@@ -441,7 +441,7 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
             "the burn must be unwound with the reverted send"
         );
         assertEq(
-            uint256(manager.legState(_flowIdOf(preimage), predicted)),
+            uint256(manager.legState(AtomicFlowFixtures.flowId(preimage), predicted)),
             uint256(LegState.Unset),
             "no leg state may exist after the reverted send"
         );
@@ -491,7 +491,7 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
         (AtomicFlowPreimage memory preimage, uint256 missingLegIndex) = _preimageWithInvalidRemoteLeg(predicted);
         ctxPreimage = preimage;
         ctx.missingLegIndex = missingLegIndex;
-        ctx.flowId = _flowIdOf(preimage);
+        ctx.flowId = AtomicFlowFixtures.flowId(preimage);
 
         vm.deal(_depositor, NATIVE_VALUE_LEG_AMOUNT);
         uint256 holderBefore = L2_BASE_TOKEN_HOLDER_ADDR.balance;
@@ -641,7 +641,7 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
         (AtomicFlowPreimage memory preimage, uint256 missingLegIndex) = _preimageWithInvalidRemoteLeg(predicted);
         ctxPreimage = preimage;
         ctx.missingLegIndex = missingLegIndex;
-        ctx.flowId = _flowIdOf(preimage);
+        ctx.flowId = AtomicFlowFixtures.flowId(preimage);
 
         vm.recordLogs();
         vm.expectEmit(true, true, true, true, address(manager));
@@ -830,7 +830,7 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
         preimage.legBundleHashes[0] = predicted;
         preimage.legSourceChainIds = new uint256[](1);
         preimage.legSourceChainIds[0] = block.chainid;
-        bytes32 flowId = _flowIdOf(preimage);
+        bytes32 flowId = AtomicFlowFixtures.flowId(preimage);
 
         bytes[] memory attrs = new bytes[](2);
         attrs[0] = abi.encodeCall(IERC7786Attributes.interopBundleSalt, (salt));
@@ -849,7 +849,7 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
         );
         assertEq(
             L2InteropCommitmentTree(L2_INTEROP_COMMITMENT_TREE_ADDR).leafAt(1).value,
-            _commitValue(flowId, predicted),
+            AtomicFlowFixtures.commitValue(flowId, predicted),
             "the leg's commit value must land in the canonical IMT"
         );
 
@@ -890,7 +890,7 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
 
         assertEq(bundleHash, predicted, "attribute order must not change the bundle hash");
         assertEq(
-            uint256(manager.legState(_flowIdOf(preimage), bundleHash)),
+            uint256(manager.legState(AtomicFlowFixtures.flowId(preimage), bundleHash)),
             uint256(LegState.Committed),
             "the leg must be Committed regardless of the atomic attribute's position"
         );

--- a/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2InteropBundleSaltTestAbstract.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2InteropBundleSaltTestAbstract.t.sol
@@ -133,20 +133,10 @@ abstract contract L2InteropBundleSaltTestAbstract is L2InteropTestUtils {
         InteropCallStarter[] memory calls = _buildSimpleCall();
         bytes memory destination = InteroperableAddress.formatEvmV1(destinationChainId);
 
-        vm.prank(sender);
-        // Low-level call so we can read the hash out of the quoter revert (see {previewBundleHash}).
-        (bool ok, bytes memory ret) = address(l2InteropCenter).call(
+        bytes32 predicted = _decodePreviewHash(
+            sender,
             abi.encodeCall(l2InteropCenter.previewBundleHash, (destination, calls, attrs))
         );
-        assertFalse(ok, "previewBundleHash must revert with InteropPreviewHash (quoter pattern)");
-        assertEq(ret.length, 36, "revert reason must be InteropPreviewHash(bytes32)");
-        assertEq(bytes4(ret), InteropPreviewHash.selector, "unexpected preview revert selector");
-        bytes32 predicted;
-        // ret layout: 4-byte selector followed by the abi-encoded bytes32 hash.
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            predicted := mload(add(ret, 0x24))
-        }
 
         (, bytes32 emitted) = _sendAndDecodeBundle(sender, attrs);
         assertEq(predicted, emitted, "previewBundleHash must equal the emitted bundleHash");

--- a/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2InteropBundleSaltTestAbstract.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2InteropBundleSaltTestAbstract.t.sol
@@ -16,7 +16,6 @@ import {
     AttributeAlreadySet,
     AttributeViolatesRestriction,
     InteropBundleSaltAlreadyUsed,
-    InteropPreviewHash,
     NonAtomicSendUnsupported
 } from "contracts/interop/InteropErrors.sol";
 import {L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT} from "contracts/common/l2-helpers/L2ContractInterfaces.sol";

--- a/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2InteropHandlerReentrancyRegressionTestAbstract.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2InteropHandlerReentrancyRegressionTestAbstract.t.sol
@@ -3,8 +3,6 @@
 pragma solidity ^0.8.20;
 // solhint-disable gas-custom-errors
 
-import {Test} from "forge-std/Test.sol";
-
 import {IERC7786Recipient} from "contracts/interop/IERC7786Recipient.sol";
 import {
     InteropBundle,

--- a/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2InteropTestUtils.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2InteropTestUtils.sol
@@ -7,12 +7,7 @@ import {Vm} from "forge-std/Vm.sol";
 import {Test} from "forge-std/Test.sol";
 import "forge-std/console.sol";
 
-import {
-    L2_INTEROP_CENTER_ADDR,
-    L2_INTEROP_HANDLER,
-    L2_INTEROP_HANDLER_ADDR,
-    L2_NATIVE_TOKEN_VAULT_ADDR
-} from "contracts/common/l2-helpers/L2ContractInterfaces.sol";
+import {L2_INTEROP_HANDLER, L2_INTEROP_HANDLER_ADDR} from "contracts/common/l2-helpers/L2ContractInterfaces.sol";
 import {L2_ATOMIC_FLOW_MANAGER_ADDR} from "contracts/common/l2-helpers/L2ContractAddresses.sol";
 import {InteropBundle} from "contracts/common/Messaging.sol";
 import {
@@ -145,13 +140,10 @@ abstract contract L2InteropTestUtils is Test, SharedL2ContractDeployer {
         }
     }
 
-    /// @dev Reads a predicted hash out of the `previewBundleHash` / `previewMessageHash` quoters. Both
-    /// ALWAYS revert with `InteropPreviewHash(bytes32)` — running the real assembly (including any
-    /// value-burning indirect leg) and unwinding it — so the hash comes out of the revert data.
-    /// @dev The predicted hash is CALLER-dependent ("for the same caller and inputs", see
-    /// {IInteropCenter.previewBundleHash}), and it feeds `flowId` on the atomic paths, so a preview taken
-    /// as the wrong sender fails much later as a proof mismatch. `_sender` is therefore never implicit:
-    /// pass `address(this)` when the matching send is unpranked.
+    /// @dev Reads a hash out of the `previewBundleHash`/`previewMessageHash` quoters, which always
+    /// revert with `InteropPreviewHash(bytes32)` after running (and unwinding) the real assembly.
+    /// @dev The hash is caller-dependent and feeds `flowId`, so a preview taken as the wrong sender
+    /// fails much later as a proof mismatch. Pass `address(this)` when the send is unpranked.
     function _decodePreviewHash(address _sender, bytes memory _callData) internal returns (bytes32 predicted) {
         vm.prank(_sender);
         // solhint-disable-next-line avoid-low-level-calls

--- a/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2InteropTestUtils.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2InteropTestUtils.sol
@@ -26,6 +26,7 @@ import {ETH_TOKEN_ADDRESS} from "contracts/common/Config.sol";
 import {SharedL2ContractDeployer} from "./_SharedL2ContractDeployer.sol";
 import {InteropDataEncoding} from "contracts/interop/InteropDataEncoding.sol";
 import {DataEncoding} from "contracts/common/libraries/DataEncoding.sol";
+import {InteropPreviewHash} from "contracts/interop/InteropErrors.sol";
 import {L2InteropHandler} from "contracts/interop/interop-handler/L2InteropHandler.sol";
 
 /// @notice Struct to hold bundle execution result for assertions
@@ -141,6 +142,28 @@ abstract contract L2InteropTestUtils is Test, SharedL2ContractDeployer {
                 1,
                 string(abi.encodePacked("Call ", vm.toString(i), " status should be Executed"))
             );
+        }
+    }
+
+    /// @dev Reads a predicted hash out of the `previewBundleHash` / `previewMessageHash` quoters. Both
+    /// ALWAYS revert with `InteropPreviewHash(bytes32)` — running the real assembly (including any
+    /// value-burning indirect leg) and unwinding it — so the hash comes out of the revert data.
+    /// @dev The predicted hash is CALLER-dependent ("for the same caller and inputs", see
+    /// {IInteropCenter.previewBundleHash}), and it feeds `flowId` on the atomic paths, so a preview taken
+    /// as the wrong sender fails much later as a proof mismatch. `_sender` is therefore never implicit:
+    /// pass `address(this)` when the matching send is unpranked.
+    function _decodePreviewHash(address _sender, bytes memory _callData) internal returns (bytes32 predicted) {
+        vm.prank(_sender);
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool ok, bytes memory ret) = address(l2InteropCenter).call(_callData);
+        require(
+            !ok && ret.length == 36 && bytes4(ret) == InteropPreviewHash.selector,
+            "preview must revert with InteropPreviewHash (quoter pattern)"
+        );
+        // ret layout: 4-byte selector followed by the abi-encoded bytes32 hash.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            predicted := mload(add(ret, 0x24))
         }
     }
 }

--- a/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/_SharedL2ContractDeployer.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/_SharedL2ContractDeployer.sol
@@ -4,20 +4,17 @@ pragma solidity ^0.8.20;
 
 // solhint-disable gas-custom-errors
 
-import {Test} from "forge-std/Test.sol";
 import "forge-std/console.sol";
 
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts-v4/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 import {BridgedStandardERC20} from "contracts/bridge/BridgedStandardERC20.sol";
-import {L2AssetRouter} from "contracts/bridge/asset-router/L2AssetRouter.sol";
 import {L2AssetTracker} from "contracts/bridge/asset-tracker/L2AssetTracker.sol";
 
 import {UpgradeableBeacon} from "@openzeppelin/contracts-v4/proxy/beacon/UpgradeableBeacon.sol";
 import {BeaconProxy} from "@openzeppelin/contracts-v4/proxy/beacon/BeaconProxy.sol";
 
 import {IL2NativeTokenVault} from "../../../../../contracts/bridge/ntv/IL2NativeTokenVault.sol";
-import {IBaseToken} from "contracts/common/l2-helpers/IBaseToken.sol";
 import {
     L2_ASSET_ROUTER_ADDR,
     L2_ASSET_ROUTER,
@@ -42,7 +39,6 @@ import {IL2Bridgehub} from "contracts/core/bridgehub/IL2Bridgehub.sol";
 import {BridgehubMintCTMAssetData, IBridgehubBase} from "contracts/core/bridgehub/IBridgehubBase.sol";
 
 import {IL2AssetRouter} from "../../../../../contracts/bridge/asset-router/IL2AssetRouter.sol";
-import {IL1Nullifier} from "../../../../../contracts/bridge/interfaces/IL1Nullifier.sol";
 import {IL1AssetRouter} from "../../../../../contracts/bridge/asset-router/IL1AssetRouter.sol";
 
 import {

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowFixtures.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowFixtures.sol
@@ -17,30 +17,22 @@ import {
     L2_INTEROP_COMMITMENT_TREE_ADDR
 } from "contracts/common/l2-helpers/L2ContractAddresses.sol";
 
-/// @notice Shared fixture helpers for the atomic-interop suites.
-/// @dev These exist to keep the consensus-critical mirrors in ONE place. `commitValue` and `flowId`
-/// restate on-chain formulas; every extra copy is a chance for a test to verify against a value the
-/// production code never produces.
-///
-/// Deliberately NOT used by `AtomicInteropProof.testFuzz_commitValue_matchesSpec`: that test restates
-/// the commit-value formula on purpose, as the spec assertion. Pointing it here would make it compare
-/// {commitValue} against itself.
+/// @notice Shared fixtures for the atomic-interop suites.
+/// @dev `commitValue` and `flowId` restate on-chain formulas, so they live here once: an extra copy is
+/// a chance for a test to verify against a value production never produces. `AtomicInteropProof`'s
+/// `testFuzz_commitValue_matchesSpec` deliberately keeps its own restatement — it is the spec
+/// assertion, and routing it here would compare {commitValue} against itself.
 library AtomicFlowFixtures {
-    /// @dev Mirrors `AtomicInteropProof.commitValue`.
     function commitValue(bytes32 _flowId, bytes32 _bundleHash) internal pure returns (uint256) {
         return uint256(keccak256(abi.encode(ATOMIC_COMMIT_LEAF_TAG, _flowId, _bundleHash)));
     }
 
-    /// @dev Mirrors `AtomicFlowManager._validateAndComputeFlowId`'s hash (without the shape checks).
     function flowId(AtomicFlowPreimage memory _preimage) internal pure returns (bytes32) {
         return keccak256(abi.encode(_preimage));
     }
 
-    /// @dev A well-formed two-leg preimage. `append` requires `legBundleHashes` to be STRICTLY
-    /// ascending, so the legs are sorted by hash and the resulting slot of each is returned — callers
-    /// need those indices to address their own leg and would otherwise recompute the same comparison.
-    /// Negative tests that need a malformed preimage should build one explicitly, or mutate the result
-    /// here, rather than gaining a "make it invalid" flag.
+    /// @dev Legs must be strictly ascending, so they are sorted here and each leg's resulting slot is
+    /// returned — callers need those indices and were all repeating the same comparison.
     function twoLegPreimage(
         bytes32 _legA,
         uint256 _chainA,
@@ -60,8 +52,7 @@ library AtomicFlowFixtures {
         preimage = nLegPreimage(legs, chains, _deadline, _settlementLayerChainId);
     }
 
-    /// @dev A preimage over caller-ordered legs. The caller owns the ordering: this is the building
-    /// block the negative shape tests (unsorted, duplicated, length-mismatched) start from.
+    /// @dev Caller owns the leg ordering: the negative shape tests start from here and then break it.
     function nLegPreimage(
         bytes32[] memory _legBundleHashes,
         uint256[] memory _legSourceChainIds,
@@ -75,7 +66,6 @@ library AtomicFlowFixtures {
         preimage.legSourceChainIds = _legSourceChainIds;
     }
 
-    /// @dev The all-empty bundle attributes every fixture bundle that carries no attributes uses.
     function noBundleAttributes() internal pure returns (BundleAttributes memory) {
         return
             BundleAttributes({
@@ -88,10 +78,9 @@ library AtomicFlowFixtures {
 }
 
 /// @notice Stands the atomic predeploys up at their canonical addresses.
-/// @dev A contract rather than a library so it can use forge-std's `deployCodeTo`. Whether the
-/// commitment tree is deployed is an explicit argument: `requireFlowFinalized` never inserts, so the
-/// finalize suite genuinely does not need one, and making that a parameter keeps the difference
-/// visible instead of leaving it as an omission a reader has to notice.
+/// @dev A contract, not a library, so it can use forge-std's `deployCodeTo`. The tree is optional
+/// because `requireFlowFinalized` never inserts — the finalize suite needs none, and making that an
+/// argument keeps the difference visible instead of leaving it an omission.
 abstract contract AtomicPredeployFixture is Test {
     function _deployAtomicPredeploys(
         uint256 _l1ChainId,

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowFixtures.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowFixtures.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+
+import {AtomicFlowManager} from "contracts/atomic-interop/AtomicFlowManager.sol";
+import {L2InteropCommitmentTree} from "contracts/atomic-interop/L2InteropCommitmentTree.sol";
+import {
+    AtomicFlowPreimage,
+    ATOMIC_COMMIT_LEAF_TAG,
+    ATOMIC_FLOW_PREIMAGE_VERSION
+} from "contracts/atomic-interop/IAtomicInterop.sol";
+import {BundleAttributes} from "contracts/common/Messaging.sol";
+import {
+    L2_ATOMIC_FLOW_MANAGER_ADDR,
+    L2_COMPLEX_UPGRADER_ADDR,
+    L2_INTEROP_COMMITMENT_TREE_ADDR
+} from "contracts/common/l2-helpers/L2ContractAddresses.sol";
+
+/// @notice Shared fixture helpers for the atomic-interop suites.
+/// @dev These exist to keep the consensus-critical mirrors in ONE place. `commitValue` and `flowId`
+/// restate on-chain formulas; every extra copy is a chance for a test to verify against a value the
+/// production code never produces.
+///
+/// Deliberately NOT used by `AtomicInteropProof.testFuzz_commitValue_matchesSpec`: that test restates
+/// the commit-value formula on purpose, as the spec assertion. Pointing it here would make it compare
+/// {commitValue} against itself.
+library AtomicFlowFixtures {
+    /// @dev Mirrors `AtomicInteropProof.commitValue`.
+    function commitValue(bytes32 _flowId, bytes32 _bundleHash) internal pure returns (uint256) {
+        return uint256(keccak256(abi.encode(ATOMIC_COMMIT_LEAF_TAG, _flowId, _bundleHash)));
+    }
+
+    /// @dev Mirrors `AtomicFlowManager._validateAndComputeFlowId`'s hash (without the shape checks).
+    function flowId(AtomicFlowPreimage memory _preimage) internal pure returns (bytes32) {
+        return keccak256(abi.encode(_preimage));
+    }
+
+    /// @dev A well-formed two-leg preimage. `append` requires `legBundleHashes` to be STRICTLY
+    /// ascending, so the legs are sorted by hash and the resulting slot of each is returned — callers
+    /// need those indices to address their own leg and would otherwise recompute the same comparison.
+    /// Negative tests that need a malformed preimage should build one explicitly, or mutate the result
+    /// here, rather than gaining a "make it invalid" flag.
+    function twoLegPreimage(
+        bytes32 _legA,
+        uint256 _chainA,
+        bytes32 _legB,
+        uint256 _chainB,
+        uint64 _deadline,
+        uint256 _settlementLayerChainId
+    ) internal pure returns (AtomicFlowPreimage memory preimage, uint256 indexA, uint256 indexB) {
+        (indexA, indexB) = _legA < _legB ? (0, 1) : (1, 0);
+
+        bytes32[] memory legs = new bytes32[](2);
+        uint256[] memory chains = new uint256[](2);
+        legs[indexA] = _legA;
+        legs[indexB] = _legB;
+        chains[indexA] = _chainA;
+        chains[indexB] = _chainB;
+        preimage = nLegPreimage(legs, chains, _deadline, _settlementLayerChainId);
+    }
+
+    /// @dev A preimage over caller-ordered legs. The caller owns the ordering: this is the building
+    /// block the negative shape tests (unsorted, duplicated, length-mismatched) start from.
+    function nLegPreimage(
+        bytes32[] memory _legBundleHashes,
+        uint256[] memory _legSourceChainIds,
+        uint64 _deadline,
+        uint256 _settlementLayerChainId
+    ) internal pure returns (AtomicFlowPreimage memory preimage) {
+        preimage.version = ATOMIC_FLOW_PREIMAGE_VERSION;
+        preimage.deadline = _deadline;
+        preimage.settlementLayerChainId = _settlementLayerChainId;
+        preimage.legBundleHashes = _legBundleHashes;
+        preimage.legSourceChainIds = _legSourceChainIds;
+    }
+
+    /// @dev The all-empty bundle attributes every fixture bundle that carries no attributes uses.
+    function noBundleAttributes() internal pure returns (BundleAttributes memory) {
+        return
+            BundleAttributes({
+                executionAddress: bytes(""),
+                unbundlerAddress: bytes(""),
+                useFixedFee: false,
+                salt: bytes32(0)
+            });
+    }
+}
+
+/// @notice Stands the atomic predeploys up at their canonical addresses.
+/// @dev A contract rather than a library so it can use forge-std's `deployCodeTo`. Whether the
+/// commitment tree is deployed is an explicit argument: `requireFlowFinalized` never inserts, so the
+/// finalize suite genuinely does not need one, and making that a parameter keeps the difference
+/// visible instead of leaving it as an omission a reader has to notice.
+abstract contract AtomicPredeployFixture is Test {
+    function _deployAtomicPredeploys(
+        uint256 _l1ChainId,
+        bool _withCommitmentTree
+    ) internal returns (AtomicFlowManager manager, L2InteropCommitmentTree commitmentTree) {
+        deployCodeTo("AtomicFlowManager.sol:AtomicFlowManager", L2_ATOMIC_FLOW_MANAGER_ADDR);
+        manager = AtomicFlowManager(L2_ATOMIC_FLOW_MANAGER_ADDR);
+        vm.prank(L2_COMPLEX_UPGRADER_ADDR);
+        manager.initL2(_l1ChainId);
+
+        if (_withCommitmentTree) {
+            deployCodeTo("L2InteropCommitmentTree.sol:L2InteropCommitmentTree", L2_INTEROP_COMMITMENT_TREE_ADDR);
+            commitmentTree = L2InteropCommitmentTree(L2_INTEROP_COMMITMENT_TREE_ADDR);
+            vm.prank(L2_COMPLEX_UPGRADER_ADDR);
+            commitmentTree.initL2();
+        }
+    }
+}

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerAppend.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerAppend.t.sol
@@ -9,7 +9,6 @@ import {L2InteropCommitmentTree} from "contracts/atomic-interop/L2InteropCommitm
 import {
     AtomicFlowPreimage,
     LegState,
-    ATOMIC_COMMIT_LEAF_TAG,
     ATOMIC_FLOW_PREIMAGE_VERSION,
     MAX_ATOMIC_FLOW_LEGS
 } from "contracts/atomic-interop/IAtomicInterop.sol";
@@ -28,11 +27,8 @@ import {
 } from "contracts/atomic-interop/AtomicInteropErrors.sol";
 import {DummyL2InteropRootStorage} from "contracts/dev-contracts/test/DummyL2InteropRootStorage.sol";
 import {
-    L2_ATOMIC_FLOW_MANAGER_ADDR,
     L2_BRIDGEHUB_ADDR,
-    L2_COMPLEX_UPGRADER_ADDR,
     L2_INTEROP_CENTER_ADDR,
-    L2_INTEROP_COMMITMENT_TREE_ADDR,
     L2_INTEROP_ROOT_STORAGE_ADDR
 } from "contracts/common/l2-helpers/L2ContractAddresses.sol";
 
@@ -91,15 +87,6 @@ contract AtomicFlowManagerAppendTest is AtomicPredeployFixture {
         );
     }
 
-    /// @dev Both forward to the single shared mirrors; see {AtomicFlowFixtures}.
-    function _flowId(AtomicFlowPreimage memory _preimage) internal pure returns (bytes32) {
-        return AtomicFlowFixtures.flowId(_preimage);
-    }
-
-    function _commitValue(bytes32 _flowIdValue, bytes32 _bundleHash) internal pure returns (uint256) {
-        return AtomicFlowFixtures.commitValue(_flowIdValue, _bundleHash);
-    }
-
     function _appendAsInteropCenter(bytes32 _bundleHash, AtomicFlowPreimage memory _preimage) internal {
         vm.prank(L2_INTEROP_CENTER_ADDR);
         manager.append(_bundleHash, 0, _preimage);
@@ -114,14 +101,10 @@ contract AtomicFlowManagerAppendTest is AtomicPredeployFixture {
         manager.append(_bundleHash, _lowNullifierIndex, _preimage);
     }
 
-    /// @notice Two legs of the SAME flow, both sourced on this chain, can be committed one after the
-    /// other, and the indexed tree links their commit values in value order. Every other case here
-    /// commits a single leg, so this is the only coverage of a second insert (leaf 2) and of the
-    /// low-leaf link being rewritten by it.
-    /// @dev Deliberately NOT a test of `_lowNullifierIndex` forwarding: that argument is only a hint —
-    /// {IndexedMerkleTree.insert} walks the linked list forward from it — so the head index 0 is always
-    /// accepted and no behavioural test can distinguish forwarding it from hard-coding 0. The index is
-    /// passed here in its correct form anyway, as a caller would.
+    /// @notice Two legs of the same flow commit in sequence and the tree links them in value order.
+    /// Every other case commits one leg, so this is the only coverage of a second insert and relink.
+    /// @dev NOT a test of `_lowNullifierIndex` forwarding: that argument is a hint that
+    /// {IndexedMerkleTree.insert} walks forward from, so `insert(value, 0)` is an equivalent mutant.
     function test_append_CommitsSecondLegAndLinksBothCommitValues() public {
         bytes32 legA = keccak256("nullifier leg A");
         bytes32 legB = keccak256("nullifier leg B");
@@ -136,11 +119,11 @@ contract AtomicFlowManagerAppendTest is AtomicPredeployFixture {
         (preimage.legBundleHashes[0], preimage.legBundleHashes[1]) = legA < legB ? (legA, legB) : (legB, legA);
         preimage.legSourceChainIds[0] = block.chainid;
         preimage.legSourceChainIds[1] = block.chainid;
-        bytes32 flowId = _flowId(preimage);
+        bytes32 flowId = AtomicFlowFixtures.flowId(preimage);
 
         // Insert in commit-value order: the smaller value brackets at the head, the larger at leaf 1.
-        uint256 valueFirst = _commitValue(flowId, preimage.legBundleHashes[0]);
-        uint256 valueSecond = _commitValue(flowId, preimage.legBundleHashes[1]);
+        uint256 valueFirst = AtomicFlowFixtures.commitValue(flowId, preimage.legBundleHashes[0]);
+        uint256 valueSecond = AtomicFlowFixtures.commitValue(flowId, preimage.legBundleHashes[1]);
         (bytes32 firstLeg, bytes32 secondLeg) = valueFirst < valueSecond
             ? (preimage.legBundleHashes[0], preimage.legBundleHashes[1])
             : (preimage.legBundleHashes[1], preimage.legBundleHashes[0]);
@@ -171,7 +154,7 @@ contract AtomicFlowManagerAppendTest is AtomicPredeployFixture {
     function test_append_CommitsLegAndInsertsCommitValue() public {
         bytes32 localLeg = keccak256("local leg");
         AtomicFlowPreimage memory preimage = _twoLegPreimage(localLeg, keccak256("remote leg"));
-        bytes32 flowId = _flowId(preimage);
+        bytes32 flowId = AtomicFlowFixtures.flowId(preimage);
 
         vm.expectEmit(true, true, true, true, address(manager));
         emit IAtomicFlowManager.FlowCommitted(flowId, localLeg, DEADLINE, 1);
@@ -179,13 +162,15 @@ contract AtomicFlowManagerAppendTest is AtomicPredeployFixture {
 
         assertEq(uint256(manager.legState(flowId, localLeg)), uint256(LegState.Committed), "leg must be Committed");
         assertEq(tree.leafCount(), 2, "commit value must be inserted after the seeded head leaf");
-        assertEq(tree.leafAt(1).value, _commitValue(flowId, localLeg), "inserted leaf must hold the commit value");
+        assertEq(
+            tree.leafAt(1).value,
+            AtomicFlowFixtures.commitValue(flowId, localLeg),
+            "inserted leaf must hold the commit value"
+        );
     }
 
-    /// @notice The v1 preimage version literal is pinned. `ATOMIC_FLOW_PREIMAGE_VERSION` is part of
-    /// the flow-id preimage encoding and is mirrored off-chain by hand in
-    /// `test/anvil-interop/src/helpers/imt-engine-lib.ts`, so a bump must be a deliberate, visible
-    /// change here rather than a silent constant edit caught only by the anvil suite.
+    /// @notice Pins the v1 version literal: it is mirrored off-chain by hand in
+    /// `test/anvil-interop/src/helpers/imt-engine-lib.ts`, so a bump must break something here.
     function test_atomicFlowPreimageVersion_isPinnedToV1() public {
         assertEq(ATOMIC_FLOW_PREIMAGE_VERSION, bytes1(0x01), "v1 preimage version literal must be pinned");
     }
@@ -215,7 +200,11 @@ contract AtomicFlowManagerAppendTest is AtomicPredeployFixture {
         bytes32 strayBundleHash = keccak256("stale off-chain prediction");
 
         vm.expectRevert(
-            abi.encodeWithSelector(ManagerCommittedBundleNotInFlow.selector, _flowId(preimage), strayBundleHash)
+            abi.encodeWithSelector(
+                ManagerCommittedBundleNotInFlow.selector,
+                AtomicFlowFixtures.flowId(preimage),
+                strayBundleHash
+            )
         );
         _appendAsInteropCenter(strayBundleHash, preimage);
     }
@@ -229,7 +218,7 @@ contract AtomicFlowManagerAppendTest is AtomicPredeployFixture {
         vm.expectRevert(
             abi.encodeWithSelector(
                 ManagerCommittedLegSourceChainMismatch.selector,
-                _flowId(preimage),
+                AtomicFlowFixtures.flowId(preimage),
                 block.chainid,
                 OTHER_CHAIN_ID
             )
@@ -362,7 +351,7 @@ contract AtomicFlowManagerAppendTest is AtomicPredeployFixture {
 
         _appendAsInteropCenter(legA, preimage);
         assertEq(
-            uint256(manager.legState(_flowId(preimage), legA)),
+            uint256(manager.legState(AtomicFlowFixtures.flowId(preimage), legA)),
             uint256(LegState.Committed),
             "all-local leg must commit without any registry entry"
         );
@@ -396,7 +385,7 @@ contract AtomicFlowManagerAppendTest is AtomicPredeployFixture {
 
         _appendAsInteropCenter(localLeg, preimage);
 
-        assertEq(uint256(manager.legState(_flowId(preimage), localLeg)), uint256(LegState.Committed));
+        assertEq(uint256(manager.legState(AtomicFlowFixtures.flowId(preimage), localLeg)), uint256(LegState.Committed));
     }
 
     /// @notice The deadline gate keys on the flow's settlement layer only: a late root imported for some
@@ -410,7 +399,7 @@ contract AtomicFlowManagerAppendTest is AtomicPredeployFixture {
 
         _appendAsInteropCenter(localLeg, preimage);
 
-        assertEq(uint256(manager.legState(_flowId(preimage), localLeg)), uint256(LegState.Committed));
+        assertEq(uint256(manager.legState(AtomicFlowFixtures.flowId(preimage), localLeg)), uint256(LegState.Committed));
     }
 
     /// @dev Builds an all-local preimage with `_legCount` strictly ascending leg hashes; returns the
@@ -445,7 +434,7 @@ contract AtomicFlowManagerAppendTest is AtomicPredeployFixture {
 
         _appendAsInteropCenter(firstLeg, preimage);
 
-        assertEq(uint256(manager.legState(_flowId(preimage), firstLeg)), uint256(LegState.Committed));
+        assertEq(uint256(manager.legState(AtomicFlowFixtures.flowId(preimage), firstLeg)), uint256(LegState.Committed));
     }
 
     /// @notice A `(flowId, bundleHash)` leg can only be committed once.
@@ -454,7 +443,9 @@ contract AtomicFlowManagerAppendTest is AtomicPredeployFixture {
         AtomicFlowPreimage memory preimage = _twoLegPreimage(localLeg, keccak256("remote leg"));
         _appendAsInteropCenter(localLeg, preimage);
 
-        vm.expectRevert(abi.encodeWithSelector(ManagerLegAlreadyCommitted.selector, _flowId(preimage), localLeg));
+        vm.expectRevert(
+            abi.encodeWithSelector(ManagerLegAlreadyCommitted.selector, AtomicFlowFixtures.flowId(preimage), localLeg)
+        );
         _appendAsInteropCenter(localLeg, preimage);
     }
 

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerAppend.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerAppend.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {Test} from "forge-std/Test.sol";
+import {AtomicFlowFixtures, AtomicPredeployFixture} from "./AtomicFlowFixtures.sol";
 
 import {AtomicFlowManager} from "contracts/atomic-interop/AtomicFlowManager.sol";
 import {IAtomicFlowManager} from "contracts/atomic-interop/IAtomicFlowManager.sol";
@@ -52,7 +52,7 @@ contract MockBridgehubRegistry {
 /// wiring and appender ACL); the Bridgehub registry is a minimal stand-in and the root storage a dummy,
 /// feeding the registration and deadline gates. The caller ACL is exercised by pranking the canonical
 /// InteropCenter.
-contract AtomicFlowManagerAppendTest is Test {
+contract AtomicFlowManagerAppendTest is AtomicPredeployFixture {
     uint256 internal constant L1_CHAIN_ID = 5;
     uint64 internal constant DEADLINE = 1_700_000_000;
     uint256 internal constant OTHER_CHAIN_ID = 777;
@@ -62,20 +62,12 @@ contract AtomicFlowManagerAppendTest is Test {
     DummyL2InteropRootStorage internal rootStorage;
 
     function setUp() public {
-        deployCodeTo("AtomicFlowManager.sol:AtomicFlowManager", L2_ATOMIC_FLOW_MANAGER_ADDR);
-        deployCodeTo("L2InteropCommitmentTree.sol:L2InteropCommitmentTree", L2_INTEROP_COMMITMENT_TREE_ADDR);
+        (manager, tree) = _deployAtomicPredeploys(L1_CHAIN_ID, true);
         deployCodeTo("AtomicFlowManagerAppend.t.sol:MockBridgehubRegistry", L2_BRIDGEHUB_ADDR);
         // `append`'s deadline-freshness gate reads the latest imported root timestamp from the canonical
         // root storage; the dummy mirrors the production tracking without the bootloader-only ACL.
         deployCodeTo("DummyL2InteropRootStorage.sol:DummyL2InteropRootStorage", L2_INTEROP_ROOT_STORAGE_ADDR);
         rootStorage = DummyL2InteropRootStorage(L2_INTEROP_ROOT_STORAGE_ADDR);
-        manager = AtomicFlowManager(L2_ATOMIC_FLOW_MANAGER_ADDR);
-        tree = L2InteropCommitmentTree(L2_INTEROP_COMMITMENT_TREE_ADDR);
-
-        vm.prank(L2_COMPLEX_UPGRADER_ADDR);
-        manager.initL2(L1_CHAIN_ID);
-        vm.prank(L2_COMPLEX_UPGRADER_ADDR);
-        tree.initL2();
 
         // The canonical remote chain used by `_twoLegPreimage` is interop-registered; tests for the
         // registration gate use other, unregistered chain ids.
@@ -89,26 +81,23 @@ contract AtomicFlowManagerAppendTest is Test {
         bytes32 _localLeg,
         bytes32 _remoteLeg
     ) internal view returns (AtomicFlowPreimage memory preimage) {
-        preimage.version = ATOMIC_FLOW_PREIMAGE_VERSION;
-        preimage.deadline = DEADLINE;
-        preimage.settlementLayerChainId = L1_CHAIN_ID;
-        preimage.legBundleHashes = new bytes32[](2);
-        preimage.legSourceChainIds = new uint256[](2);
-        (uint256 localIndex, uint256 remoteIndex) = _localLeg < _remoteLeg ? (0, 1) : (1, 0);
-        preimage.legBundleHashes[localIndex] = _localLeg;
-        preimage.legBundleHashes[remoteIndex] = _remoteLeg;
-        preimage.legSourceChainIds[localIndex] = block.chainid;
-        preimage.legSourceChainIds[remoteIndex] = OTHER_CHAIN_ID;
+        (preimage, , ) = AtomicFlowFixtures.twoLegPreimage(
+            _localLeg,
+            block.chainid,
+            _remoteLeg,
+            OTHER_CHAIN_ID,
+            DEADLINE,
+            L1_CHAIN_ID
+        );
     }
 
-    /// @dev Mirrors `AtomicFlowManager._validateAndComputeFlowId`'s hash (without the shape checks).
+    /// @dev Both forward to the single shared mirrors; see {AtomicFlowFixtures}.
     function _flowId(AtomicFlowPreimage memory _preimage) internal pure returns (bytes32) {
-        return keccak256(abi.encode(_preimage));
+        return AtomicFlowFixtures.flowId(_preimage);
     }
 
-    /// @dev Mirrors `AtomicInteropProof.commitValue`.
     function _commitValue(bytes32 _flowIdValue, bytes32 _bundleHash) internal pure returns (uint256) {
-        return uint256(keccak256(abi.encode(ATOMIC_COMMIT_LEAF_TAG, _flowIdValue, _bundleHash)));
+        return AtomicFlowFixtures.commitValue(_flowIdValue, _bundleHash);
     }
 
     function _appendAsInteropCenter(bytes32 _bundleHash, AtomicFlowPreimage memory _preimage) internal {
@@ -429,17 +418,15 @@ contract AtomicFlowManagerAppendTest is Test {
     function _manyLegPreimage(
         uint256 _legCount
     ) internal view returns (AtomicFlowPreimage memory preimage, bytes32 firstLeg) {
-        preimage.version = ATOMIC_FLOW_PREIMAGE_VERSION;
-        preimage.deadline = DEADLINE;
-        preimage.settlementLayerChainId = L1_CHAIN_ID;
-        preimage.legBundleHashes = new bytes32[](_legCount);
-        preimage.legSourceChainIds = new uint256[](_legCount);
+        bytes32[] memory legs = new bytes32[](_legCount);
+        uint256[] memory chains = new uint256[](_legCount);
         for (uint256 i = 0; i < _legCount; ++i) {
             // Strictly ascending by construction.
-            preimage.legBundleHashes[i] = bytes32(i + 1);
-            preimage.legSourceChainIds[i] = block.chainid;
+            legs[i] = bytes32(i + 1);
+            chains[i] = block.chainid;
         }
-        firstLeg = preimage.legBundleHashes[0];
+        preimage = AtomicFlowFixtures.nLegPreimage(legs, chains, DEADLINE, L1_CHAIN_ID);
+        firstLeg = legs[0];
     }
 
     /// @notice A flow with more than {MAX_ATOMIC_FLOW_LEGS} legs cannot be committed.

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerFinalize.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerFinalize.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {AtomicInteropProofBuilder} from "./AtomicInteropProofBuilder.sol";
+import {AtomicFlowFixtures} from "./AtomicFlowFixtures.sol";
 
 import {AtomicFlowManager} from "contracts/atomic-interop/AtomicFlowManager.sol";
 import {
@@ -20,11 +21,7 @@ import {
     ProofDeadlineExceeded
 } from "contracts/atomic-interop/AtomicInteropErrors.sol";
 import {IMTLeafValueMismatch} from "contracts/common/L1ContractErrors.sol";
-import {
-    L2_ATOMIC_FLOW_MANAGER_ADDR,
-    L2_COMPLEX_UPGRADER_ADDR,
-    L2_INTEROP_HANDLER_ADDR
-} from "contracts/common/l2-helpers/L2ContractAddresses.sol";
+import {L2_INTEROP_HANDLER_ADDR} from "contracts/common/l2-helpers/L2ContractAddresses.sol";
 
 /// @notice Covers `AtomicFlowManager.requireFlowFinalized` — the atomicity gate the InteropHandler
 /// consults before executing an atomic bundle. The property under test: the gate passes iff EVERY
@@ -73,8 +70,8 @@ contract AtomicFlowManagerFinalizeTest is AtomicInteropProofBuilder {
         preimage.legSourceChainIds[1] = CHAIN_B;
         flowId = keccak256(abi.encode(preimage));
 
-        legFirstIndex = _insertCommit(_commitValue(flowId, legFirst));
-        legSecondIndex = _insertCommit(_commitValue(flowId, legSecond));
+        legFirstIndex = _insertCommit(AtomicFlowFixtures.commitValue(flowId, legFirst));
+        legSecondIndex = _insertCommit(AtomicFlowFixtures.commitValue(flowId, legSecond));
     }
 
     /// @dev A finality proof with a genuine in-time inclusion proof per leg; `_tsFirst`/`_tsSecond` are
@@ -141,9 +138,8 @@ contract AtomicFlowManagerFinalizeTest is AtomicInteropProofBuilder {
         _requireFinalizedAsHandler(legFirst, finality);
     }
 
-    /// @notice ...and SURPLUS proofs are rejected too, not silently ignored. The per-leg loop only
-    /// reads `proofs[0..n)`, so without this case the count check can be weakened from `!=` to `<`
-    /// and every other finalize test still passes — the exact-shape requirement would be unpinned.
+    /// @notice ...and SURPLUS proofs too. The loop only reads `proofs[0..n)`, so without this the
+    /// count check can be weakened from `!=` to `<` and every other finalize test still passes.
     function test_RevertWhen_ProofCountTooMany() public {
         AtomicFinalityProof memory finality = _validFinality();
         ImtProof[] memory threeProofs = new ImtProof[](3);
@@ -190,8 +186,8 @@ contract AtomicFlowManagerFinalizeTest is AtomicInteropProofBuilder {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IMTLeafValueMismatch.selector,
-                _commitValue(flowId, legFirst),
-                _commitValue(flowId, legSecond)
+                AtomicFlowFixtures.commitValue(flowId, legFirst),
+                AtomicFlowFixtures.commitValue(flowId, legSecond)
             )
         );
         _requireFinalizedAsHandler(legFirst, finality);
@@ -208,8 +204,8 @@ contract AtomicFlowManagerFinalizeTest is AtomicInteropProofBuilder {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IMTLeafValueMismatch.selector,
-                _commitValue(flowId, legSecond),
-                _commitValue(flowId, legFirst)
+                AtomicFlowFixtures.commitValue(flowId, legSecond),
+                AtomicFlowFixtures.commitValue(flowId, legFirst)
             )
         );
         _requireFinalizedAsHandler(legFirst, finality);

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerFinalize.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerFinalize.t.sol
@@ -50,10 +50,8 @@ contract AtomicFlowManagerFinalizeTest is AtomicInteropProofBuilder {
     uint256 internal legSecondIndex;
 
     function setUp() public {
-        deployCodeTo("AtomicFlowManager.sol:AtomicFlowManager", L2_ATOMIC_FLOW_MANAGER_ADDR);
-        manager = AtomicFlowManager(L2_ATOMIC_FLOW_MANAGER_ADDR);
-        vm.prank(L2_COMPLEX_UPGRADER_ADDR);
-        manager.initL2(SETTLEMENT_LAYER_CHAIN_ID);
+        // No canonical commitment tree: `requireFlowFinalized` only verifies proofs, never inserts.
+        (manager, ) = _deployAtomicPredeploys(SETTLEMENT_LAYER_CHAIN_ID, false);
 
         _setUpAtomicFixtures();
 

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerInit.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerInit.t.sol
@@ -3,6 +3,8 @@ pragma solidity 0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 
+import {AtomicFlowFixtures} from "./AtomicFlowFixtures.sol";
+
 import {AtomicFlowManager} from "contracts/atomic-interop/AtomicFlowManager.sol";
 import {
     AtomicFlow,
@@ -35,14 +37,12 @@ contract AtomicFlowManagerInitTest is Test {
 
     /// @dev A minimal well-formed flow (correct flowId) declaring `_settlementLayerChainId`.
     function _flow(uint256 _settlementLayerChainId) internal pure returns (AtomicFlow memory flow) {
-        flow.preimage.version = ATOMIC_FLOW_PREIMAGE_VERSION;
-        flow.preimage.deadline = 123;
-        flow.preimage.settlementLayerChainId = _settlementLayerChainId;
-        flow.preimage.legBundleHashes = new bytes32[](1);
-        flow.preimage.legBundleHashes[0] = keccak256("leg");
-        flow.preimage.legSourceChainIds = new uint256[](1);
-        flow.preimage.legSourceChainIds[0] = 271;
-        flow.flowId = keccak256(abi.encode(flow.preimage));
+        bytes32[] memory legs = new bytes32[](1);
+        legs[0] = keccak256("leg");
+        uint256[] memory chains = new uint256[](1);
+        chains[0] = 271;
+        flow.preimage = AtomicFlowFixtures.nLegPreimage(legs, chains, 123, _settlementLayerChainId);
+        flow.flowId = AtomicFlowFixtures.flowId(flow.preimage);
     }
 
     function test_initL2_setsL1ChainId() public view {

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerInit.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerInit.t.sol
@@ -6,12 +6,7 @@ import {Test} from "forge-std/Test.sol";
 import {AtomicFlowFixtures} from "./AtomicFlowFixtures.sol";
 
 import {AtomicFlowManager} from "contracts/atomic-interop/AtomicFlowManager.sol";
-import {
-    AtomicFlow,
-    AtomicFinalityProof,
-    ImtProof,
-    ATOMIC_FLOW_PREIMAGE_VERSION
-} from "contracts/atomic-interop/IAtomicInterop.sol";
+import {AtomicFlow, AtomicFinalityProof, ImtProof} from "contracts/atomic-interop/IAtomicInterop.sol";
 import {
     ManagerAlreadyInitialized,
     ManagerL1ChainIdZero,
@@ -54,9 +49,8 @@ contract AtomicFlowManagerInitTest is Test {
         manager.initL2(L1_CHAIN_ID);
     }
 
-    /// @notice Zero is the "not initialized" sentinel, so `initL2(0)` must be rejected — otherwise it
-    /// would appear to succeed while leaving the manager re-initializable by anyone the upgrader later
-    /// delegates to. Uses a FRESH manager, since `setUp` already initialized the shared one.
+    /// @notice Zero is the "not initialized" sentinel, so `initL2(0)` must be rejected rather than
+    /// appear to succeed and leave the manager re-initializable. Fresh manager: `setUp` used the other.
     function test_RevertWhen_initL2ZeroChainId() public {
         AtomicFlowManager fresh = new AtomicFlowManager();
 

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerRecover.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerRecover.t.sol
@@ -10,18 +10,11 @@ import {IAtomicRecoverable} from "contracts/atomic-interop/IAtomicRecoverable.so
 import {IAssetRouterShared} from "contracts/bridge/asset-router/IAssetRouterShared.sol";
 import {L2_ASSET_ROUTER_ADDR, L2_COMPLEX_UPGRADER_ADDR} from "contracts/common/l2-helpers/L2ContractAddresses.sol";
 import {RecoverToL1NotSupported} from "contracts/common/L1ContractErrors.sol";
-import {
-    BundleAttributes,
-    INTEROP_BUNDLE_VERSION,
-    INTEROP_CALL_VERSION,
-    InteropBundle,
-    InteropCall
-} from "contracts/common/Messaging.sol";
+import {INTEROP_BUNDLE_VERSION, INTEROP_CALL_VERSION, InteropBundle, InteropCall} from "contracts/common/Messaging.sol";
 
-/// @dev Exposes {AtomicFlowManager._recoverBundle} so its per-call refund dispatch can be unit tested
-/// in isolation. The surrounding Committed -> Revertable -> Reverted state machine is driven through
-/// the production `append` / `authorizeRefund` / `claimRefund` path in {AtomicFlowManagerRefundTest};
-/// no test forces leg state directly (see AGENTS.md on storage overrides).
+/// @dev Exposes {AtomicFlowManager._recoverBundle} so its per-call dispatch can be tested in
+/// isolation. The Committed -> Revertable -> Reverted machine is driven through the production path in
+/// {AtomicFlowManagerRefundTest}; no test forces leg state directly.
 contract AtomicFlowManagerRecoverHarness is AtomicFlowManager {
     function exposedRecoverBundle(InteropBundle memory _bundle) external {
         _recoverBundle(_bundle);

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerRecover.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerRecover.t.sol
@@ -3,6 +3,8 @@ pragma solidity 0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 
+import {AtomicFlowFixtures} from "./AtomicFlowFixtures.sol";
+
 import {AtomicFlowManager} from "contracts/atomic-interop/AtomicFlowManager.sol";
 import {IAtomicRecoverable} from "contracts/atomic-interop/IAtomicRecoverable.sol";
 import {IAssetRouterShared} from "contracts/bridge/asset-router/IAssetRouterShared.sol";
@@ -118,12 +120,7 @@ contract AtomicFlowManagerRecoverTest is Test {
             destinationBaseTokenAssetId: _destBaseTokenAssetId,
             interopBundleSalt: bytes32(0),
             calls: calls,
-            bundleAttributes: BundleAttributes({
-                executionAddress: "",
-                unbundlerAddress: "",
-                useFixedFee: false,
-                salt: bytes32(0)
-            })
+            bundleAttributes: AtomicFlowFixtures.noBundleAttributes()
         });
     }
 
@@ -209,12 +206,7 @@ contract AtomicFlowManagerRecoverTest is Test {
             destinationBaseTokenAssetId: SOURCE_BASE_TOKEN_ASSET_ID,
             interopBundleSalt: bytes32(0),
             calls: _calls,
-            bundleAttributes: BundleAttributes({
-                executionAddress: "",
-                unbundlerAddress: "",
-                useFixedFee: false,
-                salt: bytes32(0)
-            })
+            bundleAttributes: AtomicFlowFixtures.noBundleAttributes()
         });
     }
 

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerRefund.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerRefund.t.sol
@@ -9,7 +9,6 @@ import {MockRecoveryRouter} from "./AtomicFlowManagerRecover.t.sol";
 
 import {AtomicFlowManager} from "contracts/atomic-interop/AtomicFlowManager.sol";
 import {IAtomicFlowManager} from "contracts/atomic-interop/IAtomicFlowManager.sol";
-import {L2InteropCommitmentTree} from "contracts/atomic-interop/L2InteropCommitmentTree.sol";
 import {
     AtomicFlow,
     AtomicFlowPreimage,
@@ -24,21 +23,12 @@ import {
     ProofImtRootInclusionFailed
 } from "contracts/atomic-interop/AtomicInteropErrors.sol";
 import {IAtomicRecoverable} from "contracts/atomic-interop/IAtomicRecoverable.sol";
-import {
-    BundleAttributes,
-    INTEROP_BUNDLE_VERSION,
-    INTEROP_CALL_VERSION,
-    InteropBundle,
-    InteropCall
-} from "contracts/common/Messaging.sol";
+import {INTEROP_BUNDLE_VERSION, INTEROP_CALL_VERSION, InteropBundle, InteropCall} from "contracts/common/Messaging.sol";
 import {InteropDataEncoding} from "contracts/interop/InteropDataEncoding.sol";
 import {
     L2_ASSET_ROUTER_ADDR,
-    L2_ATOMIC_FLOW_MANAGER_ADDR,
     L2_BRIDGEHUB_ADDR,
-    L2_COMPLEX_UPGRADER_ADDR,
-    L2_INTEROP_CENTER_ADDR,
-    L2_INTEROP_COMMITMENT_TREE_ADDR
+    L2_INTEROP_CENTER_ADDR
 } from "contracts/common/l2-helpers/L2ContractAddresses.sol";
 
 /// @notice Covers the refund path's guards in `AtomicFlowManager` — `authorizeRefund`'s proof and
@@ -138,7 +128,12 @@ contract AtomicFlowManagerRefundTest is AtomicInteropProofBuilder {
     /// @dev A genuine end-to-end absence proof for the missing leg (begin branch, declared on
     /// `MISSING_LEG_CHAIN`). NOT `view`: real aggregation + import mutate settlement-layer state.
     function _validAbsence() internal returns (ImtProof memory) {
-        return _realTimeoutBeginProof(MISSING_LEG_CHAIN, _commitValue(flowId, missingLeg), uint256(DEADLINE) + 1);
+        return
+            _realTimeoutBeginProof(
+                MISSING_LEG_CHAIN,
+                AtomicFlowFixtures.commitValue(flowId, missingLeg),
+                uint256(DEADLINE) + 1
+            );
     }
 
     function _flow() internal view returns (AtomicFlow memory) {
@@ -181,7 +176,7 @@ contract AtomicFlowManagerRefundTest is AtomicInteropProofBuilder {
 
         ImtProof memory absence = _realTimeoutBeginProof(
             MISSING_LEG_CHAIN,
-            _commitValue(multiFlowId, missingLegHash),
+            AtomicFlowFixtures.commitValue(multiFlowId, missingLegHash),
             uint256(DEADLINE) + 1
         );
 
@@ -294,7 +289,7 @@ contract AtomicFlowManagerRefundTest is AtomicInteropProofBuilder {
         ImtProof memory absence = _nonInclusionProof(
             block.chainid,
             REMOTE_BATCH_NUMBER,
-            _commitValue(lateFlowId, lateLeg),
+            AtomicFlowFixtures.commitValue(lateFlowId, lateLeg),
             SETTLEMENT_LAYER_CHAIN_ID,
             SL_BLOCK,
             uint256(DEADLINE) + 1
@@ -363,7 +358,7 @@ contract AtomicFlowManagerRefundTest is AtomicInteropProofBuilder {
         ImtProof memory absence = _nonInclusionProof(
             MISSING_LEG_CHAIN,
             REMOTE_BATCH_NUMBER,
-            _commitValue(flowId, missingLeg),
+            AtomicFlowFixtures.commitValue(flowId, missingLeg),
             SETTLEMENT_LAYER_CHAIN_ID,
             SL_BLOCK,
             uint256(DEADLINE) + 1
@@ -403,13 +398,10 @@ contract AtomicFlowManagerRefundTest is AtomicInteropProofBuilder {
 
     // ============ multi-call recovery through the real Revertable path ============
 
-    /// @dev Drives `_bundle`'s leg to `Revertable` entirely through production entry points: a fresh
-    /// two-leg flow, a real `append` of this bundle's leg (pranked canonical InteropCenter), then a real
-    /// `authorizeRefund` against an end-to-end absence proof for the never-committed co-leg. No leg state
-    /// is ever written directly (see AGENTS.md on storage overrides).
-    /// @dev NOT `view`: aggregation + import mutate settlement-layer state. Consumes
-    /// `MISSING_LEG_CHAIN`'s single post-genesis batch, so a test calling this must not also call
-    /// {_validAbsence}. `append` must run before the post-deadline root is imported, hence this order.
+    /// @dev Drives `_bundle`'s leg to `Revertable` through production entry points only: a real
+    /// `append`, then a real `authorizeRefund` against an absence proof for the never-committed co-leg.
+    /// @dev Consumes `MISSING_LEG_CHAIN`'s single post-genesis batch, so a caller must not also call
+    /// {_validAbsence}. `append` must precede the post-deadline root import, hence this order.
     function _revertableLegFromBundle(
         InteropBundle memory _bundle
     ) internal returns (bytes32 recoveryFlowId, bytes32 bundleHash, bytes memory bundleBytes) {
@@ -435,7 +427,7 @@ contract AtomicFlowManagerRefundTest is AtomicInteropProofBuilder {
 
         ImtProof memory absence = _realTimeoutBeginProof(
             MISSING_LEG_CHAIN,
-            _commitValue(recoveryFlowId, coLeg),
+            AtomicFlowFixtures.commitValue(recoveryFlowId, coLeg),
             uint256(DEADLINE) + 1
         );
         manager.authorizeRefund(AtomicFlow({flowId: recoveryFlowId, preimage: recoveryPreimage}), coIdx, absence);
@@ -446,9 +438,8 @@ contract AtomicFlowManagerRefundTest is AtomicInteropProofBuilder {
         );
     }
 
-    /// @dev The stateful asset-router stand-in at its canonical address (shared with
-    /// {AtomicFlowManagerRecoverTest}): unlike `vm.mockCall`, its counters are real storage, so they
-    /// roll back with a reverting `claimRefund` — which is what the abort test below proves.
+    /// @dev Shared with {AtomicFlowManagerRecoverTest}: unlike `vm.mockCall` its counters are real
+    /// storage, so they roll back with a reverting `claimRefund` — what the abort test below proves.
     function _deployMockRecoveryRouter() internal returns (MockRecoveryRouter router) {
         deployCodeTo("AtomicFlowManagerRecover.t.sol:MockRecoveryRouter", L2_ASSET_ROUTER_ADDR);
         router = MockRecoveryRouter(L2_ASSET_ROUTER_ADDR);

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerRefund.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerRefund.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.28;
 import {Vm} from "forge-std/Vm.sol";
 
 import {AtomicInteropProofBuilder} from "./AtomicInteropProofBuilder.sol";
+import {AtomicFlowFixtures} from "./AtomicFlowFixtures.sol";
 import {MockRecoveryRouter} from "./AtomicFlowManagerRecover.t.sol";
 
 import {AtomicFlowManager} from "contracts/atomic-interop/AtomicFlowManager.sol";
@@ -73,13 +74,7 @@ contract AtomicFlowManagerRefundTest is AtomicInteropProofBuilder {
     uint256 internal missingLegIndex;
 
     function setUp() public {
-        deployCodeTo("AtomicFlowManager.sol:AtomicFlowManager", L2_ATOMIC_FLOW_MANAGER_ADDR);
-        deployCodeTo("L2InteropCommitmentTree.sol:L2InteropCommitmentTree", L2_INTEROP_COMMITMENT_TREE_ADDR);
-        manager = AtomicFlowManager(L2_ATOMIC_FLOW_MANAGER_ADDR);
-        vm.prank(L2_COMPLEX_UPGRADER_ADDR);
-        manager.initL2(SETTLEMENT_LAYER_CHAIN_ID);
-        vm.prank(L2_COMPLEX_UPGRADER_ADDR);
-        L2InteropCommitmentTree(L2_INTEROP_COMMITMENT_TREE_ADDR).initL2();
+        (manager, ) = _deployAtomicPredeploys(SETTLEMENT_LAYER_CHAIN_ID, true);
 
         // Builder fixtures: the oracle tree models the missing leg's source-chain state (it never
         // holds either commit value).
@@ -136,12 +131,7 @@ contract AtomicFlowManagerRefundTest is AtomicInteropProofBuilder {
             destinationBaseTokenAssetId: bytes32(uint256(1)),
             interopBundleSalt: keccak256("refund state machine salt"),
             calls: new InteropCall[](0),
-            bundleAttributes: BundleAttributes({
-                executionAddress: bytes(""),
-                unbundlerAddress: bytes(""),
-                useFixedFee: false,
-                salt: bytes32(0)
-            })
+            bundleAttributes: AtomicFlowFixtures.noBundleAttributes()
         });
     }
 
@@ -265,12 +255,7 @@ contract AtomicFlowManagerRefundTest is AtomicInteropProofBuilder {
             destinationBaseTokenAssetId: bytes32(uint256(1)),
             interopBundleSalt: keccak256("late leg salt"),
             calls: calls,
-            bundleAttributes: BundleAttributes({
-                executionAddress: bytes(""),
-                unbundlerAddress: bytes(""),
-                useFixedFee: false,
-                salt: bytes32(0)
-            })
+            bundleAttributes: AtomicFlowFixtures.noBundleAttributes()
         });
         bytes memory lateBundleBytes = abi.encode(lateBundle);
         bytes32 lateLeg = InteropDataEncoding.encodeInteropBundleHash(lateBundleBytes);
@@ -493,12 +478,7 @@ contract AtomicFlowManagerRefundTest is AtomicInteropProofBuilder {
             destinationBaseTokenAssetId: keccak256("recovery destination base token"),
             interopBundleSalt: keccak256("multi-call recovery salt"),
             calls: _calls,
-            bundleAttributes: BundleAttributes({
-                executionAddress: bytes(""),
-                unbundlerAddress: bytes(""),
-                useFixedFee: false,
-                salt: bytes32(0)
-            })
+            bundleAttributes: AtomicFlowFixtures.noBundleAttributes()
         });
     }
 

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProof.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProof.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {AtomicInteropProofBuilder} from "./AtomicInteropProofBuilder.sol";
+import {AtomicFlowFixtures} from "./AtomicFlowFixtures.sol";
 
 import {ImtProof, ATOMIC_COMMIT_LEAF_TAG} from "contracts/atomic-interop/IAtomicInterop.sol";
 import {ChainBatchRootTree} from "contracts/common/libraries/ChainBatchRootTree.sol";
@@ -55,19 +56,17 @@ contract AtomicInteropProofTest is AtomicInteropProofBuilder {
         // created strictly after the deadline, seeded through the real storage's production entry point.
         _seedSettlementLayerInteropRoot(SETTLEMENT_LAYER_CHAIN_ID, SL_BLOCK, uint256(DEADLINE) + 1);
 
-        committedValue = _commitValue(keccak256("flowA"), keccak256("bundleA"));
+        committedValue = AtomicFlowFixtures.commitValue(keccak256("flowA"), keccak256("bundleA"));
         committedIndex = _insertCommit(committedValue);
 
         // A value for a flow that was never committed on this chain (used by the timeout/absence tests).
-        absentValue = _commitValue(keccak256("flowB"), keccak256("bundleB"));
+        absentValue = AtomicFlowFixtures.commitValue(keccak256("flowB"), keccak256("bundleB"));
     }
 
     // ============ commitValue ============
 
-    /// @notice The domain tag's LITERAL value is pinned. {testFuzz_commitValue_matchesSpec} below
-    /// derives its expectation from `ATOMIC_COMMIT_LEAF_TAG` itself, so it stays green if the tag
-    /// preimage changes; the commit value is consensus-critical and mirrored by a hand-written
-    /// off-chain implementation, so the constant must not drift silently.
+    /// @notice Pins the domain tag's literal value. {testFuzz_commitValue_matchesSpec} derives its
+    /// expectation from the constant itself, so only this catches a change to the tag preimage.
     function test_commitValueDomainTag_isPinned() public pure {
         assertEq(ATOMIC_COMMIT_LEAF_TAG, bytes4(0x3445134c), 'keccak("AtomicInterop.commit.v1")[0:4]');
     }
@@ -151,9 +150,8 @@ contract AtomicInteropProofTest is AtomicInteropProofBuilder {
         proofLib.verifyInclusion(proof, committedValue, DEADLINE, SETTLEMENT_LAYER_CHAIN_ID);
     }
 
-    /// @dev ...and the symmetric direction: a SHORTER section is rejected too. Without this the depth
-    /// equality can be weakened to `>`, which still rejects the over-long path above while accepting
-    /// an undersized one that stops short of the chain batch root.
+    /// @dev The symmetric direction: without it the depth equality can be weakened to `>`, still
+    /// rejecting the over-long path above while accepting one that stops short of the root.
     function test_RevertWhen_inclusion_chainBatchRootDepthTooShort() public {
         ImtProof memory proof = _inclusionProof(
             SOURCE_CHAIN_ID,

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProofBuilder.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProofBuilder.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {AtomicFlowFixtures, AtomicPredeployFixture} from "./AtomicFlowFixtures.sol";
+import {AtomicPredeployFixture} from "./AtomicFlowFixtures.sol";
 
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts-v4/proxy/transparent/TransparentUpgradeableProxy.sol";
 
@@ -464,11 +464,6 @@ abstract contract AtomicInteropProofBuilder is AtomicPredeployFixture {
     // ------------------------------------------------------------------------------------------------
     // Tree helpers
     // ------------------------------------------------------------------------------------------------
-
-    /// @dev Forwards to the single shared mirror; see {AtomicFlowFixtures.commitValue}.
-    function _commitValue(bytes32 _flowId, bytes32 _bundleHash) internal pure returns (uint256) {
-        return AtomicFlowFixtures.commitValue(_flowId, _bundleHash);
-    }
 
     /// @dev Inserts `_value` into the real tree as the canonical appender; returns its leaf index.
     function _insertCommit(uint256 _value) internal returns (uint256 index) {

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProofBuilder.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProofBuilder.sol
@@ -25,8 +25,6 @@ import {L2_MESSAGE_VERIFICATION} from "contracts/common/l2-helpers/L2ContractInt
 import {L1MessageRoot} from "contracts/core/message-root/L1MessageRoot.sol";
 import {IBridgehubBase} from "contracts/core/bridgehub/IBridgehubBase.sol";
 import {IGetters} from "contracts/state-transition/chain-interfaces/IGetters.sol";
-import {Merkle} from "contracts/common/libraries/Merkle.sol";
-import {MessageHashing} from "contracts/common/libraries/MessageHashing.sol";
 
 error AtomicProofBuilderOnlySupportsFirstPostGenesisBatch(uint256 sourceChainId, uint256 batchNumber);
 

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProofBuilder.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProofBuilder.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {Test} from "forge-std/Test.sol";
+import {AtomicFlowFixtures, AtomicPredeployFixture} from "./AtomicFlowFixtures.sol";
 
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts-v4/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 import {AtomicInteropProof} from "contracts/atomic-interop/libraries/AtomicInteropProof.sol";
 import {L2InteropCommitmentTree} from "contracts/atomic-interop/L2InteropCommitmentTree.sol";
 import {L2InteropRootStorage} from "contracts/interop/L2InteropRootStorage.sol";
-import {ImtProof, ATOMIC_COMMIT_LEAF_TAG} from "contracts/atomic-interop/IAtomicInterop.sol";
+import {ImtProof} from "contracts/atomic-interop/IAtomicInterop.sol";
 import {IMTLeaf} from "contracts/common/libraries/IndexedMerkleTree.sol";
 import {InteropRoot} from "contracts/common/Messaging.sol";
 import {ChainBatchRootTree} from "contracts/common/libraries/ChainBatchRootTree.sol";
@@ -99,7 +99,7 @@ contract AtomicInteropProofWrapper {
 /// chain-getter views the real aggregation oracle consults (`_ensureChainRegistered` /
 /// `_setUpAtomicFixtures`), so the canonical predeploys resolve without deploying the full bridgehub
 /// stack. None of these stubs feeds the Merkle math the proofs authenticate against.
-abstract contract AtomicInteropProofBuilder is Test {
+abstract contract AtomicInteropProofBuilder is AtomicPredeployFixture {
     /// @dev The flow deadline all proofs are built against (shared with the tests so the builders
     /// can declare the honest timeout branch for a given batch timestamp).
     uint64 internal constant DEADLINE = 1_000;
@@ -465,8 +465,9 @@ abstract contract AtomicInteropProofBuilder is Test {
     // Tree helpers
     // ------------------------------------------------------------------------------------------------
 
+    /// @dev Forwards to the single shared mirror; see {AtomicFlowFixtures.commitValue}.
     function _commitValue(bytes32 _flowId, bytes32 _bundleHash) internal pure returns (uint256) {
-        return uint256(keccak256(abi.encode(ATOMIC_COMMIT_LEAF_TAG, _flowId, _bundleHash)));
+        return AtomicFlowFixtures.commitValue(_flowId, _bundleHash);
     }
 
     /// @dev Inserts `_value` into the real tree as the canonical appender; returns its leaf index.

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProofRealVerification.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProofRealVerification.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {AtomicInteropProofBuilder} from "./AtomicInteropProofBuilder.sol";
+import {AtomicFlowFixtures} from "./AtomicFlowFixtures.sol";
 
 import {ImtProof} from "contracts/atomic-interop/IAtomicInterop.sol";
 import {ChainBatchRootTree} from "contracts/common/libraries/ChainBatchRootTree.sol";
@@ -23,7 +24,7 @@ contract AtomicInteropProofRealVerificationTest is AtomicInteropProofBuilder {
 
     function setUp() public {
         _setUpAtomicFixtures(); // deploys the real verifier; no test here ever calls _mockVerifier
-        absentValue = _commitValue(keccak256("flowB"), keccak256("bundleB"));
+        absentValue = AtomicFlowFixtures.commitValue(keccak256("flowB"), keccak256("bundleB"));
     }
 
     // ------------------------------------------------------------------------------------------------

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicRecoveryForgery.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicRecoveryForgery.t.sol
@@ -3,6 +3,8 @@ pragma solidity 0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 
+import {AtomicFlowFixtures} from "./AtomicFlowFixtures.sol";
+
 import {AtomicFlowManager} from "contracts/atomic-interop/AtomicFlowManager.sol";
 import {LegState} from "contracts/atomic-interop/IAtomicInterop.sol";
 import {L2AssetRouter} from "contracts/bridge/asset-router/L2AssetRouter.sol";
@@ -144,12 +146,7 @@ contract AtomicRecoveryForgeryTest is Test {
             destinationBaseTokenAssetId: bytes32(uint256(1)),
             interopBundleSalt: keccak256(abi.encodePacked("salt", _from, _to)),
             calls: calls,
-            bundleAttributes: BundleAttributes({
-                executionAddress: bytes(""),
-                unbundlerAddress: bytes(""),
-                useFixedFee: false,
-                salt: bytes32(0)
-            })
+            bundleAttributes: AtomicFlowFixtures.noBundleAttributes()
         });
     }
 

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicRecoveryForgery.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicRecoveryForgery.t.sol
@@ -12,13 +12,7 @@ import {IL1AssetRouter} from "contracts/bridge/asset-router/IL1AssetRouter.sol";
 import {AssetRouterBase} from "contracts/bridge/asset-router/AssetRouterBase.sol";
 import {IAtomicRecoverable} from "contracts/atomic-interop/IAtomicRecoverable.sol";
 import {AssetHandlerDoesNotExist, RecoverToL1NotSupported, Unauthorized} from "contracts/common/L1ContractErrors.sol";
-import {
-    BundleAttributes,
-    INTEROP_BUNDLE_VERSION,
-    INTEROP_CALL_VERSION,
-    InteropBundle,
-    InteropCall
-} from "contracts/common/Messaging.sol";
+import {INTEROP_BUNDLE_VERSION, INTEROP_CALL_VERSION, InteropBundle, InteropCall} from "contracts/common/Messaging.sol";
 import {InteropDataEncoding} from "contracts/interop/InteropDataEncoding.sol";
 import {DataEncoding} from "contracts/common/libraries/DataEncoding.sol";
 import {L2_ASSET_ROUTER_ADDR, L2_COMPLEX_UPGRADER_ADDR} from "contracts/common/l2-helpers/L2ContractAddresses.sol";


### PR DESCRIPTION
## What ❔

Follow-up to #2409 (already merged into this branch). Collapses six duplicated fixture patterns across the atomic-interop suites into one shared set. Tests only; no production code.

Two of the six carried real bug risk — a restated consensus formula, and a hand-rolled decode that **had already drifted**. The rest were scaffolding that made a genuine divergence hard to see.

### New `AtomicFlowFixtures.sol`

| Helper | Replaces |
| --- | --- |
| `commitValue` / `flowId` | the consensus mirrors, previously implemented **twice** (`AtomicFlowManagerAppend` + `AtomicInteropProofBuilder`). Both old helpers now forward here, so call sites are untouched and there is one implementation. |
| `twoLegPreimage` / `nLegPreimage` | **15** open-coded preimage constructions. `twoLegPreimage` also returns each leg's resulting slot — the `a < b ? (0,1) : (1,0)` comparison every caller was repeating. |
| `noBundleAttributes` | the **6** byte-identical all-empty `BundleAttributes` literals. |
| `AtomicPredeployFixture._deployAtomicPredeploys` | **5** near-identical setUp blocks. Whether the commitment tree is deployed is now an explicit argument — the finalize suite legitimately needs none (`requireFlowFinalized` never inserts), and that difference was previously discoverable only by reading all five setUps. |

### `L2InteropTestUtils._decodePreviewHash`

Replaces **four** copies of the `previewBundleHash` / `previewMessageHash` quoter-revert decode, which had drifted three ways: two `require`s vs one vs `assertFalse`/`assertEq`, and — the one that matters — some copies pranked a sender and some did not.

The predicted hash is caller-dependent ("for the same caller and inputs", per `IInteropCenter`) and it feeds `flowId` on the atomic paths, so a preview taken as the wrong sender surfaces much later as a proof mismatch rather than as a missing prank. `_sender` is now a required argument, so it cannot be forgotten.

## Deliberately NOT deduplicated

- **`AtomicInteropProof.testFuzz_commitValue_matchesSpec` keeps its own restatement** of the commit-value formula. It is the spec assertion; pointing it at the shared helper would make it compare the helper against itself. (`test_commitValueDomainTag_isPinned`, added in #2409, is what actually pins the constant — verified below.)
- **The `InteropBundle` / `InteropCall` literals.** They describe genuinely different bundles and the explicitness is worth more than the line count.

## Validation

- `forge build` clean — **all integration abstracts compile**, including the three whose suites cannot run without `zkout` artifacts.
- Atomic-interop unit suites: **108 passed, 0 failed** — unchanged from #2409.
- **Sensitivity preserved:** re-ran the three mutants #2409 closed (proof-count `!=` → `<`, leg-order `<=` → `<`, `ATOMIC_COMMIT_LEAF_TAG` preimage change). All three are still caught, by exactly the same tests. Notably `testFuzz_commitValue_matchesSpec` still does *not* catch the tag mutation and the pin does — confirming the shared helper did not quietly make the spec test tautological.
- Prettier clean; `l1-contracts/test` is in `.solhintignore`.

## Scope note

Reaches one file outside #2401's footprint: `L2InteropBundleSaltTestAbstract` held the fourth quoter copy, and collapsing it was a one-liner once the shared helper existed. Leaving it would have meant three of four copies collapsed and the rule not actually established.

> The commit is unsigned — the signing key was unavailable in the environment that produced it.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
