### PR TITLE
feat(mailbox): cap caller-supplied L1->L2 gas at 15M

### DIFF
--- a/l1-contracts/contracts/common/Config.sol
+++ b/l1-contracts/contracts/common/Config.sol
@@ -165,17 +165,18 @@ uint256 constant SERVICE_TX_MAX_GAS_LIMIT = 72_000_000;
 /// @dev The maximum transaction *body* gas that a caller-supplied L1->L2 transaction may request on
 /// an EraVM chain.
 /// @dev L1->L2 transactions must eventually be included by the operator (priority expiration and
-/// priority mode) and a single transaction cannot be split across batches. An unbounded
-/// caller-supplied gas limit is therefore a DoS vector: anyone can force the operator to execute and
-/// prove an arbitrarily expensive transaction. This cap is enforced in addition to the per-chain
+/// priority mode) and a single transaction cannot be split across batches, so the work a single one
+/// can impose on execution and proving has to be bounded at admission. This cap provides that bound
+/// for gas limits that come from the caller. It is enforced in addition to the per-chain
 /// `priorityTxMaxGasLimit`, whichever of the two is lower.
 /// @dev The bound is on the transaction body, i.e. on `l2GasLimit` after
 /// `TransactionValidator.getTransactionBodyGasLimit` subtracts the batch overhead, so the largest
 /// accepted `l2GasLimit` exceeds this constant by that overhead (at least
 /// `TX_SLOT_OVERHEAD_L2_GAS`). Execution is still bounded by this constant.
 /// @dev Two kinds of transaction are deliberately exempt: protocol-authored ones (see
-/// `SERVICE_TX_MAX_GAS_LIMIT`) and those on ZKsync OS chains, which are bounded in-circuit by
-/// `zksyncOSMaxTxGasLimit` instead (see `ZKSYNC_OS_DEFAULT_MAX_TX_GAS_LIMIT`).
+/// `SERVICE_TX_MAX_GAS_LIMIT`) and those on ZKsync OS chains, where the bootloader clamps an L1
+/// transaction's native computational resources independently of its gas limit, so raising the gas
+/// limit buys no additional work.
 uint256 constant USER_PRIORITY_TX_MAX_GAS_LIMIT = 15_000_000;
 
 /// @dev the address used to identify eth as the base token for chains.

--- a/l1-contracts/contracts/common/Config.sol
+++ b/l1-contracts/contracts/common/Config.sol
@@ -152,6 +152,32 @@ uint256 constant MEMORY_OVERHEAD_GAS = 10;
 /// @dev The maximum gas limit for a priority transaction in L2.
 uint256 constant PRIORITY_TX_MAX_GAS_LIMIT = 72_000_000;
 
+/// @dev The gas limit used by the two protocol-authored L1->L2 transactions that pass through
+/// `Mailbox._requestL2TransactionFree`: service transactions (`requestL2ServiceTransaction`) and the
+/// Gateway relay wrap (`_wrapRequest`).
+/// @dev The gas limit on these is fixed by the protocol rather than supplied by a caller, so they
+/// are exempt from `USER_PRIORITY_TX_MAX_GAS_LIMIT` and remain bounded only by the chain's
+/// `priorityTxMaxGasLimit`.
+/// @dev Upgrade and genesis transactions are authored too, but carry their own gas limit; see
+/// `PRIORITY_TX_MAX_GAS_LIMIT`.
+uint256 constant SERVICE_TX_MAX_GAS_LIMIT = 72_000_000;
+
+/// @dev The maximum transaction *body* gas that a caller-supplied L1->L2 transaction may request on
+/// an EraVM chain.
+/// @dev L1->L2 transactions must eventually be included by the operator (priority expiration and
+/// priority mode) and a single transaction cannot be split across batches. An unbounded
+/// caller-supplied gas limit is therefore a DoS vector: anyone can force the operator to execute and
+/// prove an arbitrarily expensive transaction. This cap is enforced in addition to the per-chain
+/// `priorityTxMaxGasLimit`, whichever of the two is lower.
+/// @dev The bound is on the transaction body, i.e. on `l2GasLimit` after
+/// `TransactionValidator.getTransactionBodyGasLimit` subtracts the batch overhead, so the largest
+/// accepted `l2GasLimit` exceeds this constant by that overhead (at least
+/// `TX_SLOT_OVERHEAD_L2_GAS`). Execution is still bounded by this constant.
+/// @dev Two kinds of transaction are deliberately exempt: protocol-authored ones (see
+/// `SERVICE_TX_MAX_GAS_LIMIT`) and those on ZKsync OS chains, which are bounded in-circuit by
+/// `zksyncOSMaxTxGasLimit` instead (see `ZKSYNC_OS_DEFAULT_MAX_TX_GAS_LIMIT`).
+uint256 constant USER_PRIORITY_TX_MAX_GAS_LIMIT = 15_000_000;
+
 /// @dev the address used to identify eth as the base token for chains.
 address constant ETH_TOKEN_ADDRESS = address(1);
 

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol
@@ -537,6 +537,9 @@ contract MailboxFacet is ZKChainBase, IMailboxImpl, MessageVerification, IMailbo
         });
 
         L2CanonicalTransaction memory transaction;
+        // Both callers hardcode `SERVICE_TX_MAX_GAS_LIMIT`, so the gas limit here is authored by
+        // the protocol rather than supplied by whoever triggered the call, and stays on the chain
+        // limit. Using `_userPriorityTxMaxGasLimit()` would reject those transactions outright.
         (transaction, canonicalTxHash) = _validateTx(params, s.priorityTxMaxGasLimit);
         _writePriorityOp(transaction, params.request.factoryDeps, canonicalTxHash);
     }
@@ -589,13 +592,16 @@ contract MailboxFacet is ZKChainBase, IMailboxImpl, MessageVerification, IMailbo
     /// @notice The transaction body gas ceiling for L1->L2 transactions whose gas limit comes from
     /// the caller.
     /// @dev Such transactions must eventually be included by the operator and cannot be split
-    /// across batches, so anyone could otherwise force an arbitrarily expensive transaction onto
-    /// the chain. `USER_PRIORITY_TX_MAX_GAS_LIMIT` bounds that without needing to be configured per
+    /// across batches, so the work a single one can impose has to be bounded at admission.
+    /// `USER_PRIORITY_TX_MAX_GAS_LIMIT` provides that bound without needing to be configured per
     /// chain, while a chain that has been set stricter than the constant keeps its own value.
-    /// @dev ZKsync OS chains are excluded: `Executor` commits `zksyncOSMaxTxGasLimit` to the batch
-    /// public input, so their per-transaction bound is enforced in-circuit for every transaction
-    /// rather than only at L1 admission, and a chain admin may deliberately raise it above the
-    /// EraVM constant. Applying the constant here would cap it back down unreachably.
+    /// @dev ZKsync OS chains are excluded, because there the gas limit is not what bounds the work:
+    /// the bootloader clamps an L1 transaction's native computational resources to a fixed ceiling
+    /// (`MAX_NATIVE_COMPUTATIONAL`), and at the constant native price used for L1 transactions that
+    /// clamp binds far below any gas limit worth requesting. `zksyncOSMaxTxGasLimit`, which `Executor` commits to the batch
+    /// public input, is applied when validating ordinary L2 transactions; ABI-encoded L1 priority
+    /// transactions take a separate bootloader path that deliberately does not reject them on gas
+    /// grounds. A chain admin may also raise that value above the EraVM constant on purpose.
     function _userPriorityTxMaxGasLimit() internal view returns (uint256) {
         uint256 chainLimit = s.priorityTxMaxGasLimit;
         if (s.zksyncOS) {

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol
@@ -540,6 +540,10 @@ contract MailboxFacet is ZKChainBase, IMailboxImpl, MessageVerification, IMailbo
         // Both callers hardcode `SERVICE_TX_MAX_GAS_LIMIT`, so the gas limit here is authored by
         // the protocol rather than supplied by whoever triggered the call, and stays on the chain
         // limit. Using `_userPriorityTxMaxGasLimit()` would reject those transactions outright.
+        // Protocol-authored constrains the gas limit, not who may reach this path:
+        // `ChainRegistrationSender.registerChain` is callable by anyone, bounded only by being
+        // one-shot per (chainToBeRegistered, chainRegisteredOn) pair. Bounding that belongs in
+        // access control there, not in a cap on a constant the protocol picked.
         (transaction, canonicalTxHash) = _validateTx(params, s.priorityTxMaxGasLimit);
         _writePriorityOp(transaction, params.request.factoryDeps, canonicalTxHash);
     }

--- a/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol
+++ b/l1-contracts/contracts/state-transition/chain-deps/facets/Mailbox.sol
@@ -30,7 +30,9 @@ import {
     MAX_NEW_FACTORY_DEPS,
     REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
     SERVICE_TRANSACTION_SENDER,
+    SERVICE_TX_MAX_GAS_LIMIT,
     SETTLEMENT_LAYER_RELAY_SENDER,
+    USER_PRIORITY_TX_MAX_GAS_LIMIT,
     PAUSE_DEPOSITS_TIME_WINDOW_START_TESTNET,
     PAUSE_DEPOSITS_TIME_WINDOW_START_MAINNET
 } from "../../../common/Config.sol";
@@ -387,7 +389,7 @@ contract MailboxFacet is ZKChainBase, IMailboxImpl, MessageVerification, IMailbo
                 mintValue: 0,
                 l2Value: 0,
                 // Very large amount
-                l2GasLimit: 72_000_000,
+                l2GasLimit: SERVICE_TX_MAX_GAS_LIMIT,
                 l2Calldata: data,
                 l2GasPerPubdataByteLimit: REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
                 factoryDeps: new bytes[](0),
@@ -408,7 +410,7 @@ contract MailboxFacet is ZKChainBase, IMailboxImpl, MessageVerification, IMailbo
                 mintValue: 0,
                 l2Value: 0,
                 // Very large amount
-                l2GasLimit: 72_000_000,
+                l2GasLimit: SERVICE_TX_MAX_GAS_LIMIT,
                 l2Calldata: _l2Calldata,
                 l2GasPerPubdataByteLimit: REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
                 factoryDeps: new bytes[](0),
@@ -503,7 +505,7 @@ contract MailboxFacet is ZKChainBase, IMailboxImpl, MessageVerification, IMailbo
             request.sender = AddressAliasHelper.applyL1ToL2Alias(request.sender);
         }
         L2CanonicalTransaction memory transaction;
-        (transaction, canonicalTxHash) = _validateTx(_params);
+        (transaction, canonicalTxHash) = _validateTx(_params, _userPriorityTxMaxGasLimit());
 
         _writePriorityOp(transaction, _params.request.factoryDeps, canonicalTxHash);
         if (s.settlementLayer != address(0)) {
@@ -535,7 +537,7 @@ contract MailboxFacet is ZKChainBase, IMailboxImpl, MessageVerification, IMailbo
         });
 
         L2CanonicalTransaction memory transaction;
-        (transaction, canonicalTxHash) = _validateTx(params);
+        (transaction, canonicalTxHash) = _validateTx(params, s.priorityTxMaxGasLimit);
         _writePriorityOp(transaction, params.request.factoryDeps, canonicalTxHash);
     }
 
@@ -564,8 +566,12 @@ contract MailboxFacet is ZKChainBase, IMailboxImpl, MessageVerification, IMailbo
         });
     }
 
+    /// @param _maxGasLimit The maximum transaction body gas limit to enforce. Callers whose gas
+    /// limit is user-supplied must pass `_userPriorityTxMaxGasLimit()`; callers that author the gas
+    /// limit themselves pass `s.priorityTxMaxGasLimit`.
     function _validateTx(
-        WritePriorityOpParams memory _priorityOpParams
+        WritePriorityOpParams memory _priorityOpParams,
+        uint256 _maxGasLimit
     ) internal view returns (L2CanonicalTransaction memory transaction, bytes32 canonicalTxHash) {
         transaction = _serializeL2Transaction(_priorityOpParams);
         bytes memory transactionEncoding = abi.encode(transaction);
@@ -573,11 +579,29 @@ contract MailboxFacet is ZKChainBase, IMailboxImpl, MessageVerification, IMailbo
         TransactionValidator.validateL1ToL2Transaction(
             transaction,
             transactionEncoding,
-            s.priorityTxMaxGasLimit,
+            _maxGasLimit,
             s.feeParams.priorityTxMaxPubdata,
             s.zksyncOS
         );
         canonicalTxHash = keccak256(transactionEncoding);
+    }
+
+    /// @notice The transaction body gas ceiling for L1->L2 transactions whose gas limit comes from
+    /// the caller.
+    /// @dev Such transactions must eventually be included by the operator and cannot be split
+    /// across batches, so anyone could otherwise force an arbitrarily expensive transaction onto
+    /// the chain. `USER_PRIORITY_TX_MAX_GAS_LIMIT` bounds that without needing to be configured per
+    /// chain, while a chain that has been set stricter than the constant keeps its own value.
+    /// @dev ZKsync OS chains are excluded: `Executor` commits `zksyncOSMaxTxGasLimit` to the batch
+    /// public input, so their per-transaction bound is enforced in-circuit for every transaction
+    /// rather than only at L1 admission, and a chain admin may deliberately raise it above the
+    /// EraVM constant. Applying the constant here would cap it back down unreachably.
+    function _userPriorityTxMaxGasLimit() internal view returns (uint256) {
+        uint256 chainLimit = s.priorityTxMaxGasLimit;
+        if (s.zksyncOS) {
+            return chainLimit;
+        }
+        return chainLimit < USER_PRIORITY_TX_MAX_GAS_LIMIT ? chainLimit : USER_PRIORITY_TX_MAX_GAS_LIMIT;
     }
 
     /// @notice Deposits are paused when a chain migrates to/from GW.

--- a/l1-contracts/contracts/state-transition/chain-interfaces/IGetters.sol
+++ b/l1-contracts/contracts/state-transition/chain-interfaces/IGetters.sol
@@ -125,7 +125,10 @@ interface IGetters is IZKChainBase {
     /// executed (i.e. finalized).
     function getL2SystemContractsUpgradeBatchNumber() external view returns (uint256);
 
-    /// @return The maximum number of L2 gas that a user can request for L1 -> L2 transactions
+    /// @return The chain-configured maximum transaction body gas for L1 -> L2 transactions.
+    /// @dev This is the limit protocol-authored transactions are validated against. Caller-supplied
+    /// transactions on an EraVM chain are additionally capped by `USER_PRIORITY_TX_MAX_GAS_LIMIT`,
+    /// so the effective ceiling for them is the lower of the two and may be below this value.
     function getPriorityTxMaxGasLimit() external view returns (uint256);
 
     /// @return The effective ZKsync OS single-transaction gas limit (EIP-7825), with the default

--- a/l1-contracts/deploy-scripts/gateway/GatewayVotePreparation.s.sol
+++ b/l1-contracts/deploy-scripts/gateway/GatewayVotePreparation.s.sol
@@ -230,7 +230,7 @@ contract GatewayVotePreparation is DeployCTMUtils, GatewayGovernanceUtils {
     ) internal {
         Utils.runL1L2Transaction({
             l2Calldata: data,
-            l2GasLimit: 72_000_000,
+            l2GasLimit: Utils.MAX_PRIORITY_TX_GAS,
             l2Value: 0,
             factoryDeps: factoryDeps,
             dstAddress: to,

--- a/l1-contracts/deploy-scripts/utils/Utils.sol
+++ b/l1-contracts/deploy-scripts/utils/Utils.sol
@@ -138,8 +138,11 @@ library Utils {
 
     /// @dev The gas limit these helpers request for their L1->L2 transactions. They go through
     /// `Bridgehub.requestL2TransactionDirect`/`requestL2TransactionTwoBridges`, i.e. the
-    /// caller-supplied path, so this must not exceed `USER_PRIORITY_TX_MAX_GAS_LIMIT` or every
-    /// script-issued transaction reverts with `TooMuchGas`.
+    /// caller-supplied path, which bounds the transaction *body* gas — this value less the batch
+    /// overhead `TransactionValidator.getTransactionBodyGasLimit` subtracts — by
+    /// `USER_PRIORITY_TX_MAX_GAS_LIMIT`. Requesting exactly the constant therefore leaves the body
+    /// strictly under the bound; requesting more than the constant plus that overhead reverts with
+    /// `TooMuchGas`.
     uint256 internal constant MAX_PRIORITY_TX_GAS = USER_PRIORITY_TX_MAX_GAS_LIMIT;
 
     /**

--- a/l1-contracts/deploy-scripts/utils/Utils.sol
+++ b/l1-contracts/deploy-scripts/utils/Utils.sol
@@ -20,7 +20,7 @@ import {
 import {IGovernance} from "contracts/governance/IGovernance.sol";
 import {IOwnable} from "contracts/common/interfaces/IOwnable.sol";
 import {Call} from "contracts/governance/Common.sol";
-import {REQUIRED_L2_GAS_PRICE_PER_PUBDATA} from "contracts/common/Config.sol";
+import {REQUIRED_L2_GAS_PRICE_PER_PUBDATA, USER_PRIORITY_TX_MAX_GAS_LIMIT} from "contracts/common/Config.sol";
 import {
     L2_CREATE2_FACTORY_ADDR,
     L2_DEPLOYER_SYSTEM_CONTRACT_ADDR
@@ -136,7 +136,11 @@ library Utils {
     // https://github.com/Arachnid/deterministic-deployment-proxy
     address internal constant DETERMINISTIC_CREATE2_ADDRESS = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
 
-    uint256 internal constant MAX_PRIORITY_TX_GAS = 72000000;
+    /// @dev The gas limit these helpers request for their L1->L2 transactions. They go through
+    /// `Bridgehub.requestL2TransactionDirect`/`requestL2TransactionTwoBridges`, i.e. the
+    /// caller-supplied path, so this must not exceed `USER_PRIORITY_TX_MAX_GAS_LIMIT` or every
+    /// script-issued transaction reverts with `TooMuchGas`.
+    uint256 internal constant MAX_PRIORITY_TX_GAS = USER_PRIORITY_TX_MAX_GAS_LIMIT;
 
     /**
      * @dev Returns the address that should be used for broadcasting transactions.

--- a/l1-contracts/scripts/migrate-governance.ts
+++ b/l1-contracts/scripts/migrate-governance.ts
@@ -9,7 +9,7 @@ import { BigNumber, ethers, Wallet } from "ethers";
 import { formatUnits, parseUnits } from "ethers/lib/utils";
 import * as fs from "fs";
 import { Deployer } from "../src.ts/deploy";
-import { applyL1ToL2Alias, getAddressFromEnv, getNumberFromEnv } from "../src.ts/utils";
+import { applyL1ToL2Alias, getAddressFromEnv, userPriorityTxMaxGasLimit } from "../src.ts/utils";
 import { GAS_MULTIPLIER, web3Provider } from "./utils";
 
 import type { TxInfo } from "../../l2-contracts/src/utils";
@@ -19,7 +19,7 @@ import { Provider } from "zksync-ethers";
 import { UpgradeableBeaconFactory } from "../../l2-contracts/typechain/UpgradeableBeaconFactory";
 
 const provider = web3Provider();
-const priorityTxMaxGasLimit = BigNumber.from(getNumberFromEnv("CONTRACTS_PRIORITY_TX_MAX_GAS_LIMIT"));
+const l2TxGasLimit = BigNumber.from(userPriorityTxMaxGasLimit);
 
 const l2SharedBridgeABI = JSON.parse(
   fs
@@ -139,7 +139,7 @@ async function main() {
         l2SharedBridgeCalldata,
         refundRecipient,
         gasPrice,
-        priorityTxMaxGasLimit,
+        l2TxGasLimit,
         provider
       );
       displayTx("L2 ERC20 bridge changeAdmin: ", l2TxForErc20Bridge);
@@ -155,7 +155,7 @@ async function main() {
         l2WethUpgradeCalldata,
         refundRecipient,
         gasPrice,
-        priorityTxMaxGasLimit,
+        l2TxGasLimit,
         provider
       );
       displayTx("L2 Weth upgrade: ", l2TxForWethUpgrade);
@@ -172,7 +172,7 @@ async function main() {
         l2Erc20BeaconCalldata,
         refundRecipient,
         gasPrice,
-        priorityTxMaxGasLimit,
+        l2TxGasLimit,
         provider
       );
       displayTx("L2 ERC20 beacon upgrade: ", l2TxForErc20BeaconUpgrade);

--- a/l1-contracts/scripts/sync-layer.ts
+++ b/l1-contracts/scripts/sync-layer.ts
@@ -14,7 +14,7 @@ import {
   getNumberFromEnv,
   ADDRESS_ONE,
   REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
-  priorityTxMaxGasLimit,
+  userPriorityTxMaxGasLimit,
   L2_BRIDGEHUB_ADDRESS,
   computeL2Create2Address,
   DIAMOND_CUT_DATA_ABI_STRING,
@@ -404,7 +404,12 @@ async function registerSLContractsOnL1(deployer: Deployer) {
 
   const gasPrice = (await deployer.deployWallet.provider.getGasPrice()).mul(GAS_MULTIPLIER);
   const value = (
-    await l1Bridgehub.l2TransactionBaseCost(chainId, gasPrice, priorityTxMaxGasLimit, REQUIRED_L2_GAS_PRICE_PER_PUBDATA)
+    await l1Bridgehub.l2TransactionBaseCost(
+      chainId,
+      gasPrice,
+      userPriorityTxMaxGasLimit,
+      REQUIRED_L2_GAS_PRICE_PER_PUBDATA
+    )
   ).mul(10);
   const baseTokenAddress = await l1Bridgehub.baseToken(chainId);
   const ethIsBaseToken = baseTokenAddress == ADDRESS_ONE;
@@ -430,7 +435,7 @@ async function registerSLContractsOnL1(deployer: Deployer) {
         chainId,
         mintValue: value,
         l2Value: 0,
-        l2GasLimit: priorityTxMaxGasLimit,
+        l2GasLimit: userPriorityTxMaxGasLimit,
         l2GasPerPubdataByteLimit: SYSTEM_CONFIG.requiredL2GasPricePerPubdata,
         refundRecipient: deployer.deployWallet.address,
         secondBridgeAddress: assetRouter.address,
@@ -453,7 +458,7 @@ async function registerSLContractsOnL1(deployer: Deployer) {
     L2_BRIDGEHUB_ADDRESS,
     gasPrice,
     l1Bridgehub.interface.encodeFunctionData("addChainTypeManager", [l2CTMAddress]),
-    priorityTxMaxGasLimit
+    userPriorityTxMaxGasLimit
   );
   const l2TxHash2dot5 = zkUtils.getL2HashFromPriorityOp(receipt3, gatewayAddress);
   console.log(`L2 CTM ,l2 txHash: ${l2TxHash2dot5}`);
@@ -468,7 +473,7 @@ async function registerSLContractsOnL1(deployer: Deployer) {
         chainId,
         mintValue: value,
         l2Value: 0,
-        l2GasLimit: priorityTxMaxGasLimit,
+        l2GasLimit: userPriorityTxMaxGasLimit,
         l2GasPerPubdataByteLimit: SYSTEM_CONFIG.requiredL2GasPricePerPubdata,
         refundRecipient: deployer.deployWallet.address,
         secondBridgeAddress: ctmDeploymentTracker.address,

--- a/l1-contracts/src.ts/deploy.ts
+++ b/l1-contracts/src.ts/deploy.ts
@@ -47,7 +47,7 @@ import {
   applyL1ToL2Alias,
   encodeNTVAssetId,
   computeL2Create2Address,
-  priorityTxMaxGasLimit,
+  userPriorityTxMaxGasLimit,
   isCurrentNetworkLocal,
 } from "./utils";
 import {
@@ -1307,8 +1307,8 @@ export class Deployer {
     const protocolVersion = packSemver(...unpackStringSemVer(process.env.CONTRACTS_GENESIS_PROTOCOL_SEMANTIC_VERSION));
     const chainData = ethers.utils.defaultAbiCoder.encode(["uint256"], [protocolVersion]);
     const bridgehub = this.bridgehubContract(this.deployWallet);
-    // Just some large gas limit that should always be enough
-    const l2GasLimit = ethers.BigNumber.from(72_000_000);
+    // The body-gas cap on caller-supplied L1->L2 transactions.
+    const l2GasLimit = ethers.BigNumber.from(userPriorityTxMaxGasLimit);
     const expectedCost = (
       await bridgehub.l2TransactionBaseCost(gatewayChainId, gasPrice, l2GasLimit, REQUIRED_L2_GAS_PRICE_PER_PUBDATA)
     ).mul(5);
@@ -1649,7 +1649,7 @@ export class Deployer {
       l2SharedBridgeImplementationBytecode,
       ethers.utils.defaultAbiCoder.encode(["uint256"], [eraChainId]),
       ethers.constants.HashZero,
-      priorityTxMaxGasLimit,
+      userPriorityTxMaxGasLimit,
       gasPrice,
       [L2_STANDARD_TOKEN_PROXY.bytecode],
       this.addresses.Bridgehub.BridgehubProxy,
@@ -1702,7 +1702,7 @@ export class Deployer {
       L2_SHARED_BRIDGE_PROXY.bytecode,
       l2SharedBridgeProxyConstructorData,
       ethers.constants.HashZero,
-      priorityTxMaxGasLimit,
+      userPriorityTxMaxGasLimit,
       gasPrice,
       undefined,
       this.addresses.Bridgehub.BridgehubProxy,

--- a/l1-contracts/src.ts/utils.ts
+++ b/l1-contracts/src.ts/utils.ts
@@ -15,6 +15,10 @@ import { L2_NATIVE_TOKEN_VAULT_ADDRESS, L1_TO_L2_ALIAS_OFFSET } from "./constant
 const CREATE2_PREFIX = ethers.utils.solidityKeccak256(["string"], ["zksyncCreate2"]);
 
 export const priorityTxMaxGasLimit = getNumberFromEnv("CONTRACTS_PRIORITY_TX_MAX_GAS_LIMIT");
+// `USER_PRIORITY_TX_MAX_GAS_LIMIT` in `contracts/common/Config.sol`: the bound EraVM chains put on
+// the body gas of an L1->L2 transaction whose gas limit comes from the caller. `priorityTxMaxGasLimit`
+// above stays the chain configuration value, which only protocol-authored transactions may spend.
+export const userPriorityTxMaxGasLimit = 15_000_000;
 
 const ADDRESS_MODULO = ethers.BigNumber.from(2).pow(160);
 export const STORED_BATCH_INFO_ABI_STRING =

--- a/l1-contracts/test/foundry/l1/integration/L1GatewayTests.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/L1GatewayTests.t.sol
@@ -21,7 +21,7 @@ import {TokenDeployer} from "./_SharedTokenDeployer.t.sol";
 import {ZKChainDeployer} from "./_SharedZKChainDeployer.t.sol";
 import {GatewayDeployer} from "./_SharedGatewayDeployer.t.sol";
 import {L2TxMocker} from "./_SharedL2TxMocker.t.sol";
-import {ETH_TOKEN_ADDRESS} from "contracts/common/Config.sol";
+import {ETH_TOKEN_ADDRESS, USER_PRIORITY_TX_MAX_GAS_LIMIT} from "contracts/common/Config.sol";
 import {GW_ASSET_TRACKER_ADDR, L2_NATIVE_TOKEN_VAULT_ADDR} from "contracts/common/l2-helpers/L2ContractAddresses.sol";
 import {
     L2CanonicalTransaction,
@@ -270,7 +270,7 @@ contract L1GatewayTests is L1ContractDeployer, ZKChainDeployer, TokenDeployer, L
             migratingChainId,
             expectedValue,
             0, // l2Value
-            72000000, // l2GasLimit
+            USER_PRIORITY_TX_MAX_GAS_LIMIT, // l2GasLimit
             800, // l2GasPerPubdataByteLimit
             "0x"
         );

--- a/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/_SharedL2ContractDeployer.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/_SharedL2ContractDeployer.sol
@@ -33,7 +33,7 @@ import {
     L2_NATIVE_TOKEN_VAULT_ADDR,
     L2_SYSTEM_CONTEXT_SYSTEM_CONTRACT
 } from "contracts/common/l2-helpers/L2ContractInterfaces.sol";
-import {ETH_TOKEN_ADDRESS} from "contracts/common/Config.sol";
+import {ETH_TOKEN_ADDRESS, USER_PRIORITY_TX_MAX_GAS_LIMIT} from "contracts/common/Config.sol";
 
 import {AddressAliasHelper} from "contracts/vendor/AddressAliasHelper.sol";
 import {IL2Bridgehub} from "contracts/core/bridgehub/IL2Bridgehub.sol";
@@ -303,7 +303,8 @@ abstract contract SharedL2ContractDeployer is UtilsCallMockerTest, DeployIntegra
                 mintValue: 1 ether,
                 l2Value: 10,
                 l2Calldata: hex"",
-                l2GasLimit: 72_000_000,
+                // The most a caller-supplied L1->L2 tx may request.
+                l2GasLimit: USER_PRIORITY_TX_MAX_GAS_LIMIT,
                 l2GasPerPubdataByteLimit: 800,
                 factoryDeps: deps,
                 refundRecipient: address(0)

--- a/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/_SharedL2ContractDeployer.sol
+++ b/l1-contracts/test/foundry/l1/integration/l2-tests-abstract/_SharedL2ContractDeployer.sol
@@ -303,7 +303,8 @@ abstract contract SharedL2ContractDeployer is UtilsCallMockerTest, DeployIntegra
                 mintValue: 1 ether,
                 l2Value: 10,
                 l2Calldata: hex"",
-                // The most a caller-supplied L1->L2 tx may request.
+                // Comfortably within what a caller-supplied L1->L2 tx may request: the cap is on
+                // the transaction body, i.e. on this value less the batch overhead.
                 l2GasLimit: USER_PRIORITY_TX_MAX_GAS_LIMIT,
                 l2GasPerPubdataByteLimit: 800,
                 factoryDeps: deps,

--- a/l1-contracts/test/foundry/l1/unit/concrete/state-transition/chain-deps/facets/Mailbox/UserPriorityTxGasCap.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/state-transition/chain-deps/facets/Mailbox/UserPriorityTxGasCap.t.sol
@@ -15,11 +15,12 @@ import {
 } from "contracts/common/Config.sol";
 import {TooMuchGas} from "contracts/common/L1ContractErrors.sol";
 
-/// @notice The DoS bound on *user-supplied* L1->L2 gas limits.
+/// @notice The bound on *user-supplied* L1->L2 gas limits.
 ///
-/// Only `_requestL2Transaction` carries a user-controlled `l2GasLimit`, and only that path can be
-/// forced on the operator by anyone. It is therefore capped by `USER_PRIORITY_TX_MAX_GAS_LIMIT` in
-/// addition to the per-chain `s.priorityTxMaxGasLimit`, whichever is lower.
+/// Only `_requestL2Transaction` carries a user-controlled `l2GasLimit`, so only that path needs a
+/// bound that does not depend on per-chain configuration. It is capped by
+/// `USER_PRIORITY_TX_MAX_GAS_LIMIT` in addition to the per-chain `s.priorityTxMaxGasLimit`,
+/// whichever is lower.
 ///
 /// The authored paths (`_requestL2TransactionFree` for service txs and the Gateway relay wrap, plus
 /// upgrade/genesis txs) build their own gas limit and stay on `s.priorityTxMaxGasLimit` alone.
@@ -38,7 +39,7 @@ contract MailboxUserPriorityTxGasCapTest is MailboxTest {
 
     /// Pinned so that moving the constant is a deliberate act with a failing test attached.
     function test_userCapIsFifteenMillion() public pure {
-        assertEq(USER_PRIORITY_TX_MAX_GAS_LIMIT, 15_000_000, "the DoS bound must not drift silently");
+        assertEq(USER_PRIORITY_TX_MAX_GAS_LIMIT, 15_000_000, "the user gas cap must not drift silently");
     }
 
     /// The chain limit stays at the 72M a chain is seeded with, so a pass here would mean the user
@@ -68,11 +69,11 @@ contract MailboxUserPriorityTxGasCapTest is MailboxTest {
         mailboxFacet.bridgehubRequestL2Transaction(_userRequest(BELOW_USER_CAP));
     }
 
-    /// ZKsync OS bounds every transaction via `zksyncOSMaxTxGasLimit`, which `Executor` commits to
-    /// the batch public input, so the bound is enforced in-circuit rather than at L1 admission. Its
-    /// default (2^24) is above the EraVM constant and a chain admin may raise it further, so
-    /// applying the EraVM constant here would silently undercut a knob ZKsync OS added on purpose.
-    function test_zksyncOSChainKeepsItsOwnPerTxBound() public {
+    /// On ZKsync OS the gas limit is not what bounds an L1 transaction's work: the bootloader
+    /// clamps its native computational resources to a fixed ceiling. The chain's own
+    /// `zksyncOSMaxTxGasLimit` default (2^24) already sits above the EraVM constant and an admin
+    /// may raise it further, so applying the EraVM constant here would undercut it for no gain.
+    function test_zksyncOSChainIsNotSubjectToTheEraVMUserCap() public {
         utilsFacet.util_setPriorityTxMaxGasLimit(DEFAULT_PRIORITY_TX_MAX_GAS_LIMIT);
         utilsFacet.util_setZksyncOS(true);
 

--- a/l1-contracts/test/foundry/l1/unit/concrete/state-transition/chain-deps/facets/Mailbox/UserPriorityTxGasCap.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/state-transition/chain-deps/facets/Mailbox/UserPriorityTxGasCap.t.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.28;
+
+import {MailboxTest} from "./_Mailbox_Shared.t.sol";
+import {BridgehubL2TransactionRequest} from "contracts/common/Messaging.sol";
+import {IMailboxImpl} from "contracts/state-transition/chain-interfaces/IMailboxImpl.sol";
+import {IBridgehubBase} from "contracts/core/bridgehub/IBridgehubBase.sol";
+import {
+    DEFAULT_PRIORITY_TX_MAX_GAS_LIMIT,
+    REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
+    SERVICE_TX_MAX_GAS_LIMIT,
+    USER_PRIORITY_TX_MAX_GAS_LIMIT,
+    ZKSYNC_OS_DEFAULT_MAX_TX_GAS_LIMIT
+} from "contracts/common/Config.sol";
+import {TooMuchGas} from "contracts/common/L1ContractErrors.sol";
+
+/// @notice The DoS bound on *user-supplied* L1->L2 gas limits.
+///
+/// Only `_requestL2Transaction` carries a user-controlled `l2GasLimit`, and only that path can be
+/// forced on the operator by anyone. It is therefore capped by `USER_PRIORITY_TX_MAX_GAS_LIMIT` in
+/// addition to the per-chain `s.priorityTxMaxGasLimit`, whichever is lower.
+///
+/// The authored paths (`_requestL2TransactionFree` for service txs and the Gateway relay wrap, plus
+/// upgrade/genesis txs) build their own gas limit and stay on `s.priorityTxMaxGasLimit` alone.
+contract MailboxUserPriorityTxGasCapTest is MailboxTest {
+    /// Comfortably above the user cap and below the chain limit, so only the user cap can reject it.
+    uint256 internal constant ABOVE_USER_CAP = USER_PRIORITY_TX_MAX_GAS_LIMIT + 5_000_000;
+    /// Comfortably below the user cap, so nothing should reject it.
+    uint256 internal constant BELOW_USER_CAP = USER_PRIORITY_TX_MAX_GAS_LIMIT - 5_000_000;
+
+    function setUp() public virtual {
+        setupDiamondProxy();
+        utilsFacet.util_setBridgehub(bridgehub);
+        utilsFacet.util_setBaseTokenGasPriceMultiplierDenominator(1);
+        vm.deal(bridgehub, 1000 ether);
+    }
+
+    /// Pinned so that moving the constant is a deliberate act with a failing test attached.
+    function test_userCapIsFifteenMillion() public pure {
+        assertEq(USER_PRIORITY_TX_MAX_GAS_LIMIT, 15_000_000, "the DoS bound must not drift silently");
+    }
+
+    /// The chain limit stays at the 72M a chain is seeded with, so a pass here would mean the user
+    /// cap is not being consulted at all.
+    function test_revertWhen_userTxExceedsUserCapUnderTheChainLimit() public {
+        utilsFacet.util_setPriorityTxMaxGasLimit(DEFAULT_PRIORITY_TX_MAX_GAS_LIMIT);
+
+        vm.prank(bridgehub);
+        vm.expectRevert(TooMuchGas.selector);
+        mailboxFacet.bridgehubRequestL2Transaction(_userRequest(ABOVE_USER_CAP));
+    }
+
+    function test_userTxUnderUserCapSucceeds() public {
+        utilsFacet.util_setPriorityTxMaxGasLimit(DEFAULT_PRIORITY_TX_MAX_GAS_LIMIT);
+
+        vm.prank(bridgehub);
+        bytes32 canonicalTxHash = mailboxFacet.bridgehubRequestL2Transaction(_userRequest(BELOW_USER_CAP));
+        assertTrue(canonicalTxHash != bytes32(0), "user tx under the cap must be accepted");
+    }
+
+    /// The cap is the lower of the two, so a chain configured below the constant keeps winning.
+    function test_revertWhen_chainLimitIsStricterThanUserCap() public {
+        utilsFacet.util_setPriorityTxMaxGasLimit(BELOW_USER_CAP / 2);
+
+        vm.prank(bridgehub);
+        vm.expectRevert(TooMuchGas.selector);
+        mailboxFacet.bridgehubRequestL2Transaction(_userRequest(BELOW_USER_CAP));
+    }
+
+    /// ZKsync OS bounds every transaction via `zksyncOSMaxTxGasLimit`, which `Executor` commits to
+    /// the batch public input, so the bound is enforced in-circuit rather than at L1 admission. Its
+    /// default (2^24) is above the EraVM constant and a chain admin may raise it further, so
+    /// applying the EraVM constant here would silently undercut a knob ZKsync OS added on purpose.
+    function test_zksyncOSChainKeepsItsOwnPerTxBound() public {
+        utilsFacet.util_setPriorityTxMaxGasLimit(DEFAULT_PRIORITY_TX_MAX_GAS_LIMIT);
+        utilsFacet.util_setZksyncOS(true);
+
+        // Above the EraVM user cap, below ZKsync OS's own default per-tx limit.
+        uint256 gasLimit = USER_PRIORITY_TX_MAX_GAS_LIMIT + 1_000_000;
+        assertLt(gasLimit, ZKSYNC_OS_DEFAULT_MAX_TX_GAS_LIMIT, "fixture must sit under the ZKsync OS limit");
+
+        vm.prank(bridgehub);
+        bytes32 canonicalTxHash = mailboxFacet.bridgehubRequestL2Transaction(_userRequest(gasLimit));
+        assertTrue(canonicalTxHash != bytes32(0), "ZKsync OS chains must not inherit the EraVM cap");
+    }
+
+    /// Service txs hardcode `SERVICE_TX_MAX_GAS_LIMIT`, well above the user cap. They must remain
+    /// unaffected, otherwise asset-migration confirmations and chain registration break.
+    function test_serviceTxIsNotSubjectToTheUserCap() public {
+        utilsFacet.util_setPriorityTxMaxGasLimit(SERVICE_TX_MAX_GAS_LIMIT);
+        vm.mockCall(
+            bridgehub,
+            abi.encodeWithSelector(IBridgehubBase.chainRegistrationSender.selector),
+            abi.encode(address(this))
+        );
+
+        bytes32 canonicalTxHash = IMailboxImpl(address(mailboxFacet)).requestL2ServiceTransaction(
+            makeAddr("contractL2"),
+            bytes("")
+        );
+        assertTrue(canonicalTxHash != bytes32(0), "service tx must stay on the chain limit");
+    }
+
+    function _userRequest(uint256 _l2GasLimit) private returns (BridgehubL2TransactionRequest memory) {
+        return
+            BridgehubL2TransactionRequest({
+                sender: sender,
+                contractL2: makeAddr("contractL2"),
+                mintValue: 100 ether,
+                l2Value: 0,
+                l2Calldata: "",
+                l2GasLimit: _l2GasLimit,
+                l2GasPerPubdataByteLimit: REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
+                factoryDeps: new bytes[](0),
+                refundRecipient: sender
+            });
+    }
+}

--- a/l1-contracts/test/foundry/l1/unit/concrete/state-transition/chain-deps/facets/Mailbox/UserPriorityTxGasCap.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/state-transition/chain-deps/facets/Mailbox/UserPriorityTxGasCap.t.sol
@@ -10,6 +10,7 @@ import {
     DEFAULT_PRIORITY_TX_MAX_GAS_LIMIT,
     REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
     SERVICE_TX_MAX_GAS_LIMIT,
+    TX_SLOT_OVERHEAD_L2_GAS,
     USER_PRIORITY_TX_MAX_GAS_LIMIT,
     ZKSYNC_OS_DEFAULT_MAX_TX_GAS_LIMIT
 } from "contracts/common/Config.sol";
@@ -29,6 +30,8 @@ contract MailboxUserPriorityTxGasCapTest is MailboxTest {
     uint256 internal constant ABOVE_USER_CAP = USER_PRIORITY_TX_MAX_GAS_LIMIT + 5_000_000;
     /// Comfortably below the user cap, so nothing should reject it.
     uint256 internal constant BELOW_USER_CAP = USER_PRIORITY_TX_MAX_GAS_LIMIT - 5_000_000;
+    /// The largest `l2GasLimit` the cap accepts for a request with empty calldata.
+    uint256 internal constant MAX_ACCEPTED_GAS_LIMIT = USER_PRIORITY_TX_MAX_GAS_LIMIT + TX_SLOT_OVERHEAD_L2_GAS;
 
     function setUp() public virtual {
         setupDiamondProxy();
@@ -40,6 +43,30 @@ contract MailboxUserPriorityTxGasCapTest is MailboxTest {
     /// Pinned so that moving the constant is a deliberate act with a failing test attached.
     function test_userCapIsFifteenMillion() public pure {
         assertEq(USER_PRIORITY_TX_MAX_GAS_LIMIT, 15_000_000, "the user gas cap must not drift silently");
+    }
+
+    /// The cap is on transaction *body* gas: `getTransactionBodyGasLimit` subtracts the batch
+    /// overhead before the comparison, so the largest accepted `l2GasLimit` is the cap plus that
+    /// overhead. The request below encodes to 800 bytes, under the 1000 at which the per-byte
+    /// `MEMORY_OVERHEAD_GAS` term overtakes `TX_SLOT_OVERHEAD_L2_GAS`, so the overhead is the slot
+    /// one. Calldata or factory deps in the fixture would move the boundary.
+    function test_userTxAtTheBodyGasBoundarySucceeds() public {
+        utilsFacet.util_setPriorityTxMaxGasLimit(DEFAULT_PRIORITY_TX_MAX_GAS_LIMIT);
+
+        vm.prank(bridgehub);
+        bytes32 canonicalTxHash = mailboxFacet.bridgehubRequestL2Transaction(_userRequest(MAX_ACCEPTED_GAS_LIMIT));
+        assertTrue(canonicalTxHash != bytes32(0), "the cap bounds body gas, not the requested gas limit");
+    }
+
+    /// One gas past that boundary. Paired with the test above this pins the overhead the cap is
+    /// measured against: capping the raw `l2GasLimit` fails the previous test, and measuring
+    /// against a larger overhead fails this one.
+    function test_revertWhen_userTxIsOneGasOverTheBodyGasBoundary() public {
+        utilsFacet.util_setPriorityTxMaxGasLimit(DEFAULT_PRIORITY_TX_MAX_GAS_LIMIT);
+
+        vm.prank(bridgehub);
+        vm.expectRevert(TooMuchGas.selector);
+        mailboxFacet.bridgehubRequestL2Transaction(_userRequest(MAX_ACCEPTED_GAS_LIMIT + 1));
     }
 
     /// The chain limit stays at the 72M a chain is seeded with, so a pass here would mean the user

--- a/l1-contracts/test/unit_tests/gateway.spec.ts
+++ b/l1-contracts/test/unit_tests/gateway.spec.ts
@@ -12,7 +12,7 @@ import {
   registerZKChainWithBridgeRegistration,
 } from "../../src.ts/deploy-test-process";
 import { ethTestConfig, REQUIRED_L2_GAS_PRICE_PER_PUBDATA, L2_BRIDGEHUB_ADDRESS } from "../../src.ts/constants";
-import { priorityTxMaxGasLimit } from "../../src.ts/utils";
+import { priorityTxMaxGasLimit, userPriorityTxMaxGasLimit } from "../../src.ts/utils";
 import { SYSTEM_CONFIG } from "../../scripts/utils";
 
 import type { Deployer } from "../../src.ts/deploy";
@@ -85,7 +85,12 @@ describe("Gateway", function () {
     const ctm = migratingDeployer.chainTypeManagerContract(migratingDeployer.deployWallet);
     const gasPrice = await migratingDeployer.deployWallet.provider.getGasPrice();
     const value = (
-      await bridgehub.l2TransactionBaseCost(chainId, gasPrice, priorityTxMaxGasLimit, REQUIRED_L2_GAS_PRICE_PER_PUBDATA)
+      await bridgehub.l2TransactionBaseCost(
+        chainId,
+        gasPrice,
+        userPriorityTxMaxGasLimit,
+        REQUIRED_L2_GAS_PRICE_PER_PUBDATA
+      )
     ).mul(10);
 
     const ctmDeploymentTracker = migratingDeployer.ctmDeploymentTracker(migratingDeployer.deployWallet);
@@ -100,7 +105,7 @@ describe("Gateway", function () {
           chainId,
           mintValue: value,
           l2Value: 0,
-          l2GasLimit: priorityTxMaxGasLimit,
+          l2GasLimit: userPriorityTxMaxGasLimit,
           l2GasPerPubdataByteLimit: SYSTEM_CONFIG.requiredL2GasPricePerPubdata,
           refundRecipient: migratingDeployer.deployWallet.address,
           secondBridgeAddress: assetRouter.address,
@@ -119,7 +124,7 @@ describe("Gateway", function () {
           chainId,
           mintValue: value,
           l2Value: 0,
-          l2GasLimit: priorityTxMaxGasLimit,
+          l2GasLimit: userPriorityTxMaxGasLimit,
           l2GasPerPubdataByteLimit: SYSTEM_CONFIG.requiredL2GasPricePerPubdata,
           refundRecipient: migratingDeployer.deployWallet.address,
           secondBridgeAddress: ctmDeploymentTracker.address,
@@ -141,7 +146,7 @@ describe("Gateway", function () {
         l2Contract: ethers.constants.AddressZero,
         l2Value: 0,
         l2Calldata: "0x",
-        l2GasLimit: priorityTxMaxGasLimit,
+        l2GasLimit: userPriorityTxMaxGasLimit,
         l2GasPerPubdataByteLimit: REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
         factoryDeps: [],
         refundRecipient: ethers.constants.AddressZero,

--- a/l2-contracts/src/deploy-force-deploy-upgrader-through-l1.ts
+++ b/l2-contracts/src/deploy-force-deploy-upgrader-through-l1.ts
@@ -3,7 +3,7 @@ import * as hre from "hardhat";
 
 import { Command } from "commander";
 import { ethers, Wallet } from "ethers";
-import { computeL2Create2Address, create2DeployFromL1, priorityTxMaxGasLimit, provider } from "./utils";
+import { computeL2Create2Address, create2DeployFromL1, userPriorityTxMaxGasLimit, provider } from "./utils";
 import { ethTestConfig } from "./deploy-utils";
 
 // Script to deploy the force deploy upgrader contract and output its address.
@@ -43,7 +43,7 @@ async function main() {
       forceDeployUpgraderBytecode,
       "0x",
       create2Salt,
-      priorityTxMaxGasLimit
+      userPriorityTxMaxGasLimit
     );
 
     console.log(`CONTRACTS_L2_DEFAULT_UPGRADE_ADDR=${forceDeployUpgraderAddress}`);

--- a/l2-contracts/src/deploy-testnet-paymaster-through-l1.ts
+++ b/l2-contracts/src/deploy-testnet-paymaster-through-l1.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import { ethers, Wallet } from "ethers";
-import { computeL2Create2Address, create2DeployFromL1, priorityTxMaxGasLimit, provider } from "./utils";
+import { computeL2Create2Address, create2DeployFromL1, userPriorityTxMaxGasLimit, provider } from "./utils";
 import { ethTestConfig } from "./deploy-utils";
 
 import * as hre from "hardhat";
@@ -41,7 +41,7 @@ async function main() {
           testnetPaymasterBytecode,
           "0x",
           create2Salt,
-          priorityTxMaxGasLimit
+          userPriorityTxMaxGasLimit
         )
       ).wait();
 

--- a/l2-contracts/src/publish-bridge-preimages.ts
+++ b/l2-contracts/src/publish-bridge-preimages.ts
@@ -4,7 +4,7 @@ import * as hre from "hardhat";
 import { Command } from "commander";
 import { Wallet, ethers } from "ethers";
 import { Deployer } from "../../l1-contracts/src.ts/deploy";
-import { REQUIRED_L2_GAS_PRICE_PER_PUBDATA, provider, priorityTxMaxGasLimit } from "./utils";
+import { REQUIRED_L2_GAS_PRICE_PER_PUBDATA, provider, userPriorityTxMaxGasLimit } from "./utils";
 import { ethTestConfig } from "./deploy-shared-bridge-on-l2-through-l1";
 
 function getContractBytecode(contractName: string) {
@@ -47,7 +47,7 @@ async function main() {
           mintValue: 0,
           l2Value: 0,
           l2Calldata: "0x",
-          l2GasLimit: priorityTxMaxGasLimit,
+          l2GasLimit: userPriorityTxMaxGasLimit,
           l2GasPerPubdataByteLimit: REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
           factoryDeps: [getContractBytecode("L2SharedBridge")],
           refundRecipient: wallet.address,

--- a/l2-contracts/src/update-l2-erc20-metadata.ts
+++ b/l2-contracts/src/update-l2-erc20-metadata.ts
@@ -3,7 +3,7 @@ import "@nomiclabs/hardhat-ethers";
 import { Command } from "commander";
 import { Wallet, ethers, BigNumber } from "ethers";
 import { Provider } from "zksync-ethers";
-import { getNumberFromEnv } from "../../l1-contracts/src.ts/utils";
+import { userPriorityTxMaxGasLimit } from "../../l1-contracts/src.ts/utils";
 import { web3Provider } from "../../l1-contracts/scripts/utils";
 import { Deployer } from "../../l1-contracts/src.ts/deploy";
 import { getL1TxInfo } from "./utils";
@@ -11,7 +11,7 @@ import { ethTestConfig } from "./deploy-shared-bridge-on-l2-through-l1";
 
 // From openzeppelin-upgradable v4.9.5 Initializable contract implementation.
 const INITIALIZED_STORAGE_SLOT = 0;
-const priorityTxMaxGasLimit = BigNumber.from(getNumberFromEnv("CONTRACTS_PRIORITY_TX_MAX_GAS_LIMIT"));
+const l2TxGasLimit = BigNumber.from(userPriorityTxMaxGasLimit);
 const provider = web3Provider();
 
 async function getReinitializeTokenCalldata(
@@ -65,15 +65,7 @@ async function getReinitializeTokenTxInfo(
     ignoreDecimalsGetter,
     version
   );
-  return await getL1TxInfo(
-    deployer,
-    tokenAddress,
-    l2Calldata,
-    refundRecipient,
-    gasPrice,
-    priorityTxMaxGasLimit,
-    provider
-  );
+  return await getL1TxInfo(deployer, tokenAddress, l2Calldata, refundRecipient, gasPrice, l2TxGasLimit, provider);
 }
 
 async function main() {

--- a/l2-contracts/src/upgrade-bridge-impl.ts
+++ b/l2-contracts/src/upgrade-bridge-impl.ts
@@ -9,7 +9,7 @@ import * as path from "path";
 import { Provider } from "zksync-ethers";
 import { REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT } from "zksync-ethers/build/utils";
 import { web3Provider } from "../../l1-contracts/scripts/utils";
-import { getAddressFromEnv, getNumberFromEnv } from "../../l1-contracts/src.ts/utils";
+import { getAddressFromEnv, userPriorityTxMaxGasLimit } from "../../l1-contracts/src.ts/utils";
 import { Deployer } from "../../l1-contracts/src.ts/deploy";
 import { awaitPriorityOps, computeL2Create2Address, create2DeployFromL1, getL1TxInfo } from "./utils";
 
@@ -58,7 +58,7 @@ function validateUpgradeInfo(info: UpgradeInfo) {
   checkSupportedContract(info.contract);
 }
 
-const priorityTxMaxGasLimit = BigNumber.from(getNumberFromEnv("CONTRACTS_PRIORITY_TX_MAX_GAS_LIMIT"));
+const l2TxGasLimit = BigNumber.from(userPriorityTxMaxGasLimit);
 const l2SharedBridgeProxyAddress = getAddressFromEnv("CONTRACTS_L2_SHARED_BRIDGE_ADDR");
 const l1Erc20BridgeProxyAddress = getAddressFromEnv("CONTRACTS_L1_SHARED_BRIDGE_PROXY_ADDR");
 const EIP1967_IMPLEMENTATION_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
@@ -104,15 +104,7 @@ async function getTransparentProxyUpgradeTxInfo(
   gasPrice: BigNumber
 ) {
   const l2Calldata = await getTransparentProxyUpgradeCalldata(target);
-  return await getL1TxInfo(
-    deployer,
-    proxyAddress,
-    l2Calldata,
-    refundRecipient,
-    gasPrice,
-    priorityTxMaxGasLimit,
-    provider
-  );
+  return await getL1TxInfo(deployer, proxyAddress, l2Calldata, refundRecipient, gasPrice, l2TxGasLimit, provider);
 }
 
 async function getTokenBeaconUpgradeTxInfo(
@@ -124,7 +116,7 @@ async function getTokenBeaconUpgradeTxInfo(
 ) {
   const l2Calldata = await getBeaconProxyUpgradeCalldata(target);
 
-  return await getL1TxInfo(deployer, proxy, l2Calldata, refundRecipient, gasPrice, priorityTxMaxGasLimit, provider);
+  return await getL1TxInfo(deployer, proxy, l2Calldata, refundRecipient, gasPrice, l2TxGasLimit, provider);
 }
 
 async function getL1BridgeUpgradeTxInfo(proxyTarget: string) {
@@ -222,7 +214,7 @@ async function main() {
         bridgeImplBytecode,
         "0x",
         salt,
-        priorityTxMaxGasLimit,
+        l2TxGasLimit,
         gasPrice
       );
       console.log("L1 tx hash: ", tx.hash);
@@ -348,7 +340,7 @@ async function main() {
       const neededValue = await zksync.l2TransactionBaseCost(
         chainId,
         gasPrice,
-        priorityTxMaxGasLimit,
+        l2TxGasLimit,
         REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT
       );
 

--- a/l2-contracts/src/utils.ts
+++ b/l2-contracts/src/utils.ts
@@ -4,7 +4,7 @@ import { Interface } from "ethers/lib/utils";
 import { deployedAddressesFromEnv } from "../../l1-contracts/src.ts/deploy-utils";
 import type { Deployer } from "../../l1-contracts/src.ts/deploy";
 import { ADDRESS_ONE } from "../../l1-contracts/src.ts/constants";
-import { getNumberFromEnv } from "../../l1-contracts/src.ts/utils";
+import { userPriorityTxMaxGasLimit } from "../../l1-contracts/src.ts/utils";
 import { IBridgehubFactory } from "../../l1-contracts/typechain/IBridgehubFactory";
 import { web3Provider } from "../../l1-contracts/scripts/utils";
 
@@ -26,7 +26,8 @@ const CREATE2_PREFIX = ethers.utils.solidityKeccak256(["string"], ["zksyncCreate
 const L1_TO_L2_ALIAS_OFFSET = "0x1111000000000000000000000000000000001111";
 const ADDRESS_MODULO = ethers.BigNumber.from(2).pow(160);
 
-export const priorityTxMaxGasLimit = getNumberFromEnv("CONTRACTS_PRIORITY_TX_MAX_GAS_LIMIT");
+// Re-exported so the L2 deployment scripts keep taking their L1->L2 gas limit from one place.
+export { userPriorityTxMaxGasLimit };
 
 export function applyL1ToL2Alias(address: string): string {
   return ethers.utils.hexZeroPad(
@@ -202,7 +203,7 @@ export async function publishBytecodeFromL1(
     wallet,
     ethers.constants.AddressZero,
     "0x",
-    priorityTxMaxGasLimit,
+    userPriorityTxMaxGasLimit,
     gasPrice,
     factoryDeps
   );
@@ -243,7 +244,7 @@ export async function getL1TxInfo(
   l2Calldata: string,
   refundRecipient: string,
   gasPrice: BigNumber,
-  priorityTxMaxGasLimit: BigNumber,
+  l2GasLimit: BigNumber,
   provider: ethers.providers.JsonRpcProvider
 ): Promise<TxInfo> {
   const zksync = deployer.stateTransitionContract(ethers.Wallet.createRandom().connect(provider));
@@ -251,17 +252,13 @@ export async function getL1TxInfo(
     to,
     0,
     l2Calldata,
-    priorityTxMaxGasLimit,
+    l2GasLimit,
     REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT,
     [], // It is assumed that the target has already been deployed
     refundRecipient,
   ]);
 
-  const neededValue = await zksync.l2TransactionBaseCost(
-    gasPrice,
-    priorityTxMaxGasLimit,
-    REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT
-  );
+  const neededValue = await zksync.l2TransactionBaseCost(gasPrice, l2GasLimit, REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT);
 
   return {
     target: zksync.address,


### PR DESCRIPTION
# What ❔

Splits the L1→L2 gas limit by who authors it. `Mailbox._validateTx` takes the limit as a parameter
instead of always reading `s.priorityTxMaxGasLimit`:

| Path | Limit |
|---|---|
| `_requestL2Transaction` — caller-supplied gas | `min(priorityTxMaxGasLimit, USER_PRIORITY_TX_MAX_GAS_LIMIT)` = **15M** |
| `_requestL2TransactionFree` — service txs, Gateway relay wrap | `priorityTxMaxGasLimit` = 72M |
| upgrade / genesis (`BaseZkSyncUpgrade`) | `priorityTxMaxGasLimit` = 72M, untouched |

ZKsync OS chains keep `priorityTxMaxGasLimit`, because there the gas limit is not what bounds the
work. The bootloader clamps an L1 transaction's native computational resources to
`MAX_NATIVE_COMPUTATIONAL` (`get_resources_for_tx`), and at the constant native price used for L1
transactions that clamp binds far below any gas limit worth requesting, so a larger `l2GasLimit`
buys no additional computation. (`zksyncOSMaxTxGasLimit`, which `Executor` commits to the batch
public input, applies to ordinary L2 transaction validation — `process_l1_transaction` deliberately
does not reject L1 transactions on gas grounds.) An admin may also raise that value above 15M on
purpose.

The bound is on transaction *body* gas, i.e. after `getTransactionBodyGasLimit` subtracts batch
overhead. The largest accepted `l2GasLimit` is therefore 15M plus that overhead (15,010,000 for
empty calldata); execution stays bounded at 15M.

`Utils.MAX_PRIORITY_TX_GAS` was 72M on the caller-supplied path, so every script-issued L1→L2
transaction (chain registration, L2 deploys, Gateway migration) would have reverted `TooMuchGas`. It
derives from the cap now, as do two other literals on that path.

# Why ❔

L1→L2 transactions must eventually be included by the operator (priority expiration, priority mode)
and a single transaction cannot be split across batches, so the work any one of them can impose on
execution and proving has to be bounded at admission. An unbounded caller-supplied `l2GasLimit`
leaves that bound entirely to per-chain configuration. Service transactions and upgrades carry a
gas limit authored by the protocol, so they stay at 72M.

Supersedes #2406. The cap is a constant rather than per-chain state, so no governance action and no
per-chain migration is needed — it applies to existing and new chains as soon as the facet upgrade
lands. A chain configured stricter than 15M keeps its own value.

No storage layout, selector or ABI changes; both new functions are `internal`.

# Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
