### PR TITLE
EVM-1325: Add formatting checks for all Rust crates

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -52,6 +52,7 @@ jobs:
           components: rustfmt
 
       - name: Check formatting
+        # `+1.91.1` overrides crate-local rust-toolchain.toml files.
         run: cargo +1.91.1 fmt --check
         working-directory: ${{ matrix.working-directory }}
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,8 +33,16 @@ jobs:
 
       - uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2
 
-  protocol-ops-fmt:
+  rust-fmt:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        working-directory:
+          - protocol-ops
+          - tools/upgrade-readiness-checker
+          - tools/verifier-gen
+          - tools/wallets-gen
+          - tools/zksync-os-genesis-gen
     steps:
       - uses: actions/checkout@v6
 
@@ -45,7 +53,7 @@ jobs:
 
       - name: Check formatting
         run: cargo fmt --check
-        working-directory: protocol-ops
+        working-directory: ${{ matrix.working-directory }}
 
   protocol-ops-clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -52,7 +52,7 @@ jobs:
           components: rustfmt
 
       - name: Check formatting
-        run: cargo fmt --check
+        run: cargo +1.91.1 fmt --check
         working-directory: ${{ matrix.working-directory }}
 
   protocol-ops-clippy:

--- a/docs/ai-review/docs/ci-green.md
+++ b/docs/ai-review/docs/ci-green.md
@@ -153,7 +153,7 @@ For Rust:
 
 ```bash
 for dir in protocol-ops tools/{upgrade-readiness-checker,verifier-gen,wallets-gen,zksync-os-genesis-gen}; do
-  (cd "$dir" && cargo +stable fmt --check)  # nightly disagrees with CI on edge cases
+  (cd "$dir" && cargo +1.91.1 fmt --check)  # nightly disagrees with CI on edge cases
 done
 (cd protocol-ops && cargo clippy --all-targets -- -D warnings)
 ```
@@ -281,7 +281,7 @@ yarn lint:ts --fix
 yarn prettier:fix
 yarn l1 errors-lint --check
 for dir in protocol-ops tools/{upgrade-readiness-checker,verifier-gen,wallets-gen,zksync-os-genesis-gen}; do
-  (cd "$dir" && cargo +stable fmt --check)
+  (cd "$dir" && cargo +1.91.1 fmt --check)
 done
 ( cd protocol-ops && cargo clippy --all-targets -- -D warnings )
 

--- a/docs/ai-review/docs/ci-green.md
+++ b/docs/ai-review/docs/ci-green.md
@@ -2,7 +2,7 @@
 
 ## Relevant files
 
-- `.github/workflows/lint.yaml` — Solidity / TS lint, codespell, typos, `cargo fmt --check`, `cargo clippy -D warnings` for `protocol-ops`.
+- `.github/workflows/lint.yaml` — Solidity / TS lint, codespell, typos, `cargo fmt --check` for all Rust crates, and `cargo clippy -D warnings` for `protocol-ops`.
 - `.github/workflows/l1-contracts-ci.yaml` — l1-contracts build, `check-zkstack-out`, `check-hashes`, `check-selectors`, `check-legacy-bridge-sol`.
 - `.github/workflows/l1-contracts-foundry-ci.yaml` — foundry test build + contract-size check.
 - `.github/workflows/anvil-interop-ci.yaml` — interop integration test, v31→v32 upgrade test.
@@ -149,12 +149,13 @@ yarn prettier:fix                # All formats — adds trailing newlines, etc.
 yarn l1 errors-lint --check
 ```
 
-For `protocol-ops` (Rust):
+For Rust:
 
 ```bash
-cd protocol-ops
-cargo +stable fmt --check  # nightly disagrees with CI on edge cases
-cargo clippy --all-targets -- -D warnings
+for dir in protocol-ops tools/{upgrade-readiness-checker,verifier-gen,wallets-gen,zksync-os-genesis-gen}; do
+  (cd "$dir" && cargo +stable fmt --check)  # nightly disagrees with CI on edge cases
+done
+(cd protocol-ops && cargo clippy --all-targets -- -D warnings)
 ```
 
 CI also runs `codespell` and `crate-ci/typos` as separate jobs (see `.github/workflows/lint.yaml`). They are easy to forget locally because neither is wired into `yarn lint:check`. Both must pass independently.
@@ -279,7 +280,10 @@ yarn lint:sol --fix --noPrompt
 yarn lint:ts --fix
 yarn prettier:fix
 yarn l1 errors-lint --check
-( cd protocol-ops && cargo +stable fmt --check && cargo clippy --all-targets -- -D warnings )
+for dir in protocol-ops tools/{upgrade-readiness-checker,verifier-gen,wallets-gen,zksync-os-genesis-gen}; do
+  (cd "$dir" && cargo +stable fmt --check)
+done
+( cd protocol-ops && cargo clippy --all-targets -- -D warnings )
 
 # 4. Selectors
 ( cd l1-contracts && yarn selectors --fix )

--- a/docs/ai-review/docs/ci-green.md
+++ b/docs/ai-review/docs/ci-green.md
@@ -152,8 +152,9 @@ yarn l1 errors-lint --check
 For Rust:
 
 ```bash
+# `+1.91.1` overrides crate-local nightly toolchains to match CI.
 for dir in protocol-ops tools/{upgrade-readiness-checker,verifier-gen,wallets-gen,zksync-os-genesis-gen}; do
-  (cd "$dir" && cargo +1.91.1 fmt --check)  # nightly disagrees with CI on edge cases
+  (cd "$dir" && cargo +1.91.1 fmt --check)
 done
 (cd protocol-ops && cargo clippy --all-targets -- -D warnings)
 ```
@@ -280,6 +281,7 @@ yarn lint:sol --fix --noPrompt
 yarn lint:ts --fix
 yarn prettier:fix
 yarn l1 errors-lint --check
+# `+1.91.1` overrides crate-local nightly toolchains to match CI.
 for dir in protocol-ops tools/{upgrade-readiness-checker,verifier-gen,wallets-gen,zksync-os-genesis-gen}; do
   (cd "$dir" && cargo +1.91.1 fmt --check)
 done


### PR DESCRIPTION
## What

Add `cargo fmt --check` CI coverage for every Rust crate and update the CI guide.

## Verification

- `cargo +1.91.1 fmt --check` for all five crates
- `yarn lint:check`
- `yarn l1 errors-lint --check`
