### PR TITLE
docs(upgrade-envs): describe the zksync-os-integration-test env as it is used

### DIFF
--- a/l1-contracts/upgrade-envs/permanent-values/zksync-os-integration-test.toml
+++ b/l1-contracts/upgrade-envs/permanent-values/zksync-os-integration-test.toml
@@ -1,11 +1,17 @@
-# Permanent values for the `v30-local-fixture` environment: the frozen v30.2
-# L1-settling-only local chain committed in zksync-os-integration-tests
-# (tests/local-chains/v30.2). Identical to `local.toml` except it has no
+# Permanent values for the `zksync-os-integration-test` environment: the frozen
+# L1-settling-only local chains committed in zksync-os-integration-tests under
+# `tests/local-chains/`. Identical to `local.toml` except it has no
 # `[legacy_gateway]` section — this fixture never had a gateway chain, so the
 # stage-2 decommission calls generated from that section would revert with
-# SettlementLayersMustSettleOnL1().
+# SettlementLayersMustSettleOnL1(), and `local.toml` names as that gateway a
+# chain id the fixture uses for a chain being upgraded.
 #
-# Paired by basename with `../v0.31.0-interopB/v30-local-fixture.toml`.
+# Only the absence of `[legacy_gateway]` and `era_chain_id` are read on this
+# path; the addresses below are informational, since the integration test passes
+# the bridgehub and CTM explicitly.
+#
+# Paired by basename with the upgrade input of whichever release the fixture is
+# taken to (currently `../v0.33.0-atomic-interop/zksync-os-integration-test.toml`).
 
 era_chain_id = 6565
 is_zk_sync_os = true

--- a/l1-contracts/upgrade-envs/v0.33.0-atomic-interop/zksync-os-integration-test.toml
+++ b/l1-contracts/upgrade-envs/v0.33.0-atomic-interop/zksync-os-integration-test.toml
@@ -1,10 +1,16 @@
-# Upgrade input for the frozen local chain committed in zksync-os-integration-tests
-# (`tests/local-chains/`, currently v31.0 / chain 506), used by its v31 -> v33 upgrade test.
+# Upgrade input for the frozen local ecosystem committed in zksync-os-integration-tests
+# (`tests/local-chains/`, currently v31.1: a rollup and a validium), used by its v31 -> v33
+# upgrade test.
 #
 # Same content as `local.toml` in this directory — it is the same kind of freshly deployed anvil
 # ecosystem — under its own basename so the fixture is addressable as
-# `--env zksync-os-integration-test`, which also picks
+# `--env zksync-os-integration-test`, which also picks the gateway-less
 # `permanent-values/zksync-os-integration-test.toml`.
+#
+# The values below are inert on this path and kept for parity with `local.toml`: the target
+# protocol version and chain-creation params come from `configs/genesis/zksync-os/latest.json`
+# (`DefaultCoreUpgrade.loadProtocolVersionFromGenesis`), the old version from the CTM on chain,
+# and the bridgehub/CTM addresses from the caller's `--bridgehub` / `--ctm-proxy`.
 
 era_chain_id = 6565
 testnet_verifier = true


### PR DESCRIPTION
Corrects the `zksync-os-integration-test` upgrade-env files: they still described the v30.2 single-chain fixture and a `v30-local-fixture` basename that no longer exists.

**How:** rewrites the two headers (`permanent-values/` and `v0.33.0-atomic-interop/`) to say what the environment is, why it exists separately from `local.toml` (no `[legacy_gateway]`), and which of its values the upgrade path actually reads. Comments only.