### PR TITLE
fix(protocol-ops): make ecosystem and chain deploys work on public testnets

### DIFF
--- a/protocol-ops/src/commands/chain/init.rs
+++ b/protocol-ops/src/commands/chain/init.rs
@@ -51,6 +51,13 @@ pub struct ChainInitArgs {
     #[clap(long, help_heading = "Input")]
     pub bridgehub: Address,
 
+    /// CTM proxy address. Optional: discovered from L1 when omitted. Pass it for
+    /// the first chain on a fresh ecosystem, where discovery has to fall back to
+    /// scanning `ChainTypeManagerAdded` from block 0 and hosted RPCs cap the
+    /// `eth_getLogs` range.
+    #[clap(long, help_heading = "Input")]
+    pub ctm_proxy: Option<Address>,
+
     /// Owner address for the chain (default: sender)
     #[clap(long, help_heading = "Signers")]
     pub owner: Option<Address>,
@@ -128,12 +135,20 @@ pub async fn run(args: ChainInitArgs) -> anyhow::Result<()> {
             .context("resolving bridgehub.admin() from L1")?;
     let bridgehub_admin = runner.prepare_sender(bridgehub_admin_addr).await?;
 
-    // Discover CTM proxy from L1.
-    let ctm_proxy =
-        crate::common::l1_contracts::discover_ctm_proxy(&runner.rpc_url, args.bridgehub)
-            .await
-            .context("Failed to discover CTM proxy from L1")?;
-    logger::info(format!("CTM proxy (from L1): {:#x}", ctm_proxy));
+    let ctm_proxy = match args.ctm_proxy {
+        Some(ctm) => {
+            logger::info(format!("CTM proxy (from --ctm-proxy): {:#x}", ctm));
+            ctm
+        }
+        None => {
+            let ctm =
+                crate::common::l1_contracts::discover_ctm_proxy(&runner.rpc_url, args.bridgehub)
+                    .await
+                    .context("Failed to discover CTM proxy from L1")?;
+            logger::info(format!("CTM proxy (from L1): {:#x}", ctm));
+            ctm
+        }
+    };
 
     // Resolve VM type from CTM.
     let vm_type = {

--- a/protocol-ops/src/commands/dev/execute_safe.rs
+++ b/protocol-ops/src/commands/dev/execute_safe.rs
@@ -44,19 +44,23 @@ const GAS_ESTIMATE_BUFFER_BPS: u64 = 12_500;
 /// ~30M on a quiet chain; we cap below that so a single tx can never equal
 /// or exceed the block limit (which reth rejects with `gas limit too high`).
 const PER_TX_GAS_LIMIT_CAP: u64 = 20_000_000;
-/// Floor gas price (1 gwei). Used when the node returns `eth_gasPrice` below
-/// it (anvil/reth on a quiet local chain reports near-zero).
-const GAS_PRICE_FLOOR_WEI: u128 = 1_000_000_000;
+/// Floor gas price (5 gwei). Used when the node returns `eth_gasPrice` below
+/// it (anvil/reth on a quiet local chain reports near-zero), and to keep
+/// public-testnet broadcasts from sitting in the mempool when Sepolia's
+/// reported price briefly dips.
+const GAS_PRICE_FLOOR_WEI: u128 = 5_000_000_000;
 /// Multiplier (in basis points) applied to live `eth_gasPrice` so our txs
 /// outbid the base-fee floor on a busy public chain (Sepolia / mainnet). 300%
 /// gives us ~3x headroom over chain median which is what gets txs included
 /// within 1-2 blocks instead of hanging in the mempool for 30+ minutes.
 const GAS_PRICE_MULTIPLIER_BPS: u128 = 30_000;
 
-/// Receipt polling interval. Alloy's default is tuned for public chains;
-/// tighten it so per-tx receipt polling doesn't dominate bundle latency on
-/// anvil's instamine or reth's sub-second block time.
-const RECEIPT_POLL_INTERVAL_MS: u64 = 50;
+/// Receipt polling interval. Kept well above alloy's default only where it
+/// matters: a 50ms poll across a ~100-tx bundle trips per-second compute
+/// limits on hosted RPCs (Alchemy returns HTTP 429), which aborts the
+/// broadcast mid-bundle. 1.5s still resolves a receipt within a block on a
+/// public chain, and local anvil/reth bundles pay a bounded extra wait.
+const RECEIPT_POLL_INTERVAL_MS: u64 = 1_500;
 
 /// Returns a legacy `gasPrice` that's high enough to land within ~1-2 blocks
 /// on busy public chains, but never below `GAS_PRICE_FLOOR_WEI` so local

--- a/protocol-ops/src/commands/ecosystem/init.rs
+++ b/protocol-ops/src/commands/ecosystem/init.rs
@@ -59,6 +59,10 @@ pub struct EcosystemInitArgs {
     /// CREATE2 factory salt (random by default).
     #[clap(long, help_heading = "Advanced input")]
     pub create2_factory_salt: Option<B256>,
+    /// L1 WETH token address (default: mainnet WETH). Set this on any other
+    /// L1, since it is immutable in the deployed bridge contracts.
+    #[clap(long, help_heading = "Advanced input")]
+    pub token_weth_address: Option<Address>,
 }
 
 // ── run() ───────────────────────────────────────────────────────────────────
@@ -92,6 +96,7 @@ pub async fn run(args: EcosystemInitArgs) -> anyhow::Result<()> {
         with_testnet_verifier: args.with_testnet_verifier,
         zk_token_asset_id,
         create2_factory_salt: args.create2_factory_salt,
+        token_weth_address: args.token_weth_address,
     };
     let output = ecosystem_init(&mut runner, &sender, &owner, &input).await?;
 
@@ -128,6 +133,7 @@ pub async fn ecosystem_init(
         owner: owner.address,
         era_chain_id: input.era_chain_id,
         create2_factory_salt: input.create2_factory_salt,
+        token_weth_address: input.token_weth_address,
     };
     let hub_output = hub_init(runner, sender, owner, &hub_input).await?;
     let bridgehub_addr = hub_output.deployed_addresses.bridgehub.bridgehub_proxy_addr;
@@ -161,6 +167,7 @@ pub struct EcosystemInitInput {
     pub with_testnet_verifier: bool,
     pub zk_token_asset_id: Option<B256>,
     pub create2_factory_salt: Option<B256>,
+    pub token_weth_address: Option<Address>,
 }
 
 #[derive(Serialize)]

--- a/protocol-ops/src/commands/hub/deploy.rs
+++ b/protocol-ops/src/commands/hub/deploy.rs
@@ -17,6 +17,10 @@ pub struct DeployInput {
     pub owner: Address,
     pub era_chain_id: u64,
     pub create2_factory_salt: Option<B256>,
+    /// L1 WETH token. Baked as an immutable into the `L1AssetRouter` and
+    /// `L1NativeTokenVault` implementations, so it cannot be changed after
+    /// deployment without an implementation upgrade. Defaults to mainnet WETH.
+    pub token_weth_address: Option<Address>,
 }
 
 /// Deploy hub contracts and return the output.
@@ -29,6 +33,10 @@ pub fn deploy(
 
     if let Some(salt) = input.create2_factory_salt {
         initial_config.create2_factory_salt = salt;
+    }
+
+    if let Some(weth) = input.token_weth_address {
+        initial_config.token_weth_address = weth;
     }
 
     let deploy_config = DeployL1Config::new(

--- a/protocol-ops/src/commands/hub/deploy.rs
+++ b/protocol-ops/src/commands/hub/deploy.rs
@@ -8,6 +8,7 @@ use crate::common::{
     traits::{ReadConfig, SaveConfig},
     wallets::Wallet,
 };
+use crate::types::L1Network;
 use alloy::primitives::{Address, B256};
 use serde::Serialize;
 
@@ -19,7 +20,8 @@ pub struct DeployInput {
     pub create2_factory_salt: Option<B256>,
     /// L1 WETH token. Baked as an immutable into the `L1AssetRouter` and
     /// `L1NativeTokenVault` implementations, so it cannot be changed after
-    /// deployment without an implementation upgrade. Defaults to mainnet WETH.
+    /// deployment without an implementation upgrade. When omitted it is
+    /// resolved from the L1 the deploy is running against.
     pub token_weth_address: Option<Address>,
 }
 
@@ -35,9 +37,10 @@ pub fn deploy(
         initial_config.create2_factory_salt = salt;
     }
 
-    if let Some(weth) = input.token_weth_address {
-        initial_config.token_weth_address = weth;
-    }
+    initial_config.token_weth_address = match input.token_weth_address {
+        Some(weth) => weth,
+        None => L1Network::from_l1_rpc(&runner.rpc_url)?.weth_address()?,
+    };
 
     let deploy_config = DeployL1Config::new(
         input.owner,

--- a/protocol-ops/src/commands/hub/init.rs
+++ b/protocol-ops/src/commands/hub/init.rs
@@ -34,6 +34,10 @@ pub struct HubInitArgs {
     /// CREATE2 factory salt
     #[clap(long, help_heading = "Advanced input")]
     pub create2_factory_salt: Option<B256>,
+    /// L1 WETH token address (default: mainnet WETH). Set this on any other
+    /// L1, since it is immutable in the deployed bridge contracts.
+    #[clap(long, help_heading = "Advanced input")]
+    pub token_weth_address: Option<Address>,
 }
 
 // ── run() ───────────────────────────────────────────────────────────────────
@@ -47,6 +51,7 @@ pub async fn run(args: HubInitArgs) -> anyhow::Result<()> {
         owner: owner.address,
         era_chain_id: args.era_chain_id,
         create2_factory_salt: args.create2_factory_salt,
+        token_weth_address: args.token_weth_address,
     };
     let output = hub_init(&mut runner, &sender, &owner, &input).await?;
     let bridgehub_addr = output.deployed_addresses.bridgehub.bridgehub_proxy_addr;
@@ -64,6 +69,7 @@ pub struct HubInitInput {
     pub owner: Address,
     pub era_chain_id: u64,
     pub create2_factory_salt: Option<B256>,
+    pub token_weth_address: Option<Address>,
 }
 
 /// Initialize hub: deploy contracts and accept ownership.
@@ -78,6 +84,7 @@ pub async fn hub_init(
         owner: input.owner,
         era_chain_id: input.era_chain_id,
         create2_factory_salt: input.create2_factory_salt,
+        token_weth_address: input.token_weth_address,
     };
     let t = std::time::Instant::now();
     let output = deploy(runner, deployer, &deploy_input)?;

--- a/protocol-ops/src/common/addresses.rs
+++ b/protocol-ops/src/common/addresses.rs
@@ -4,11 +4,10 @@ pub const ZERO_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
 /// ETH pseudo-token address used by chain registration configs.
 pub const ETH_ADDRESS: &str = "0x0000000000000000000000000000000000000001";
 
-/// Mainnet WETH address used by the default L1 deployment config.
+/// Canonical mainnet WETH. Resolved via `L1Network::weth_address`.
 pub const MAINNET_WETH_ADDRESS: &str = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 
-/// Sepolia WETH address. Pass via `--token-weth-address` when deploying an
-/// ecosystem on Sepolia; the default config carries the mainnet address.
+/// Canonical Sepolia WETH. Resolved via `L1Network::weth_address`.
 pub const SEPOLIA_WETH_ADDRESS: &str = "0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9";
 
 /// Locally deployed ZK token address used by interop fixtures.

--- a/protocol-ops/src/common/addresses.rs
+++ b/protocol-ops/src/common/addresses.rs
@@ -7,6 +7,10 @@ pub const ETH_ADDRESS: &str = "0x0000000000000000000000000000000000000001";
 /// Mainnet WETH address used by the default L1 deployment config.
 pub const MAINNET_WETH_ADDRESS: &str = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 
+/// Sepolia WETH address. Pass via `--token-weth-address` when deploying an
+/// ecosystem on Sepolia; the default config carries the mainnet address.
+pub const SEPOLIA_WETH_ADDRESS: &str = "0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9";
+
 /// Locally deployed ZK token address used by interop fixtures.
 pub const LOCAL_ZK_TOKEN_ADDRESS: &str = "0x8207187d1682B3ebaF2e1bdE471aC9d5B886fD93";
 

--- a/protocol-ops/src/types/l1_network.rs
+++ b/protocol-ops/src/types/l1_network.rs
@@ -1,11 +1,13 @@
 use std::str::FromStr;
 
-use alloy::primitives::B256;
+use alloy::primitives::{Address, B256};
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use strum::EnumIter;
 
-use crate::common::addresses::{LOCAL_ZK_TOKEN_ADDRESS, LOCAL_ZK_TOKEN_ASSET_ID};
+use crate::common::addresses::{
+    LOCAL_ZK_TOKEN_ADDRESS, LOCAL_ZK_TOKEN_ASSET_ID, MAINNET_WETH_ADDRESS, SEPOLIA_WETH_ADDRESS,
+};
 
 #[derive(
     Copy,
@@ -40,6 +42,25 @@ impl L1Network {
             11155111 => Ok(Self::Sepolia),
             other => anyhow::bail!("Unrecognized L1 chain ID: {}", other),
         }
+    }
+
+    /// Canonical WETH for this L1. Unlike the ZK token below, WETH has a
+    /// single well-known deployment per network, so it is resolved here
+    /// rather than carried per env. It is baked as an immutable into
+    /// `L1AssetRouter` and `L1NativeTokenVault`, so a wrong value can only be
+    /// corrected by an implementation upgrade. There is deliberately no
+    /// cross-network fallback: a network without a canonical address must
+    /// pass `--token-weth-address` rather than silently inherit another
+    /// network's WETH.
+    pub fn weth_address(&self) -> anyhow::Result<Address> {
+        let raw = match self {
+            L1Network::Mainnet => MAINNET_WETH_ADDRESS,
+            L1Network::Sepolia => SEPOLIA_WETH_ADDRESS,
+            L1Network::Holesky | L1Network::Localhost => {
+                anyhow::bail!("no canonical WETH address for {self}; pass --token-weth-address")
+            }
+        };
+        Ok(Address::from_str(raw).expect("hardcoded WETH address must parse"))
     }
 
     /// `zk_token_asset_id` for live networks is intentionally read from


### PR DESCRIPTION
Four issues hit deploying a v33 ZKsync OS ecosystem to Sepolia, patched locally to get through. Upstreaming so the next person doesn't rediscover them.

- **L1 WETH was mainnet-only.** Any non-mainnet deploy baked mainnet WETH into the `L1AssetRouter` and `L1NativeTokenVault` immutables, fixable afterwards only by an implementation upgrade. Now resolved from `L1Network`, with `--token-weth-address` to override. Holesky and Localhost error rather than inherit another network's WETH.
- **`RECEIPT_POLL_INTERVAL_MS` 50 -> 1500.** Tuned for anvil instamine. Across a ~100-tx bundle it trips hosted-RPC limits; a broadcast died after 8 transactions on Alchemy HTTP 429.
- **`GAS_PRICE_FLOOR_WEI` 1 -> 5 gwei.** Effective price `max(3x live, 5 gwei)`, which lands within a block or two on Sepolia.
- **`--ctm-proxy` on `chain init`.** Discovery scans from block 0 and hosted RPCs cap `eth_getLogs`. Only needed for the first chain on a fresh ecosystem; unchanged when omitted.

`cargo check`, `fmt`, and `clippy --all-targets` clean.
