### PR TITLE
test(atomic-interop): finish the fixture dedup and strip decorative comments

### DIFF
--- a/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2AtomicInteropExecuteTestAbstract.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2AtomicInteropExecuteTestAbstract.t.sol
@@ -58,7 +58,6 @@ abstract contract L2AtomicInteropExecuteTestAbstract is L2InteropTestUtils, Atom
     uint256 internal constant SL_BLOCK = 401;
     uint256 internal constant LOCAL_BATCH_NUMBER = 3;
     uint256 internal constant REMOTE_BATCH_NUMBER = 9;
-    uint256 internal constant TRANSFER_AMOUNT = 100;
 
     /// @dev These tests exercise the REAL append/finalize logic, so the shared deployer's void mock of
     /// `AtomicFlowManager.append`/`requireFlowFinalized` (installed in its `setUp`) is disabled here;
@@ -84,16 +83,6 @@ abstract contract L2AtomicInteropExecuteTestAbstract is L2InteropTestUtils, Atom
     /// @dev The exact single-call token-transfer starter `InteropLibrary.sendToken` sends: an indirect
     /// call through the L2 AssetRouter, which burns `_amount` of `_l2Token` from the sender and mints
     /// to {_receiver} on the destination.
-    function _tokenCallStarter(address _l2Token, uint256 _amount) internal returns (InteropCallStarter[] memory calls) {
-        bytes memory secondBridgeCalldata = InteropLibrary.buildSecondBridgeCalldata(
-            L2_NATIVE_TOKEN_VAULT.assetId(_l2Token),
-            _amount,
-            _receiver(),
-            address(0)
-        );
-        calls = new InteropCallStarter[](1);
-        calls[0] = InteropLibrary.buildSecondBridgeCall(secondBridgeCalldata, L2_ASSET_ROUTER_ADDR);
-    }
 
     /// @dev Predicts the bundle hash of a send with the given full (non-atomic) bundle-attribute set,
     /// via the `previewBundleHash` quoter — it runs the real assembly but ALWAYS reverts with
@@ -132,7 +121,7 @@ abstract contract L2AtomicInteropExecuteTestAbstract is L2InteropTestUtils, Atom
     /// zero-length to skip.
     function _sendAtomicLegWithRemotePeer(bytes32 _salt, bytes memory _extraBundleAttribute) internal {
         ectx.l2Token = initializeTokenByDeposit();
-        InteropCallStarter[] memory calls = _tokenCallStarter(ectx.l2Token, TRANSFER_AMOUNT);
+        InteropCallStarter[] memory calls = _tokenCallStarter(ectx.l2Token, TRANSFER_AMOUNT, _receiver());
 
         bytes[] memory predictionAttrs;
         if (_extraBundleAttribute.length != 0) {
@@ -276,16 +265,7 @@ abstract contract L2AtomicInteropExecuteTestAbstract is L2InteropTestUtils, Atom
 
         // The remote leg's commit value was never inserted; the best available "membership" data is
         // the oracle tree's genesis head leaf, whose value (0) is not the leg's commit value.
-        ImtProof memory bogusRemoteProof = ImtProof({
-            sourceChainId: destinationChainId,
-            batchNumber: REMOTE_BATCH_NUMBER,
-            chainImtRoot: tree.root(),
-            provesAgainstBeginRoot: false,
-            settlementProof: _settlementProof(L1_CHAIN_ID, SL_BLOCK, DEADLINE - 1, new bytes32[](0)),
-            leaf: tree.leafAt(0),
-            imtLeafIndex: 0,
-            imtProof: tree.merklePath(0)
-        });
+        ImtProof memory bogusRemoteProof = _uncommittedRemoteProof();
         AtomicFinalityProof memory finality = _buildFinality(bogusRemoteProof);
 
         vm.expectRevert(
@@ -343,9 +323,7 @@ abstract contract L2AtomicInteropExecuteTestAbstract is L2InteropTestUtils, Atom
         L2InteropHandler(L2_INTEROP_HANDLER_ADDR).executeAtomicBundle(ectxBundleBytes, finality);
     }
 
-    // ------------------------------------------------------------------------------------------------
     // verifyAtomicBundle — the same atomicity gate on the verify (no-execution) path
-    // ------------------------------------------------------------------------------------------------
 
     /// @notice `verifyAtomicBundle` passes the SAME atomicity gate as execution: with every leg proven
     /// committed in time, the bundle is marked `Verified` (exact event), and NOTHING executes — no
@@ -387,16 +365,7 @@ abstract contract L2AtomicInteropExecuteTestAbstract is L2InteropTestUtils, Atom
 
         // The remote leg's commit value was never inserted; the best available "membership" data is
         // the oracle tree's genesis head leaf, whose value (0) is not the leg's commit value.
-        ImtProof memory bogusRemoteProof = ImtProof({
-            sourceChainId: destinationChainId,
-            batchNumber: REMOTE_BATCH_NUMBER,
-            chainImtRoot: tree.root(),
-            provesAgainstBeginRoot: false,
-            settlementProof: _settlementProof(L1_CHAIN_ID, SL_BLOCK, DEADLINE - 1, new bytes32[](0)),
-            leaf: tree.leafAt(0),
-            imtLeafIndex: 0,
-            imtProof: tree.merklePath(0)
-        });
+        ImtProof memory bogusRemoteProof = _uncommittedRemoteProof();
         AtomicFinalityProof memory finality = _buildFinality(bogusRemoteProof);
 
         _mockVerifier(true);
@@ -429,5 +398,21 @@ abstract contract L2AtomicInteropExecuteTestAbstract is L2InteropTestUtils, Atom
         AtomicFinalityProof memory emptyFinality;
         vm.expectRevert(abi.encodeWithSelector(BundleAlreadyProcessed.selector, ectx.bundleHash));
         L2InteropHandler(L2_INTEROP_HANDLER_ADDR).verifyAtomicBundle(ectxBundleBytes, emptyFinality);
+    }
+
+    /// @dev A proof for the remote leg that was never committed: the best available "membership" data
+    /// is the oracle tree's genesis head leaf, whose value is not the leg's commit value.
+    function _uncommittedRemoteProof() internal view returns (ImtProof memory) {
+        return
+            ImtProof({
+                sourceChainId: destinationChainId,
+                batchNumber: REMOTE_BATCH_NUMBER,
+                chainImtRoot: tree.root(),
+                provesAgainstBeginRoot: false,
+                settlementProof: _settlementProof(L1_CHAIN_ID, SL_BLOCK, DEADLINE - 1, new bytes32[](0)),
+                leaf: tree.leafAt(0),
+                imtLeafIndex: 0,
+                imtProof: tree.merklePath(0)
+            });
     }
 }

--- a/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2AtomicInteropSendRefundTestAbstract.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2AtomicInteropSendRefundTestAbstract.t.sol
@@ -154,16 +154,6 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
     }
 
     /// @dev Single indirect asset-router call that burns `_amount` of `_l2Token` from the sender.
-    function _tokenCallStarter(address _l2Token, uint256 _amount) internal returns (InteropCallStarter[] memory calls) {
-        bytes memory secondBridgeCalldata = InteropLibrary.buildSecondBridgeCalldata(
-            L2_NATIVE_TOKEN_VAULT.assetId(_l2Token),
-            _amount,
-            makeAddr("atomic recipient"),
-            address(0)
-        );
-        calls = new InteropCallStarter[](1);
-        calls[0] = InteropLibrary.buildSecondBridgeCall(secondBridgeCalldata, L2_ASSET_ROUTER_ADDR);
-    }
 
     /// @dev Predicts the bundle hash the atomic send will produce, via the `previewBundleHash` quoter with
     /// the same calls and salt (the atomic metadata is not part of the bundle, so the hash is identical).
@@ -239,8 +229,6 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
     /// @dev `abi.encode(InteropBundle)` of the sent bundle, as `claimRefund` consumes it.
     bytes internal ctxBundleBytes;
 
-    uint256 internal constant TRANSFER_AMOUNT = 100;
-
     /// @notice Atomic send whose preimage pairs the real (burned) local leg with a never-committable remote
     /// leg; after the deadline the missing leg is proven absent and the burn is refunded.
     function test_atomicSend_WithInvalidRemoteLeg_IsRefundableAfterTimeout() public {
@@ -277,7 +265,7 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
     function test_previewBundleHash_rollsBackBurningIndirectLeg() public {
         _setUpAtomicStack();
         address l2Token = initializeTokenByDeposit();
-        InteropCallStarter[] memory calls = _tokenCallStarter(l2Token, TRANSFER_AMOUNT);
+        InteropCallStarter[] memory calls = _tokenCallStarter(l2Token, TRANSFER_AMOUNT, makeAddr("atomic recipient"));
         uint256 balanceBefore = IERC20(l2Token).balanceOf(address(this));
 
         bytes[] memory attrs = new bytes[](1);
@@ -311,7 +299,11 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
         AtomicFlowManager manager = AtomicFlowManager(L2_ATOMIC_FLOW_MANAGER_ADDR);
         ctx.l2Token = initializeTokenByDeposit();
         bytes32 salt = keccak256("atomic invalid-remote-leg salt");
-        InteropCallStarter[] memory calls = _tokenCallStarter(ctx.l2Token, TRANSFER_AMOUNT);
+        InteropCallStarter[] memory calls = _tokenCallStarter(
+            ctx.l2Token,
+            TRANSFER_AMOUNT,
+            makeAddr("atomic recipient")
+        );
 
         bytes32 predicted = _predictBundleHash(calls, salt);
         (AtomicFlowPreimage memory preimage, uint256 missingLegIndex) = _preimageWithInvalidRemoteLeg(predicted);
@@ -407,7 +399,7 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
         address l2Token = initializeTokenByDeposit();
         uint256 amount = 100;
         bytes32 salt = keccak256("atomic not-in-preimage salt");
-        InteropCallStarter[] memory calls = _tokenCallStarter(l2Token, amount);
+        InteropCallStarter[] memory calls = _tokenCallStarter(l2Token, amount, makeAddr("atomic recipient"));
 
         bytes32 predicted = _predictBundleHash(calls, salt);
         // Well-formed preimage that does not contain the bundle being sent (e.g. a stale prediction).
@@ -765,7 +757,7 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
 
         address l2Token = initializeTokenByDeposit();
         bytes32 salt = keccak256("atomic phantom co-leg salt");
-        InteropCallStarter[] memory calls = _tokenCallStarter(l2Token, TRANSFER_AMOUNT);
+        InteropCallStarter[] memory calls = _tokenCallStarter(l2Token, TRANSFER_AMOUNT, makeAddr("atomic recipient"));
 
         bytes32 predicted = _predictBundleHash(calls, salt);
         (AtomicFlowPreimage memory preimage, uint256 remoteIndex) = _preimageWithInvalidRemoteLeg(predicted);
@@ -872,7 +864,7 @@ abstract contract L2AtomicInteropSendRefundTestAbstract is L2InteropTestUtils, A
 
         address l2Token = initializeTokenByDeposit();
         bytes32 salt = keccak256("atomic attribute-order salt");
-        InteropCallStarter[] memory calls = _tokenCallStarter(l2Token, TRANSFER_AMOUNT);
+        InteropCallStarter[] memory calls = _tokenCallStarter(l2Token, TRANSFER_AMOUNT, makeAddr("atomic recipient"));
 
         bytes32 predicted = _predictBundleHash(calls, salt);
         (AtomicFlowPreimage memory preimage, ) = _preimageWithInvalidRemoteLeg(predicted);

--- a/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2InteropTestUtils.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/L2InteropTestUtils.sol
@@ -4,6 +4,10 @@ pragma solidity ^0.8.20;
 // solhint-disable gas-custom-errors
 
 import {Vm} from "forge-std/Vm.sol";
+import {L2_NATIVE_TOKEN_VAULT} from "contracts/common/l2-helpers/L2ContractInterfaces.sol";
+import {L2_ASSET_ROUTER_ADDR} from "contracts/common/l2-helpers/L2ContractAddresses.sol";
+import {InteropLibrary} from "deploy-scripts/InteropLibrary.sol";
+import {InteropCallStarter} from "contracts/common/Messaging.sol";
 import {Test} from "forge-std/Test.sol";
 import "forge-std/console.sol";
 
@@ -32,6 +36,9 @@ struct BundleExecutionResult {
 }
 
 abstract contract L2InteropTestUtils is Test, SharedL2ContractDeployer {
+    /// @dev Token amount the atomic integration fixtures move.
+    uint256 internal constant TRANSFER_AMOUNT = 100;
+
     uint256 destinationChainId = INTEROP_DESTINATION_CHAIN_ID;
     bytes32 destinationBaseTokenAssetId = DataEncoding.encodeNTVAssetId(L1_CHAIN_ID, ETH_TOKEN_ADDRESS);
 
@@ -157,5 +164,21 @@ abstract contract L2InteropTestUtils is Test, SharedL2ContractDeployer {
         assembly {
             predicted := mload(add(ret, 0x24))
         }
+    }
+
+    /// @dev One second-bridge call starter transferring `_amount` of `_l2Token` to `_receiver`.
+    function _tokenCallStarter(
+        address _l2Token,
+        uint256 _amount,
+        address _receiver
+    ) internal view returns (InteropCallStarter[] memory calls) {
+        bytes memory secondBridgeCalldata = InteropLibrary.buildSecondBridgeCalldata(
+            L2_NATIVE_TOKEN_VAULT.assetId(_l2Token),
+            _amount,
+            _receiver,
+            address(0)
+        );
+        calls = new InteropCallStarter[](1);
+        calls[0] = InteropLibrary.buildSecondBridgeCall(secondBridgeCalldata, L2_ASSET_ROUTER_ADDR);
     }
 }

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerFinalize.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerFinalize.t.sol
@@ -32,7 +32,6 @@ import {L2_INTEROP_HANDLER_ADDR} from "contracts/common/l2-helpers/L2ContractAdd
 /// Proof fixtures are real end-to-end per {AtomicInteropProofBuilder}; the manager sits at its
 /// canonical predeploy and is called from the pranked canonical InteropHandler.
 contract AtomicFlowManagerFinalizeTest is AtomicInteropProofBuilder {
-    uint256 internal constant SETTLEMENT_LAYER_CHAIN_ID = 1; // L1
     uint256 internal constant CHAIN_A = 271;
     uint256 internal constant CHAIN_B = 272;
 
@@ -68,7 +67,7 @@ contract AtomicFlowManagerFinalizeTest is AtomicInteropProofBuilder {
         preimage.legSourceChainIds = new uint256[](2);
         preimage.legSourceChainIds[0] = CHAIN_A;
         preimage.legSourceChainIds[1] = CHAIN_B;
-        flowId = keccak256(abi.encode(preimage));
+        flowId = AtomicFlowFixtures.flowId(preimage);
 
         legFirstIndex = _insertCommit(AtomicFlowFixtures.commitValue(flowId, legFirst));
         legSecondIndex = _insertCommit(AtomicFlowFixtures.commitValue(flowId, legSecond));

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerRecover.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerRecover.t.sol
@@ -162,6 +162,12 @@ contract AtomicFlowManagerRecoverTest is Test {
             "double recovery"
         );
 
+        // Pin that the router-backed branch is taken: otherwise this passes even if `_recoverBundle`
+        // skips both branches.
+        vm.expectCall(
+            L2_ASSET_ROUTER_ADDR,
+            abi.encodeWithSelector(IAtomicRecoverable.recoverAtomicCall.selector, DEST_CHAIN_ID, callData)
+        );
         manager.exposedRecoverBundle(_bundleFrom(L2_ASSET_ROUTER_ADDR, SOURCE_BASE_TOKEN_ASSET_ID, 1 ether, callData));
     }
 

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerRefund.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerRefund.t.sol
@@ -41,7 +41,6 @@ import {
 /// intrinsically-local late-commit case stub the leaf verifier. Real fund recovery is covered by
 /// `L2AtomicInteropSendRefundTestAbstract` and `AtomicRecoveryForgery.t.sol`.
 contract AtomicFlowManagerRefundTest is AtomicInteropProofBuilder {
-    uint256 internal constant SETTLEMENT_LAYER_CHAIN_ID = 1; // L1
     uint256 internal constant REMOTE_BATCH_NUMBER = 7;
     uint256 internal constant SL_BLOCK = 300;
     /// @dev The missing leg's remote source chain — aggregatable in the settlement-layer MessageRoot
@@ -89,7 +88,7 @@ contract AtomicFlowManagerRefundTest is AtomicInteropProofBuilder {
         preimage.legSourceChainIds[committedIdx] = block.chainid;
         preimage.legSourceChainIds[missingIdx] = MISSING_LEG_CHAIN;
         missingLegIndex = missingIdx;
-        flowId = keccak256(abi.encode(preimage));
+        flowId = AtomicFlowFixtures.flowId(preimage);
 
         // The remote missing-leg source must look interop-registered to the send-side `append` (a
         // Bridgehub registry lookup, orthogonal to the atomic proof machinery).
@@ -163,7 +162,7 @@ contract AtomicFlowManagerRefundTest is AtomicInteropProofBuilder {
         multiPreimage.legSourceChainIds[0] = block.chainid;
         multiPreimage.legSourceChainIds[1] = MISSING_LEG_CHAIN;
         multiPreimage.legSourceChainIds[2] = block.chainid;
-        bytes32 multiFlowId = keccak256(abi.encode(multiPreimage));
+        bytes32 multiFlowId = AtomicFlowFixtures.flowId(multiPreimage);
 
         // Commit BOTH non-missing legs through the production send-side path.
         for (uint256 i = 0; i < 3; ++i) {
@@ -268,7 +267,7 @@ contract AtomicFlowManagerRefundTest is AtomicInteropProofBuilder {
         latePreimage.legBundleHashes[peerIdx] = peerLeg;
         latePreimage.legSourceChainIds[lateIdx] = block.chainid;
         latePreimage.legSourceChainIds[peerIdx] = block.chainid;
-        bytes32 lateFlowId = keccak256(abi.encode(latePreimage));
+        bytes32 lateFlowId = AtomicFlowFixtures.flowId(latePreimage);
 
         // Both legs are committed in current manager state; the proof below authenticates historical
         // absence from a post-deadline batch root.
@@ -420,7 +419,7 @@ contract AtomicFlowManagerRefundTest is AtomicInteropProofBuilder {
         recoveryPreimage.legBundleHashes[coIdx] = coLeg;
         recoveryPreimage.legSourceChainIds[localIdx] = block.chainid;
         recoveryPreimage.legSourceChainIds[coIdx] = MISSING_LEG_CHAIN;
-        recoveryFlowId = keccak256(abi.encode(recoveryPreimage));
+        recoveryFlowId = AtomicFlowFixtures.flowId(recoveryPreimage);
 
         vm.prank(L2_INTEROP_CENTER_ADDR);
         manager.append(bundleHash, 0, recoveryPreimage);

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProof.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProof.t.sol
@@ -37,8 +37,9 @@ import {IMTLeafValueMismatch, IMTLowLeafNextTooSmall} from "contracts/common/L1C
 /// last-batch / inclusion branches all run for real. The deeper non-leftmost last-batch shape is also
 /// exercised end-to-end by {AtomicInteropProofRealVerification}.
 contract AtomicInteropProofTest is AtomicInteropProofBuilder {
+    /// @dev Per-suite proof fixture values. Not hoisted onto the builder: other derived suites pick
+    /// their own (the execute abstract uses a different `SL_BLOCK`).
     uint256 internal constant SOURCE_CHAIN_ID = 271;
-    uint256 internal constant SETTLEMENT_LAYER_CHAIN_ID = 1; // L1
     uint256 internal constant BATCH_N = 100;
     uint256 internal constant SL_BLOCK = 555;
 

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProofBuilder.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProofBuilder.sol
@@ -98,6 +98,8 @@ contract AtomicInteropProofWrapper {
 /// `_setUpAtomicFixtures`), so the canonical predeploys resolve without deploying the full bridgehub
 /// stack. None of these stubs feeds the Merkle math the proofs authenticate against.
 abstract contract AtomicInteropProofBuilder is AtomicPredeployFixture {
+    /// @dev The settlement layer every atomic flow in these suites declares (L1).
+    uint256 internal constant SETTLEMENT_LAYER_CHAIN_ID = 1;
     /// @dev The flow deadline all proofs are built against (shared with the tests so the builders
     /// can declare the honest timeout branch for a given batch timestamp).
     uint64 internal constant DEADLINE = 1_000;
@@ -105,7 +107,7 @@ abstract contract AtomicInteropProofBuilder is AtomicPredeployFixture {
     /// @dev The settlement layer every real proof aggregates + imports against (L1 in this release).
     /// Defaults to 1; harnesses whose flows declare a different `settlementLayerChainId` (e.g. the
     /// integration deployment's `L1_CHAIN_ID`) override it so the baked proof word + import key align.
-    uint256 internal builderSlChainId = 1;
+    uint256 internal builderSlChainId = SETTLEMENT_LAYER_CHAIN_ID;
 
     AtomicInteropProofWrapper internal proofLib;
     L2InteropCommitmentTree internal tree;
@@ -162,10 +164,8 @@ abstract contract AtomicInteropProofBuilder is AtomicPredeployFixture {
         );
     }
 
-    // ------------------------------------------------------------------------------------------------
     // Real settlement machinery: aggregate a chain batch root, import the shared root, build a proof
     // whose sibling paths come from the live MessageRoot trees. Nothing mocked in steps 1/2/4.
-    // ------------------------------------------------------------------------------------------------
 
     /// @dev Registers `_sourceChainId` in the MessageRoot and seeds its genesis (batch 0) leaf, once.
     function _ensureChainRegistered(uint256 _sourceChainId) internal {
@@ -398,9 +398,7 @@ abstract contract AtomicInteropProofBuilder is AtomicPredeployFixture {
             });
     }
 
-    // ------------------------------------------------------------------------------------------------
     // Mocks / real-storage seeding
-    // ------------------------------------------------------------------------------------------------
 
     /// @dev Drives the (separately-tested) cross-chain leaf verifier to `_ok` for every call.
     function _mockVerifier(bool _ok) internal {
@@ -459,9 +457,7 @@ abstract contract AtomicInteropProofBuilder is AtomicPredeployFixture {
         );
     }
 
-    // ------------------------------------------------------------------------------------------------
     // Tree helpers
-    // ------------------------------------------------------------------------------------------------
 
     /// @dev Inserts `_value` into the real tree as the canonical appender; returns its leaf index.
     function _insertCommit(uint256 _value) internal returns (uint256 index) {
@@ -496,9 +492,7 @@ abstract contract AtomicInteropProofBuilder is AtomicPredeployFixture {
         revert("AtomicInteropProofBuilder: no predecessor (value absent)");
     }
 
-    // ------------------------------------------------------------------------------------------------
     // settlementProof-blob assembler
-    // ------------------------------------------------------------------------------------------------
 
     /// @dev Builds the proof-metadata word (top 4 bytes: version, logLeafProofLen, batchLeafProofLen,
     /// finalProofNode; remaining bytes zero — the format `MessageHashing.parseProofMetadata` expects).
@@ -588,9 +582,7 @@ abstract contract AtomicInteropProofBuilder is AtomicPredeployFixture {
         }
     }
 
-    // ------------------------------------------------------------------------------------------------
     // ImtProof assemblers
-    // ------------------------------------------------------------------------------------------------
 
     /// @dev Inclusion proof for a value already inserted at `_leafIndex` in the real tree.
     function _inclusionProof(

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProofRealVerification.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProofRealVerification.t.sol
@@ -15,8 +15,9 @@ import {ProofNotLastBatchInRoot} from "contracts/atomic-interop/AtomicInteropErr
 /// produces only the one-level first-post-genesis path (mask `0b1`), so this suite forward-computes a
 /// two-level right-child last-leaf path and its invalid counterpart.
 contract AtomicInteropProofRealVerificationTest is AtomicInteropProofBuilder {
+    /// @dev Per-suite proof fixture values. Not hoisted onto the builder: other derived suites pick
+    /// their own (the execute abstract uses a different `SL_BLOCK`).
     uint256 internal constant SOURCE_CHAIN_ID = 271;
-    uint256 internal constant SETTLEMENT_LAYER_CHAIN_ID = 1; // L1
     uint256 internal constant BATCH_N = 100;
     uint256 internal constant SL_BLOCK = 555;
 
@@ -27,9 +28,7 @@ contract AtomicInteropProofRealVerificationTest is AtomicInteropProofBuilder {
         absentValue = AtomicFlowFixtures.commitValue(keccak256("flowB"), keccak256("bundleB"));
     }
 
-    // ------------------------------------------------------------------------------------------------
     // Real settlement-proof builder (forward-computed, no mocks)
-    // ------------------------------------------------------------------------------------------------
 
     /// @dev General builder: same two-hop reconstruction, but with a caller-chosen batch-leaf position
     /// (`_batchLeafMask` + `_batchLeafSiblings`) inside the chain's batch tree — used to exercise the
@@ -135,6 +134,9 @@ contract AtomicInteropProofRealVerificationTest is AtomicInteropProofBuilder {
             imtProof: tree.merklePath(lowIndex)
         });
 
+        // This suite exists to run the REAL verifier, so pin the call: `verifyTimeoutAbsence` returns
+        // nothing, so without this a no-op `_authenticateRoot` would pass.
+        _expectRootAuthentication(absence, ChainBatchRootTree.IMT_END_ROOT_LEAF_INDEX);
         proofLib.verifyTimeoutAbsence(absence, absentValue, DEADLINE, SETTLEMENT_LAYER_CHAIN_ID);
     }
 

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicRecoveryForgery.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicRecoveryForgery.t.sol
@@ -155,9 +155,7 @@ contract AtomicRecoveryForgeryTest is Test {
         manager.forceRevertable(flowId, bundleHash);
     }
 
-    // ---------------------------------------------------------------------------------------------
     // Recovery side (AtomicFlowManager._recoverBundle skips `from != L2_ASSET_ROUTER_ADDR`)
-    // ---------------------------------------------------------------------------------------------
 
     /// A forged, never-burned `finalizeDeposit` (its `from` is the attacker, not the router's burn path) is
     /// skipped on recovery: the NTV is never asked to release funds. The claim itself still goes through —
@@ -294,9 +292,7 @@ contract AtomicRecoveryForgeryTest is Test {
         );
     }
 
-    // ---------------------------------------------------------------------------------------------
     // L2AssetRouter.recoverAtomicCall entry-point surface (the recovery collaborator, called directly)
-    // ---------------------------------------------------------------------------------------------
 
     /// @notice `recoverAtomicCall` is gated to the atomic flow manager: any other caller is rejected
     /// with `Unauthorized`, so nobody can drive a recovery (a re-mint) outside the timeout flow.


### PR DESCRIPTION
## What ❔

Second dedup/cleanup round on this branch, following #2409 and #2410. From my own scan plus an independent Codex pass over the whole PR diff. Tests only.

### Duplication

| Was | Now |
| --- | --- |
| Five inline `keccak256(abi.encode(preimage))` copies | `AtomicFlowFixtures.flowId` |
| `_tokenCallStarter` duplicated statement-for-statement between the execute and send/refund suites | one copy in `L2InteropTestUtils`, receiver as an argument |
| The eight-field uncommitted-remote `ImtProof` built verbatim twice | `_uncommittedRemoteProof()` |
| `SETTLEMENT_LAYER_CHAIN_ID` ×4, `TRANSFER_AMOUNT` ×2 | hoisted onto the bases that already own them |

The `flowId` copies are the notable one: #2410 removed the named `_flowId` / `_flowIdOf` wrappers but left the raw formula in four setUps and in one of the helpers that PR itself added — the exact mirror the shared fixture exists to eliminate. Codex caught it.

### Assertions

Both strengthen existing tests. **Neither adds a test.**

- **`AtomicInteropProofRealVerification`'s happy path asserted nothing at all.** `verifyTimeoutAbsence` returns void, so the suite whose entire purpose is the un-mocked verifier never checked that it ran. Now pins the `proveL2LeafInclusionShared` call.
- **`test_recoverBundle_routerBackedValueDoesNotRefundSeparately`** stubbed `recoverAtomicCall` without ever expecting it, so it also passed if `_recoverBundle` skipped both branches. Now pins the call.

Verified by mutation: each test fails with its new assertion and passed without it. To be precise, **neither was a globally surviving mutant** — other tests already caught both. What changed is that each test now fails for its own stated reason instead of incidentally.

### Comments

Removed 18 decorative `//-----` ruler lines.

## Not done, deliberately

- **`SL_BLOCK`, `SOURCE_CHAIN_ID`, `BATCH_N` stay per-suite.** I tried hoisting them and `SL_BLOCK` collided: the execute abstract deliberately uses `401` where the proof suites use `555`. They are fixture values that happen to coincide in two files, not shared constants. `L1_CHAIN_ID = 5` in two unrelated suites is the same story.
- **The suites' comment density is left alone.** These files are 23–28% comments — and files this PR does not touch sit at 25–28%, so it is the repo's house style rather than something this PR introduced. Lowering the bar would be a repo-wide change. (The one clear outlier is the 40-line `AtomicInteropProofBuilder` contract docstring, which has roughly 15 lines of slack; happy to trim it on request.)

## Validation

- `forge build` clean, including the integration abstracts whose suites cannot run without `zkout` artifacts.
- Atomic-interop unit suites: **108 passed, 0 failed** — unchanged.
- Both new assertions mutation-verified as described above.
- Prettier clean; `l1-contracts/test` is in `.solhintignore`.

> The commit is unsigned. On squash merge GitHub re-signs, as it did for #2409.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
