### PR TITLE
test(atomic-interop): use abi.encodeCall where the encoding is type-checkable

### DIFF
--- a/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/_SharedL2ContractDeployer.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/_SharedL2ContractDeployer.sol
@@ -264,7 +264,7 @@ abstract contract SharedL2ContractDeployer is UtilsCallMockerTest, DeployIntegra
         );
         vm.mockCall(
             L2_BRIDGEHUB_ADDR,
-            abi.encodeWithSelector(IBridgehubBase.baseToken.selector, ERA_CHAIN_ID + 1),
+            abi.encodeCall(IBridgehubBase.baseToken, (ERA_CHAIN_ID + 1)),
             abi.encode(address(uint160(1)))
         );
         vm.mockCall(

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerRecover.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerRecover.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {Test} from "forge-std/Test.sol";
+import {AssetRouterBase} from "contracts/bridge/asset-router/AssetRouterBase.sol";
 
 import {AtomicFlowFixtures} from "./AtomicFlowFixtures.sol";
 
@@ -150,10 +151,10 @@ contract AtomicFlowManagerRecoverTest is Test {
     function test_recoverBundle_routerBackedValueDoesNotRefundSeparately() public {
         // Indirect (router-produced) calls force `value == 0` at send, so a `from == router` call takes
         // only the recoverAtomicCall branch — never bridgehubRecoverBaseToken (no double refund).
-        bytes memory callData = abi.encodeWithSignature("finalizeDeposit(uint256,bytes32,bytes)");
+        bytes memory callData = abi.encodeWithSelector(AssetRouterBase.finalizeDeposit.selector);
         vm.mockCall(
             L2_ASSET_ROUTER_ADDR,
-            abi.encodeWithSelector(IAtomicRecoverable.recoverAtomicCall.selector, DEST_CHAIN_ID, callData),
+            abi.encodeCall(IAtomicRecoverable.recoverAtomicCall, (DEST_CHAIN_ID, callData)),
             abi.encode(true)
         );
         vm.mockCallRevert(
@@ -166,7 +167,7 @@ contract AtomicFlowManagerRecoverTest is Test {
         // skips both branches.
         vm.expectCall(
             L2_ASSET_ROUTER_ADDR,
-            abi.encodeWithSelector(IAtomicRecoverable.recoverAtomicCall.selector, DEST_CHAIN_ID, callData)
+            abi.encodeCall(IAtomicRecoverable.recoverAtomicCall, (DEST_CHAIN_ID, callData))
         );
         manager.exposedRecoverBundle(_bundleFrom(L2_ASSET_ROUTER_ADDR, SOURCE_BASE_TOKEN_ASSET_ID, 1 ether, callData));
     }

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerRefund.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicFlowManagerRefund.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {Vm} from "forge-std/Vm.sol";
+import {IBridgehubBase} from "contracts/core/bridgehub/IBridgehubBase.sol";
 
 import {AtomicInteropProofBuilder} from "./AtomicInteropProofBuilder.sol";
 import {AtomicFlowFixtures} from "./AtomicFlowFixtures.sol";
@@ -104,7 +105,7 @@ contract AtomicFlowManagerRefundTest is AtomicInteropProofBuilder {
     function _registerRemoteLegSource(uint256 _chainId) internal {
         vm.mockCall(
             L2_BRIDGEHUB_ADDR,
-            abi.encodeWithSignature("baseTokenAssetId(uint256)", _chainId),
+            abi.encodeCall(IBridgehubBase.baseTokenAssetId, (_chainId)),
             abi.encode(keccak256(abi.encode("remote base token asset id", _chainId)))
         );
     }
@@ -528,12 +529,12 @@ contract AtomicFlowManagerRefundTest is AtomicInteropProofBuilder {
         // Both recovery calls must be reached once in the failed claim and once in the successful retry.
         vm.expectCall(
             L2_ASSET_ROUTER_ADDR,
-            abi.encodeWithSelector(IAtomicRecoverable.recoverAtomicCall.selector, RECOVERY_DEST_CHAIN_ID, hex"600d"),
+            abi.encodeCall(IAtomicRecoverable.recoverAtomicCall, (RECOVERY_DEST_CHAIN_ID, hex"600d")),
             2
         );
         vm.expectCall(
             L2_ASSET_ROUTER_ADDR,
-            abi.encodeWithSelector(IAtomicRecoverable.recoverAtomicCall.selector, RECOVERY_DEST_CHAIN_ID, hex"baad"),
+            abi.encodeCall(IAtomicRecoverable.recoverAtomicCall, (RECOVERY_DEST_CHAIN_ID, hex"baad")),
             2
         );
         vm.expectRevert("recovery boom");

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProofBuilder.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicInteropProofBuilder.sol
@@ -175,13 +175,13 @@ abstract contract AtomicInteropProofBuilder is AtomicPredeployFixture {
         address chainSender = address(uint160(uint256(keccak256(abi.encode("chainSender", _sourceChainId)))));
         vm.mockCall(
             msgRootBridgehub,
-            abi.encodeWithSelector(IBridgehubBase.getZKChain.selector, _sourceChainId),
+            abi.encodeCall(IBridgehubBase.getZKChain, (_sourceChainId)),
             abi.encode(chainSender)
         );
         vm.mockCall(chainSender, abi.encodeWithSelector(IGetters.getZKsyncOS.selector), abi.encode(true));
         vm.mockCall(
             chainSender,
-            abi.encodeWithSelector(IGetters.l2LogsRootHash.selector, uint256(0)),
+            abi.encodeCall(IGetters.l2LogsRootHash, (uint256(0))),
             abi.encode(ChainBatchRootTree.genesisChainBatchRoot())
         );
         vm.prank(msgRootBridgehub);
@@ -446,13 +446,15 @@ abstract contract AtomicInteropProofBuilder is AtomicPredeployFixture {
     function _expectRootAuthentication(ImtProof memory _proof, uint256 _imtRootLeafIndex) internal {
         vm.expectCall(
             address(L2_MESSAGE_VERIFICATION),
-            abi.encodeWithSelector(
-                L2_MESSAGE_VERIFICATION.proveL2LeafInclusionShared.selector,
-                _proof.sourceChainId,
-                _proof.batchNumber,
-                _imtRootLeafIndex,
-                _proof.chainImtRoot,
-                _proof.settlementProof
+            abi.encodeCall(
+                L2_MESSAGE_VERIFICATION.proveL2LeafInclusionShared,
+                (
+                    _proof.sourceChainId,
+                    _proof.batchNumber,
+                    _imtRootLeafIndex,
+                    _proof.chainImtRoot,
+                    _proof.settlementProof
+                )
             )
         );
     }

--- a/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicRecoveryForgery.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/atomic-interop/AtomicRecoveryForgery.t.sol
@@ -117,12 +117,7 @@ contract AtomicRecoveryForgeryTest is Test {
             _amount: amount,
             _erc20Metadata: bytes("")
         });
-        bytes memory callData = abi.encodeWithSelector(
-            AssetRouterBase.finalizeDeposit.selector,
-            block.chainid,
-            assetId,
-            mintData
-        );
+        bytes memory callData = abi.encodeCall(AssetRouterBase.finalizeDeposit, (block.chainid, assetId, mintData));
 
         InteropCall[] memory calls = new InteropCall[](1);
         calls[0] = InteropCall({


### PR DESCRIPTION
## What ❔

`abi.encodeCall` type-checks its arguments against the function signature; `encodeWithSelector` and `encodeWithSignature` do not. This converts every site in this PR's files where that is possible.

| Change | Count |
| --- | ---: |
| `abi.encodeWithSelector(IFoo.bar.selector, args)` → `abi.encodeCall(IFoo.bar, (args))` | 9 |
| `abi.encodeWithSignature("baseTokenAssetId(uint256)", _chainId)` → `abi.encodeCall(IBridgehubBase.baseTokenAssetId, (_chainId))` | 1 |
| `abi.encodeWithSignature("finalizeDeposit(uint256,bytes32,bytes)")` → `abi.encodeWithSelector(AssetRouterBase.finalizeDeposit.selector)` | 1 |

The last one is selector-only with no arguments, so `encodeCall` cannot express it — but dropping the signature string still stops a typo there from silently producing a different selector.

**The conversion found no latent bug.** Everything compiled first time, which means the untyped encodings were all correctly typed already. The value is that they can no longer drift silently when a signature changes.

## Why the scope is 11 sites and not ~197

`encodeCall` is the wrong tool for the large majority of encoding sites in these suites, so converting them would break or weaken tests:

- **103 sites encode custom errors** — `vm.expectRevert(abi.encodeWithSelector(SomeError.selector, ...))`. `abi.encodeCall` takes a *function pointer*, and errors are not functions. There is no equivalent, so these must stay.
- **52 sites deliberately encode a selector only**, with no arguments, so `vm.mockCall` / `vm.expectCall` match a call *whatever its arguments are*. `encodeCall` requires the full argument list, which would narrow the match and change what those tests assert — in the mock cases the test often does not control the arguments at all.

That leaves 11 reachable sites in this PR's files. A further **18 convertible sites exist in suites this PR does not touch**; left alone as unrelated churn, and easy to sweep separately if wanted.

## Validation

- `forge build` clean, including the integration abstracts.
- Atomic-interop unit suites: **108 passed, 0 failed** — unchanged, before and after prettier.
- Prettier clean; `l1-contracts/test` is in `.solhintignore`.

> The commit is unsigned; GitHub re-signs on squash merge, as with the earlier PRs on this branch.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
