### PR TITLE
feat(deploy-scripts): dedicated reverter and pinned salt for chain init

### DIFF
--- a/l1-contracts/contracts/script-interfaces/IRegisterZKChain.sol
+++ b/l1-contracts/contracts/script-interfaces/IRegisterZKChain.sol
@@ -14,6 +14,8 @@ struct RegisterZKChainConfig {
     address validatorSenderOperatorProve;
     // optional - if not set, then equal to 0
     address validatorSenderOperatorExecute;
+    // optional - dedicated REVERTER; when 0 the role stays on validatorSenderOperatorEth
+    address validatorSenderOperatorReverter;
     address baseToken;
     bytes32 baseTokenAssetId;
     uint128 baseTokenGasPriceMultiplierNominator;

--- a/l1-contracts/deploy-scripts/ctm/RegisterZKChain.s.sol
+++ b/l1-contracts/deploy-scripts/ctm/RegisterZKChain.s.sol
@@ -214,6 +214,11 @@ contract RegisterZKChainScript is Create2FactoryUtils, IRegisterZKChain {
         } else {
             config.validatorSenderOperatorExecute = address(0);
         }
+        if (vm.keyExistsToml(toml, "$.chain.validator_sender_operator_reverter")) {
+            config.validatorSenderOperatorReverter = toml.readAddress("$.chain.validator_sender_operator_reverter");
+        } else {
+            config.validatorSenderOperatorReverter = address(0);
+        }
 
         if (vm.keyExistsToml(toml, "$.initialize_legacy_bridge")) {
             config.initializeLegacyBridge = toml.readBool("$.initialize_legacy_bridge");
@@ -407,13 +412,14 @@ contract RegisterZKChainScript is Create2FactoryUtils, IRegisterZKChain {
         // and execute operators are set, they receive PROVER / EXECUTOR instead (see below).
         bool zkSyncOsValidatorSplit = config.validatorSenderOperatorProve != address(0) &&
             config.validatorSenderOperatorExecute != address(0);
+        bool dedicatedReverter = config.validatorSenderOperatorReverter != address(0);
         validatorTimelock.addValidatorRoles(
             chainAddress,
             config.validatorSenderOperatorEth,
             IValidatorTimelock.ValidatorRotationParams({
                 rotatePrecommitterRole: true,
                 rotateCommitterRole: false,
-                rotateReverterRole: true,
+                rotateReverterRole: !dedicatedReverter,
                 rotateProverRole: !zkSyncOsValidatorSplit,
                 rotateExecutorRole: !zkSyncOsValidatorSplit,
                 rotateUpgraderRole: true
@@ -456,6 +462,21 @@ contract RegisterZKChainScript is Create2FactoryUtils, IRegisterZKChain {
                     rotateReverterRole: false,
                     rotateProverRole: false,
                     rotateExecutorRole: true,
+                    rotateUpgraderRole: false
+                })
+            );
+        }
+
+        if (dedicatedReverter) {
+            validatorTimelock.addValidatorRoles(
+                chainAddress,
+                config.validatorSenderOperatorReverter,
+                IValidatorTimelock.ValidatorRotationParams({
+                    rotatePrecommitterRole: false,
+                    rotateCommitterRole: false,
+                    rotateReverterRole: true,
+                    rotateProverRole: false,
+                    rotateExecutorRole: false,
                     rotateUpgraderRole: false
                 })
             );

--- a/l1-contracts/test/foundry/l1/integration/ValidatorRolesOnRegistration.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/ValidatorRolesOnRegistration.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {IValidatorTimelock} from "contracts/state-transition/validators/interfaces/IValidatorTimelock.sol";
+import {ETH_TOKEN_ADDRESS} from "contracts/common/Config.sol";
+
+import {L1ContractDeployer} from "./_SharedL1ContractDeployer.t.sol";
+import {TokenDeployer} from "./_SharedTokenDeployer.t.sol";
+import {ZKChainDeployer} from "./_SharedZKChainDeployer.t.sol";
+
+/// Validator roles handed out by RegisterZKChain.s.sol. Chain 10 is registered without a
+/// dedicated reverter, chain 11 with `validator_sender_operator_reverter` set.
+contract ValidatorRolesOnRegistrationTests is L1ContractDeployer, ZKChainDeployer, TokenDeployer {
+    uint256 internal constant CHAIN_WITHOUT_REVERTER = 10;
+    uint256 internal constant CHAIN_WITH_REVERTER = 11;
+    address internal constant ETH_OPERATOR = address(0);
+    address internal constant PROVE_OPERATOR = address(2);
+    address internal constant DEDICATED_REVERTER = address(4);
+
+    IValidatorTimelock internal timelock;
+
+    function setUp() public {
+        _deployL1Contracts();
+        _deployTokens();
+        _registerNewTokens(tokens);
+        _deployEra();
+        _deployZKChain(ETH_TOKEN_ADDRESS);
+        _deployZKChainWithReverter(ETH_TOKEN_ADDRESS, DEDICATED_REVERTER);
+        timelock = IValidatorTimelock(ctmAddresses.stateTransition.proxies.validatorTimelock);
+    }
+
+    function test_reverterStaysOnEthOperatorWithoutDedicatedReverter() public view {
+        bytes32 reverterRole = timelock.REVERTER_ROLE();
+        assertTrue(timelock.hasRoleForChainId(CHAIN_WITHOUT_REVERTER, reverterRole, ETH_OPERATOR));
+        assertFalse(timelock.hasRoleForChainId(CHAIN_WITHOUT_REVERTER, reverterRole, DEDICATED_REVERTER));
+    }
+
+    function test_dedicatedReverterGetsReverterRoleOnly() public view {
+        bytes32 reverterRole = timelock.REVERTER_ROLE();
+        assertTrue(timelock.hasRoleForChainId(CHAIN_WITH_REVERTER, reverterRole, DEDICATED_REVERTER));
+        assertFalse(timelock.hasRoleForChainId(CHAIN_WITH_REVERTER, reverterRole, ETH_OPERATOR));
+        assertFalse(timelock.hasRoleForChainId(CHAIN_WITH_REVERTER, timelock.PROVER_ROLE(), DEDICATED_REVERTER));
+        assertFalse(timelock.hasRoleForChainId(CHAIN_WITH_REVERTER, timelock.EXECUTOR_ROLE(), DEDICATED_REVERTER));
+        assertFalse(timelock.hasRoleForChainId(CHAIN_WITH_REVERTER, timelock.COMMITTER_ROLE(), DEDICATED_REVERTER));
+    }
+
+    function test_proveOperatorKeepsProverRoleWithDedicatedReverter() public view {
+        assertTrue(timelock.hasRoleForChainId(CHAIN_WITH_REVERTER, timelock.PROVER_ROLE(), PROVE_OPERATOR));
+    }
+}

--- a/l1-contracts/test/foundry/l1/integration/ValidatorRolesOnRegistration.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/ValidatorRolesOnRegistration.t.sol
@@ -8,11 +8,12 @@ import {L1ContractDeployer} from "./_SharedL1ContractDeployer.t.sol";
 import {TokenDeployer} from "./_SharedTokenDeployer.t.sol";
 import {ZKChainDeployer} from "./_SharedZKChainDeployer.t.sol";
 
-/// Validator roles handed out by RegisterZKChain.s.sol. Chain 10 is registered without a
-/// dedicated reverter, chain 11 with `validator_sender_operator_reverter` set.
+/// Validator roles handed out by RegisterZKChain.s.sol. One chain is registered without a
+/// dedicated reverter, one with `validator_sender_operator_reverter` set. Explicit chain ids keep
+/// this suite off the config files the other suites write concurrently (ids 10 and up).
 contract ValidatorRolesOnRegistrationTests is L1ContractDeployer, ZKChainDeployer, TokenDeployer {
-    uint256 internal constant CHAIN_WITHOUT_REVERTER = 10;
-    uint256 internal constant CHAIN_WITH_REVERTER = 11;
+    uint256 internal constant CHAIN_WITHOUT_REVERTER = 917100;
+    uint256 internal constant CHAIN_WITH_REVERTER = 917101;
     address internal constant ETH_OPERATOR = address(0);
     address internal constant PROVE_OPERATOR = address(2);
     address internal constant DEDICATED_REVERTER = address(4);
@@ -24,8 +25,8 @@ contract ValidatorRolesOnRegistrationTests is L1ContractDeployer, ZKChainDeploye
         _deployTokens();
         _registerNewTokens(tokens);
         _deployEra();
-        _deployZKChain(ETH_TOKEN_ADDRESS);
-        _deployZKChainWithReverter(ETH_TOKEN_ADDRESS, DEDICATED_REVERTER);
+        _deployZKChainWithPausedDeposits(ETH_TOKEN_ADDRESS, CHAIN_WITHOUT_REVERTER);
+        _deployZKChainWithReverter(ETH_TOKEN_ADDRESS, CHAIN_WITH_REVERTER, DEDICATED_REVERTER);
         timelock = IValidatorTimelock(ctmAddresses.stateTransition.proxies.validatorTimelock);
     }
 

--- a/l1-contracts/test/foundry/l1/integration/_SharedZKChainDeployer.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/_SharedZKChainDeployer.t.sol
@@ -30,6 +30,8 @@ contract ZKChainDeployer is L1ContractDeployer {
         address validatorSenderOperatorBlobsEth;
         address validatorSenderOperatorProve;
         address validatorSenderOperatorExecute;
+        // Zero means "no dedicated reverter", which is what every existing fixture expects.
+        address validatorSenderOperatorReverter;
         uint128 baseTokenGasPriceMultiplierNominator;
         uint128 baseTokenGasPriceMultiplierDenominator;
         bool allowEvmEmulator;
@@ -38,6 +40,7 @@ contract ZKChainDeployer is L1ContractDeployer {
     ChainConfig internal eraConfig;
 
     uint256 currentZKChainId = 10;
+    address internal dedicatedReverterForNextChain;
     uint256 eraZKChainId = 9;
     uint256[] public zkChainIds;
 
@@ -83,6 +86,14 @@ contract ZKChainDeployer is L1ContractDeployer {
         address admin = IZKChain(chainAddress).getAdmin();
         vm.prank(admin);
         IMigrator(chainAddress).unpauseDeposits();
+    }
+
+    /// Same as `_deployZKChain`, with a dedicated reverter in the chain's config. The reverter
+    /// only applies to this one deployment.
+    function _deployZKChainWithReverter(address _baseToken, address _reverter) internal {
+        dedicatedReverterForNextChain = _reverter;
+        _deployZKChain(_baseToken);
+        dedicatedReverterForNextChain = address(0);
     }
 
     function _deployZKChainWithPausedDeposits(address _baseToken, uint256 _chainId) internal {
@@ -152,6 +163,7 @@ contract ZKChainDeployer is L1ContractDeployer {
             validatorSenderOperatorBlobsEth: address(1),
             validatorSenderOperatorProve: address(2),
             validatorSenderOperatorExecute: address(3),
+            validatorSenderOperatorReverter: dedicatedReverterForNextChain,
             baseTokenGasPriceMultiplierNominator: uint128(1),
             baseTokenGasPriceMultiplierDenominator: uint128(1),
             allowEvmEmulator: false
@@ -181,6 +193,13 @@ contract ZKChainDeployer is L1ContractDeployer {
         );
         vm.serializeAddress("chain", "validator_sender_operator_prove", description.validatorSenderOperatorProve);
         vm.serializeAddress("chain", "validator_sender_operator_execute", description.validatorSenderOperatorExecute);
+        if (description.validatorSenderOperatorReverter != address(0)) {
+            vm.serializeAddress(
+                "chain",
+                "validator_sender_operator_reverter",
+                description.validatorSenderOperatorReverter
+            );
+        }
         vm.serializeUint(
             "chain",
             "base_token_gas_price_multiplier_nominator",

--- a/l1-contracts/test/foundry/l1/integration/_SharedZKChainDeployer.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/_SharedZKChainDeployer.t.sol
@@ -88,11 +88,11 @@ contract ZKChainDeployer is L1ContractDeployer {
         IMigrator(chainAddress).unpauseDeposits();
     }
 
-    /// Same as `_deployZKChain`, with a dedicated reverter in the chain's config. The reverter
-    /// only applies to this one deployment.
-    function _deployZKChainWithReverter(address _baseToken, address _reverter) internal {
+    /// Registers `_chainId` with a dedicated reverter in its config (deposits stay paused, like
+    /// `_deployZKChainWithPausedDeposits`). The reverter only applies to this one deployment.
+    function _deployZKChainWithReverter(address _baseToken, uint256 _chainId, address _reverter) internal {
         dedicatedReverterForNextChain = _reverter;
-        _deployZKChain(_baseToken);
+        _deployZKChainInner(_baseToken, _chainId);
         dedicatedReverterForNextChain = address(0);
     }
 

--- a/l1-contracts/zkstack-out/IRegisterZKChain.sol/IRegisterZKChain.json
+++ b/l1-contracts/zkstack-out/IRegisterZKChain.sol/IRegisterZKChain.json
@@ -55,6 +55,11 @@
             "internalType": "address"
           },
           {
+            "name": "validatorSenderOperatorReverter",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
             "name": "baseToken",
             "type": "address",
             "internalType": "address"

--- a/protocol-ops/src/commands/chain/init.rs
+++ b/protocol-ops/src/commands/chain/init.rs
@@ -46,6 +46,10 @@ pub struct ChainInitArgs {
     /// L1 batch execute operator (ZKSync OS only)
     #[clap(long, help_heading = "Input")]
     pub execute_operator: Option<Address>,
+    /// Dedicated reverter. Gets REVERTER on the ValidatorTimelock instead of the prove
+    /// operator, so no follow-up role grant is needed
+    #[clap(long, help_heading = "Input")]
+    pub reverter_operator: Option<Address>,
 
     /// Bridgehub proxy address
     #[clap(long, help_heading = "Input")]
@@ -80,6 +84,10 @@ pub struct ChainInitArgs {
         help_heading = "Advanced input"
     )]
     pub token_multiplier_setter: Option<Address>,
+    /// CREATE2 salt for the chain's ChainAdmin and other CREATE2 deployments (random by
+    /// default). Pin it so a re-run reproduces the same addresses and bundle
+    #[clap(long, help_heading = "Advanced input")]
+    pub create2_factory_salt: Option<B256>,
     /// Base token address (default: ETH = 0x0...01)
     #[clap(
         long,
@@ -181,14 +189,22 @@ pub async fn run(args: ChainInitArgs) -> anyhow::Result<()> {
         vm_type,
         l2_da_commitment_scheme: args.l2_da_commitment_scheme,
         register_for_interop: args.register_for_interop,
-        create2_factory_salt: None,
+        create2_factory_salt: args.create2_factory_salt,
         pause_deposits: args.pause_deposits,
         evm_emulator: args.evm_emulator,
         deploy_paymaster: args.deploy_paymaster,
         make_permanent_rollup: args.make_permanent_rollup,
         skip_priority_txs: args.skip_priority_txs,
     };
-    let output = chain_init(&mut runner, &deployer, &owner, &bridgehub_admin, &input).await?;
+    let output = chain_init_with_reverter(
+        &mut runner,
+        &deployer,
+        &owner,
+        &bridgehub_admin,
+        &input,
+        args.reverter_operator,
+    )
+    .await?;
 
     write_output_if_requested(
         "chain.init",
@@ -206,13 +222,28 @@ pub async fn run(args: ChainInitArgs) -> anyhow::Result<()> {
 }
 
 /// Initialize a chain: register, accept admin, configure DA/validators, deploy L2 contracts.
+/// REVERTER lands on the prove operator; see [`chain_init_with_reverter`] for a dedicated one.
+/// Kept with this signature because external crates (zksync-os-integration-tests) call it.
 pub async fn chain_init(
+    runner: &mut ForgeRunner,
+    deployer: &Wallet,
+    owner: &Wallet,
+    bridgehub_admin: &Wallet,
+    input: &ChainInitInput,
+) -> anyhow::Result<FullChainInitOutput> {
+    chain_init_with_reverter(runner, deployer, owner, bridgehub_admin, input, None).await
+}
+
+/// [`chain_init`] with an optional dedicated reverter that receives REVERTER instead of the
+/// prove operator.
+pub async fn chain_init_with_reverter(
     runner: &mut ForgeRunner,
     deployer: &Wallet,
     owner: &Wallet,
     // Retained for call-site compatibility; the legacy-bridge setup that used it has been removed.
     _bridgehub_admin: &Wallet,
     input: &ChainInitInput,
+    reverter_operator: Option<Address>,
 ) -> anyhow::Result<FullChainInitOutput> {
     // Register chain on CTM
     logger::step(format!(
@@ -227,7 +258,7 @@ pub async fn chain_init(
     // replay. Admin-gated calls in the script already broadcast explicitly
     // via `vm.broadcast(admin.owner())`, so they don't need `--sender` to
     // be the admin — the deployer EOA works for everything else.
-    let register_output = register_chain(runner, deployer, input)?;
+    let register_output = register_chain(runner, deployer, input, reverter_operator)?;
     let diamond_proxy = register_output.diamond_proxy_addr;
     let chain_admin = register_output.chain_admin_addr;
     let mut full_output = FullChainInitOutput::from_register(&register_output);
@@ -364,6 +395,7 @@ pub fn register_chain(
     runner: &mut ForgeRunner,
     auth: &Wallet,
     input: &ChainInitInput,
+    reverter_operator: Option<Address>,
 ) -> anyhow::Result<RegisterChainOutput> {
     let salt = input
         .create2_factory_salt
@@ -379,6 +411,7 @@ pub fn register_chain(
         // The legacy-bridge setup this gated was removed with legacy bridging.
         false,
         input.evm_emulator,
+        reverter_operator,
     )?;
 
     let input_path = runner.input_path(&REGISTER_CHAIN_INVOCATION)?;

--- a/protocol-ops/src/common/forge/scripts/register_chain.rs
+++ b/protocol-ops/src/common/forge/scripts/register_chain.rs
@@ -46,6 +46,7 @@ impl RegisterChainL1Config {
         create2_factory_salt: Option<B256>,
         initialize_legacy_bridge: bool,
         evm_emulator: bool,
+        reverter_operator: Option<Address>,
     ) -> anyhow::Result<Self> {
         Ok(Self {
             chain: ChainL1Config {
@@ -74,6 +75,7 @@ impl RegisterChainL1Config {
                     VMOption::EraVM => Address::ZERO,
                     VMOption::ZKSyncOsVM => chain_params.execute_operator,
                 },
+                validator_sender_operator_reverter: reverter_operator.filter(|a| !a.is_zero()),
                 allow_evm_emulator: evm_emulator,
             },
             owner_address: chain_params.owner,
@@ -97,6 +99,9 @@ pub struct ChainL1Config {
     pub validator_sender_operator_blobs_eth: Address,
     pub validator_sender_operator_prove: Address,
     pub validator_sender_operator_execute: Address,
+    /// Dedicated REVERTER. Absent: the role stays on the eth-path (prove) operator.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validator_sender_operator_reverter: Option<Address>,
     pub base_token_gas_price_multiplier_nominator: u64,
     pub base_token_gas_price_multiplier_denominator: u64,
     pub governance_security_council_address: Address,


### PR DESCRIPTION
## Why

Every mainnet chain runs a dedicated reverter, but `protocol_ops chain init` gives REVERTER to the prove operator (the eth-path validator in `RegisterZKChain.s.sol`) and has no way to name another address. Each registration so far needed a follow-up `ChainAdmin.multicall -> ValidatorTimelock.addValidatorRoles`, which is one more transaction to review and one more thing to forget (the Sepolia v33 chains got theirs late).

`chain init` also picks a random CREATE2 salt, so a bundle prepared for review cannot be reproduced from the same inputs the way `ecosystem init --create2-factory-salt` allows.

## What

- `RegisterZKChain.s.sol`: reads an optional `chain.validator_sender_operator_reverter`. When set, REVERTER goes to that address and not to the eth-path operator; otherwise behaviour is unchanged. `RegisterZKChainConfig` gains the field, `zkstack-out` regenerated.
- `protocol_ops chain init`: new `--reverter-operator` and `--create2-factory-salt` flags. The reverter is threaded through `chain_init_with_reverter` / `register_chain(.., reverter)`; `chain_init` keeps its signature (zksync-os-integration-tests calls it) and passes `None`.
- Tests: `ValidatorRolesOnRegistration.t.sol` registers one chain without and one with a dedicated reverter and asserts where REVERTER, PROVER, EXECUTOR, COMMITTER land. The shared deployer's `ZKChainDescription` carries the optional reverter and only serialises it when set. The suite uses explicit chain ids because the harness passes the config path through a process-global env var, so parallel suites race on the shared ids 10+ (CI runs `--threads 1`).

## Verification

- `forge build`, `cargo build --release`, `cargo clippy --all-targets` clean.
- `forge test --threads 1 --match-path 'test/foundry/l1/integration/*.t.sol'`: 251 passed, 0 failed.
- External `zksync-os-integration-tests` (`cargo test -p tests --release`, `protocol_ops` patched to `97a05e721`): all suites pass (`l1` 3/3, `atomic_swap` 2/2, `upgrade_v31_to_v33` 1/1, `v31_fixture` 1/1).
