### PR TITLE
docs: remove duplicate words from contract comments

### DIFF
--- a/l1-contracts/contracts/bridge/ntv/INativeTokenVault.sol
+++ b/l1-contracts/contracts/bridge/ntv/INativeTokenVault.sol
@@ -33,7 +33,7 @@ interface INativeTokenVault {
     /// @dev This function is used to ensure that the token is registered with the NTV.
     function ensureTokenIsRegistered(address _nativeToken) external returns (bytes32);
 
-    /// @notice Used to get the the ERC20 data for a token
+    /// @notice Used to get the ERC20 data for a token
     function getERC20Getters(address _token, uint256 _originChainId) external view returns (bytes memory);
 
     /// @notice Used to get the token address of an assetId

--- a/l1-contracts/contracts/governance/PermanentRestriction.sol
+++ b/l1-contracts/contracts/governance/PermanentRestriction.sol
@@ -274,7 +274,7 @@ contract PermanentRestriction is Restriction, IPermanentRestriction, Ownable2Ste
 
     /// @notice Tries to get the new admin from the migration.
     /// @param _call The call data.
-    /// @return Returns a tuple of of the new admin and whether the transaction is indeed the migration.
+    /// @return Returns a tuple of the new admin and whether the transaction is indeed the migration.
     /// If the second item is `false`, the caller should ignore the first value.
     /// @dev If any other error is returned, it is assumed to be out of gas or some other unexpected
     /// error that should be bubbled up by the caller.

--- a/l1-contracts/contracts/state-transition/libraries/BatchDecoder.sol
+++ b/l1-contracts/contracts/state-transition/libraries/BatchDecoder.sol
@@ -103,7 +103,7 @@ library BatchDecoder {
     /// @notice Decodes proof data from a calldata byte array into the previous batch, an array of proved batches, and a proof array.
     /// @param _proofData The calldata byte array containing the data for proving batches.
     /// @return prevBatch The batch information before the batches to be verified.
-    /// @return provedBatches An array containing the the batches to be verified.
+    /// @return provedBatches An array containing the batches to be verified.
     /// @return proof An array containing the proof for the verifier.
     function _decodeProofData(
         bytes calldata _proofData
@@ -134,7 +134,7 @@ library BatchDecoder {
     /// @param _processBatchFrom The expected batch number of the first batch in the array.
     /// @param _processBatchTo The expected batch number of the last batch in the array.
     /// @return prevBatch The batch information before the batches to be verified.
-    /// @return provedBatches An array containing the the batches to be verified.
+    /// @return provedBatches An array containing the batches to be verified.
     /// @return proof An array containing the proof for the verifier.
     function decodeAndCheckProofData(
         bytes calldata _proofData,

--- a/system-contracts/contracts/SystemContext.sol
+++ b/system-contracts/contracts/SystemContext.sol
@@ -104,7 +104,7 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, SystemContra
         origin = _newOrigin;
     }
 
-    /// @notice Set the the current gas price.
+    /// @notice Set the current gas price.
     /// @param _gasPrice The new tx gasPrice.
     function setGasPrice(uint256 _gasPrice) external onlyCallFromBootloader {
         gasPrice = _gasPrice;
@@ -263,7 +263,7 @@ contract SystemContext is ISystemContext, ISystemContextDeprecated, SystemContra
         uint128 _newTimestamp
     ) internal {
         if (virtualBlockUpgradeInfo.virtualBlockFinishL2Block != 0) {
-            // No need to to do anything about virtual blocks anymore
+            // No need to do anything about virtual blocks anymore
             // All the info is the same as for L2 blocks.
             currentVirtualL2BlockInfo = currentL2BlockInfo;
             return;


### PR DESCRIPTION
# What ❔

Remove six duplicated words from contract documentation comments in:

- `SystemContext`;
- `PermanentRestriction`;
- `BatchDecoder`;
- `INativeTokenVault`.

Examples include “Set the the current gas price” and “an array containing the the batches”. No Solidity statements, interfaces, storage layout, or generated artifacts change.

## Why ❔

These comments feed source-level and generated contract documentation. Removing duplicated words makes the API descriptions clearer without affecting deployed behavior.

## Checklist

- [x] PR title corresponds to the body.
- [ ] Tests added/updated (not applicable: comments only).
- [x] Documentation comments have been updated.