### PR TITLE
[EVM-1309] Harden anvil-interop assertions

### DIFF
--- a/l1-contracts/test/anvil-interop/README.md
+++ b/l1-contracts/test/anvil-interop/README.md
@@ -54,6 +54,11 @@ yarn setup-and-dump
 
 This runs the full deployment with pinned settings (`blockTime=1`, `timestamp=1`) and dumps each chain's state to the `chain-states/` directory. Interval mining makes the final block height and block-indexed state wall-clock-dependent, so the CI determinism check uses `compare-chain-states.ts` to normalize the documented drift and requires every non-normalized field to match.
 
+Spec `01` compares all predeploy runtimes byte-for-byte against artifacts compiled with the
+`anvil-interop` Foundry profile used by the snapshots. Its setup builds those reference artifacts
+in `outputs/predeploy-identity<run-suffix>/`, leaving the default artifacts used by coverage intact.
+A cold identity build adds compilation time; reruns reuse that separate cache. No snapshots are regenerated.
+
 ## Running Tests Without Redeployment
 
 After running once with `--keep-chains`, the Anvil chains and deployment state persist. Re-run just the hardhat tests:

--- a/l1-contracts/test/anvil-interop/docs/prod-divergences.md
+++ b/l1-contracts/test/anvil-interop/docs/prod-divergences.md
@@ -1,0 +1,13 @@
+# Production divergences observed while hardening EVM-1309
+
+- MockL2MessageVerification accepts synthetic inclusion proofs: 03/06/07/08/09/13 cannot prove settlement authentication or rejection of forged roots; fixable with real root/proof relay.
+- MockL1MessengerHook is a no-op: 02/05/07/08/09 can assert L1MessengerZKOS events, but not server-side message publication; needs a server-backed test.
+- MockMintBaseTokenHook is a no-op and L2BaseToken is prefunded: 02/05 can prove recipient credits and source debits, but not production mint/supply conservation; needs real mint integration.
+- MockContractDeployer bypasses production force deployments: 01 checks the mock runtime, not deployment authorization or proxy installation; fixable with real deployment integration.
+- L2 implementations are installed directly at predeploy addresses: 01 runtime identity does not cover proxy delegation, admin slots or upgrades; fixable by deploying production proxies.
+- No validium chain: 01/04 and bridging specs cannot exercise DA-mode-specific behavior; fixable with an additional topology (outside this PR).
+- One gateway topology with a deliberately restricted registration set: 03 rejects unregistered routes, not every production cross-settlement route; fixable with additional registered topologies.
+- L1 withdrawal inclusion uses DummyL1MessageRoot and synthetic proofs: 02/05 finalization assertions cannot prove committed/proved/executed batch inclusion; needs real settlement.
+- Priority requests are replayed as funded, impersonated EVM transactions: 02/05 can assert exact l2Value delivery, but not bootloader gas refunds or production pubdata fees; needs a server-backed test.
+- Spec 13 imports synthetic settlement roots through bootloader impersonation: IMT proofs and timeout boundaries are checked, but chain-batch leaf authentication is mocked; fixable with authenticated root relay.
+- Gateway setup replaces L2ChainAssetHandler with L2ChainAssetHandlerDev (and an L1 Dev handler) to enable migrations disabled in production: 01 must compare the gateway runtime to the Dev artifact; production migration restrictions need separate coverage.

--- a/l1-contracts/test/anvil-interop/src/core/const.ts
+++ b/l1-contracts/test/anvil-interop/src/core/const.ts
@@ -161,3 +161,4 @@ export enum CallStatus {
 
 // Selector for a non-existent function: someVeryUnfortunateCall()
 export const FAILING_CALL_CALLDATA = "0x00056d83";
+export const FAILING_INTEROP_CALL_REASON = "Intentional interop receiver failure";

--- a/l1-contracts/test/anvil-interop/src/helpers/balance-helpers.ts
+++ b/l1-contracts/test/anvil-interop/src/helpers/balance-helpers.ts
@@ -75,7 +75,9 @@ export async function approveToken(
   const wallet = new Wallet(getInteropSourcePrivateKey(), provider);
   const erc20 = new Contract(tokenAddress, getAbi("TestnetERC20Token"), wallet);
   const approveTx = await erc20.approve(spender, amount);
-  await approveTx.wait();
+  const receipt = await approveTx.wait();
+  expect(receipt.status, "token approval must succeed").to.equal(1);
+  expect((await erc20.allowance(wallet.address, spender)).toString(), "approved allowance").to.equal(amount.toString());
 }
 
 /**
@@ -139,7 +141,38 @@ export function expectBalanceDelta(before: BigNumber, after: BigNumber, expected
   ).to.be.true;
 }
 
+export async function expectSuccessfulReceipt(
+  provider: providers.JsonRpcProvider,
+  txHash: string | null | undefined,
+  label: string
+): Promise<providers.TransactionReceipt> {
+  expect(txHash, `${label}: transaction must have been submitted`).to.match(/^0x[0-9a-fA-F]{64}$/);
+  const receipt = await provider.getTransactionReceipt(txHash!);
+  expect(receipt, `${label}: transaction must be mined`).to.exist;
+  expect(receipt.status, `${label}: transaction must succeed`).to.equal(1);
+  return receipt;
+}
+
+/** Assert one event from the expected emitter, then expose its decoded arguments for outcome checks. */
+export function expectEvent(
+  receipt: providers.TransactionReceipt,
+  contract: ContractName,
+  address: string,
+  eventName: string
+): ethers.utils.Result {
+  expect(receipt.status, `${eventName}: transaction must succeed`).to.equal(1);
+  const iface = new ethers.utils.Interface(getAbi(contract));
+  const topic = iface.getEventTopic(eventName);
+  const logs = receipt.logs.filter(
+    (log) => log.address.toLowerCase() === address.toLowerCase() && log.topics[0] === topic
+  );
+  expect(logs, `${eventName} from ${address}`).to.have.length(1);
+  return iface.parseLog(logs[0]).args;
+}
+
 interface EthersLikeError {
+  argument?: string;
+  value?: unknown;
   body?: string;
   data?: unknown;
   error?: unknown;
@@ -166,7 +199,10 @@ export function customError(contract: ContractName, signature: string): CustomEr
 
 function resolveExpectedReason(expectedReason: ExpectedRevert): { matchValue: string; description: string } {
   if (typeof expectedReason === "string") {
-    return { matchValue: expectedReason, description: expectedReason };
+    const encodedReason =
+      ethers.utils.id("Error(string)").slice(0, 10) +
+      ethers.utils.defaultAbiCoder.encode(["string"], [expectedReason]).slice(2);
+    return { matchValue: encodedReason, description: expectedReason };
   }
 
   const selector = new ethers.utils.Interface(getAbi(expectedReason.contract)).getSighash(expectedReason.signature);
@@ -182,6 +218,12 @@ function extractRevertData(err: unknown): string {
   const errorWithData = err as EthersLikeError;
   const nestedErrorData = extractRevertData(errorWithData.error);
   if (nestedErrorData !== "" && nestedErrorData !== "0x") return nestedErrorData;
+
+  // staticPreviewHash decodes the intentional preview revert; other custom errors surface
+  // as ethers ABI decoding errors with the original revert bytes in argument="data"/value.
+  if (errorWithData.argument === "data" && typeof errorWithData.value === "string") {
+    return errorWithData.value;
+  }
 
   const directData = errorWithData.data;
   if (typeof directData === "string" && directData !== "" && directData !== "0x") return directData;
@@ -209,7 +251,8 @@ async function extractRevertDataFromCall(provider: providers.JsonRpcProvider, er
   if (!tx?.to || !tx.data) return "";
 
   try {
-    await provider.call(
+    // ethers can return eth_call revert bytes instead of throwing; retain both forms.
+    return await provider.call(
       {
         to: tx.to,
         from: tx.from,
@@ -222,42 +265,36 @@ async function extractRevertDataFromCall(provider: providers.JsonRpcProvider, er
   } catch (callErr: unknown) {
     return extractRevertData(callErr);
   }
-
-  return "";
 }
 
 /**
  * Assert that an async call reverts (throws).
- * Optionally match the error message / revert data against a selector or ABI-derived custom error.
+ * Match revert data against an ABI-encoded Error(string) or custom error selector.
  */
 export async function expectRevert(
   fn: () => Promise<unknown>,
   label: string,
-  expectedReason?: ExpectedRevert,
+  expectedReason: ExpectedRevert,
   provider?: providers.JsonRpcProvider
 ): Promise<void> {
   try {
     await fn();
   } catch (err: unknown) {
-    if (expectedReason) {
-      const { matchValue, description } = resolveExpectedReason(expectedReason);
-      // Check both the JS error message and the on-chain revert data
-      const msg = err instanceof Error ? err.message : String(err);
-      const hasReasonInMessage = msg.includes(matchValue);
-      const errorWithData = typeof err === "object" && err !== null ? (err as EthersLikeError) : undefined;
-      let errorData = extractRevertData(err);
-      if ((errorData === "" || errorData === "0x") && provider && errorWithData) {
-        const recoveredData = await extractRevertDataFromCall(provider, errorWithData);
-        if (recoveredData) {
-          errorData = recoveredData;
-        }
+    const { matchValue, description } = resolveExpectedReason(expectedReason);
+    const msg = err instanceof Error ? err.message : String(err);
+    const errorWithData = typeof err === "object" && err !== null ? (err as EthersLikeError) : undefined;
+    let errorData = extractRevertData(err);
+    if ((errorData === "" || errorData === "0x") && provider && errorWithData) {
+      const recoveredData = await extractRevertDataFromCall(provider, errorWithData);
+      if (recoveredData) {
+        errorData = recoveredData;
       }
-      const hasReasonInData = errorData.includes(matchValue);
-      expect(
-        hasReasonInMessage || hasReasonInData,
-        `${label}: revert reason mismatch — expected ${description} in message or data.\nMessage: ${msg.slice(0, 200)}\nData: ${String(errorData).slice(0, 200)}`
-      ).to.be.true;
     }
+    const hasReasonInData = errorData.startsWith(matchValue);
+    expect(
+      hasReasonInData,
+      `${label}: revert reason mismatch — expected ${description} in revert data.\nMessage: ${msg.slice(0, 200)}\nData: ${String(errorData).slice(0, 200)}`
+    ).to.be.true;
     return; // reverted as expected
   }
   expect.fail(`${label}: expected revert but call succeeded`);

--- a/l1-contracts/test/anvil-interop/src/helpers/interop-helpers.ts
+++ b/l1-contracts/test/anvil-interop/src/helpers/interop-helpers.ts
@@ -14,6 +14,7 @@ import { getInteropSourcePrivateKey, isLiveInteropMode } from "../core/accounts"
 import {
   ATOMIC_SEND_BUNDLE_GAS_LIMIT,
   DEFAULT_TX_GAS_LIMIT,
+  FAILING_INTEROP_CALL_REASON,
   INTEROP_BUNDLE_TUPLE_TYPE,
   INTEROP_CENTER_ADDR,
   L2_BOOTLOADER_ADDR,
@@ -38,7 +39,13 @@ import {
 } from "./imt-engine-lib";
 import type { AtomicFlowPreimage } from "./imt-engine-lib";
 export type { AtomicFlowPreimage } from "./imt-engine-lib";
-import { approveTokenForNtv, expectBalanceDelta, getTokenAddressForAsset, getTokenBalance } from "./balance-helpers";
+import {
+  approveTokenForNtv,
+  expectEvent,
+  expectBalanceDelta,
+  getTokenAddressForAsset,
+  getTokenBalance,
+} from "./balance-helpers";
 
 const abiCoder = ethers.utils.defaultAbiCoder;
 const sendResultsByBundleData = new Map<string, InteropSendResult>();
@@ -339,7 +346,8 @@ export async function registerL2NativeTokenIfNeeded(
   const registeredAssetId: string = await ntv.assetId(tokenAddress);
   if (registeredAssetId === ethers.constants.HashZero) {
     const tx = await ntv.registerToken(tokenAddress, { gasLimit: 500_000 });
-    await tx.wait();
+    const receipt = await tx.wait();
+    expect(receipt.status, "interop setup transaction must succeed").to.equal(1);
   }
 }
 
@@ -451,25 +459,14 @@ export async function sendInteropBundle(options: SendBundleOptions): Promise<Int
     value: options.value || 0,
   });
   const receipt = await tx.wait();
+  expect(receipt.status, "interop transaction must succeed").to.equal(1);
 
-  // Extract InteropBundleSent event
-  let interopBundle: unknown = null;
-  let bundleHash: string = ethers.constants.HashZero;
-  for (const logEntry of receipt.logs) {
-    try {
-      const parsed = interopCenter.interface.parseLog({ topics: logEntry.topics, data: logEntry.data });
-      if (parsed?.name === "InteropBundleSent") {
-        interopBundle = parsed.args["interopBundle"];
-        bundleHash = parsed.args["interopBundleHash"];
-        break;
-      }
-    } catch {
-      // Not an InteropCenter log
-    }
-  }
-  if (!interopBundle) {
-    throw new Error("InteropBundleSent event not found in source transaction receipt");
-  }
+  const sent = expectEvent(receipt, "InteropCenter", INTEROP_CENTER_ADDR, "InteropBundleSent");
+  const interopBundle = sent.interopBundle;
+  const bundleHash: string = sent.interopBundleHash;
+  expect(interopBundle.sourceChainId.toNumber()).to.equal(legSourceChainId);
+  expect(interopBundle.destinationChainId.toNumber()).to.equal(options.destinationChainId);
+  expect(interopBundle.calls, "sent bundle call count").to.have.length(options.callStarters.length);
 
   // For the auto single-leg path the predicted hash feeds the atomic flowId; a mismatch would make the
   // finality proof unverifiable. (Caller-managed flows do their own cross-check.)
@@ -570,25 +567,13 @@ export async function sendInteropMessage(options: SendMessageOptions): Promise<I
     }
   );
   const receipt = await tx.wait();
+  expect(receipt.status, "interop transaction must succeed").to.equal(1);
 
-  // Extract InteropBundleSent event
-  let interopBundle: unknown = null;
-  let bundleHash: string = ethers.constants.HashZero;
-  for (const logEntry of receipt.logs) {
-    try {
-      const parsed = interopCenter.interface.parseLog({ topics: logEntry.topics, data: logEntry.data });
-      if (parsed?.name === "InteropBundleSent") {
-        interopBundle = parsed.args["interopBundle"];
-        bundleHash = parsed.args["interopBundleHash"];
-        break;
-      }
-    } catch {
-      // Not an InteropCenter log
-    }
-  }
-  if (!interopBundle) {
-    throw new Error("InteropBundleSent event not found in sendMessage receipt");
-  }
+  const sent = expectEvent(receipt, "InteropCenter", INTEROP_CENTER_ADDR, "InteropBundleSent");
+  const interopBundle = sent.interopBundle;
+  const bundleHash: string = sent.interopBundleHash;
+  expect(interopBundle.sourceChainId.toNumber()).to.equal(atomic.sourceChainId);
+  expect(interopBundle.calls, "sent bundle call count").to.have.length(1);
 
   if (bundleHash.toLowerCase() !== predictedBundleHash.toLowerCase()) {
     throw new Error(`predicted message bundleHash ${predictedBundleHash} != emitted ${bundleHash}`);
@@ -662,7 +647,11 @@ export async function executeBundle(
   const tx = await interopHandler.executeAtomicBundle(bundleData, proof, {
     gasLimit: gasLimit || DEFAULT_TX_GAS_LIMIT,
   });
-  return tx.wait();
+  const receipt = await tx.wait();
+  expect(receipt.status, "interop transaction must succeed").to.equal(1);
+  const event = expectEvent(receipt, "L2InteropHandler", L2_INTEROP_HANDLER_ADDR, "BundleExecuted");
+  expect(event.bundleHash, "BundleExecuted bundle hash").to.equal(ethers.utils.keccak256(bundleData));
+  return receipt;
 }
 
 /**
@@ -699,7 +688,11 @@ export async function verifyBundle(
   const { bundleData, proof } = await getInteropExecutionData(destProvider, bundleInput, sourceChainId);
 
   const tx = await interopHandler.verifyAtomicBundle(bundleData, proof, { gasLimit: DEFAULT_TX_GAS_LIMIT });
-  return tx.wait();
+  const receipt = await tx.wait();
+  expect(receipt.status, "interop transaction must succeed").to.equal(1);
+  const event = expectEvent(receipt, "L2InteropHandler", L2_INTEROP_HANDLER_ADDR, "BundleVerified");
+  expect(event.bundleHash, "BundleVerified bundle hash").to.equal(ethers.utils.keccak256(bundleData));
+  return receipt;
 }
 
 /**
@@ -734,7 +727,11 @@ export async function unbundleBundle(
   const interopHandler = new Contract(L2_INTEROP_HANDLER_ADDR, getAbi("L2InteropHandler"), wallet);
 
   const tx = await interopHandler.unbundleBundle(bundleData, callStatuses, { gasLimit: DEFAULT_TX_GAS_LIMIT });
-  return tx.wait();
+  const receipt = await tx.wait();
+  expect(receipt.status, "interop transaction must succeed").to.equal(1);
+  const event = expectEvent(receipt, "L2InteropHandler", L2_INTEROP_HANDLER_ADDR, "BundleUnbundled");
+  expect(event.bundleHash, "BundleUnbundled bundle hash").to.equal(ethers.utils.keccak256(bundleData));
+  return receipt;
 }
 
 /**
@@ -793,7 +790,8 @@ export async function setInteropProtocolFee(provider: providers.JsonRpcProvider,
   const interopCenter = new Contract(INTEROP_CENTER_ADDR, getAbi("InteropCenter"), provider);
   await impersonateAndRun(provider, L2_BOOTLOADER_ADDR, async (signer) => {
     const tx = await interopCenter.connect(signer).setInteropFee(fee, { gasLimit: 500_000 });
-    await tx.wait();
+    const receipt = await tx.wait();
+    expect(receipt.status, "interop setup transaction must succeed").to.equal(1);
   });
 
   const actualFee = await interopCenter.interopProtocolFee();
@@ -931,23 +929,23 @@ export async function deployDummyInteropRecipient(
   return contract.address;
 }
 
-/**
- * Deploy a minimal contract that reverts on any call.
- * Used to create deterministic failing calls in unbundle tests.
- *
- * Bytecode: PUSH1 0x00 PUSH1 0x00 REVERT (runtime: 0x60006000fd)
- * Init code: deploys the revert bytecode as runtime code.
- */
+/** Deploy a receiver that always reverts with a distinctive reason, so unrelated failures cannot satisfy tests. */
 export async function deployRevertingContract(
   provider: providers.JsonRpcProvider,
   signerKey?: string
 ): Promise<string> {
   const wallet = new Wallet(signerKey || getInteropSourcePrivateKey(), provider);
-  // Init code that returns 0x60006000fd as the deployed runtime code
-  // PUSH5 0x60006000fd PUSH1 0x00 MSTORE PUSH1 0x05 PUSH1 0x1b RETURN
-  const initCode = "0x6460006000fd6000526005601bf3";
+  const revertData =
+    ethers.utils.id("Error(string)").slice(0, 10) + abiCoder.encode(["string"], [FAILING_INTEROP_CALL_REASON]).slice(2);
+  // Both programs copy the bytes following their 12-byte header: runtime reverts with the
+  // ABI-encoded reason; init code returns that runtime. No Solidity fixture changes are needed.
+  const dataLength = ethers.utils.hexlify(ethers.utils.arrayify(revertData).length).slice(2);
+  const runtime = `60${dataLength}600c60003960${dataLength}6000fd${revertData.slice(2)}`;
+  const runtimeLength = ethers.utils.hexlify(runtime.length / 2).slice(2);
+  const initCode = `0x60${runtimeLength}600c60003960${runtimeLength}6000f3${runtime}`;
   const tx = await wallet.sendTransaction({ data: initCode });
   const receipt = await tx.wait();
+  expect(receipt.status, "interop transaction must succeed").to.equal(1);
   if (!receipt.contractAddress) throw new Error("Failed to deploy reverting contract");
   return receipt.contractAddress;
 }

--- a/l1-contracts/test/anvil-interop/test/hardhat/01-deployment-verification.spec.ts
+++ b/l1-contracts/test/anvil-interop/test/hardhat/01-deployment-verification.spec.ts
@@ -1,20 +1,12 @@
+import { execFileSync } from "child_process";
+import * as path from "path";
 import { expect } from "chai";
 import type { providers } from "ethers";
-import { Contract } from "ethers";
+import { Contract, ethers } from "ethers";
 import { DeploymentRunner } from "../../src/deployment-runner";
 import { getAbi } from "../../src/core/contracts";
 import { createProvider } from "../../src/core/utils";
-import {
-  L2_BRIDGEHUB_ADDR,
-  L2_ASSET_ROUTER_ADDR,
-  L2_ASSET_TRACKER_ADDR,
-  L2_NATIVE_TOKEN_VAULT_ADDR,
-  L2_MESSAGE_ROOT_ADDR,
-  L2_CHAIN_ASSET_HANDLER_ADDR,
-  INTEROP_CENTER_ADDR,
-  L2_INTEROP_HANDLER_ADDR,
-  L2_MESSAGE_VERIFICATION_ADDR,
-} from "../../src/core/const";
+import { PREDEPLOY_SYSTEM_CONTRACTS } from "../../src/core/predeploys";
 
 describe("01 - Deployment Verification", function () {
   this.timeout(0);
@@ -39,7 +31,6 @@ describe("01 - Deployment Verification", function () {
     it("has Bridgehub deployed with code", async () => {
       const code = await l1Provider.getCode(state.l1Addresses!.bridgehub);
       expect(code).to.not.equal("0x");
-      expect(code).to.not.equal("0x0");
     });
 
     it("has L1AssetRouter (SharedBridge) deployed with code", async () => {
@@ -73,22 +64,46 @@ describe("01 - Deployment Verification", function () {
         expect(chainAddr, `Chain ${chainConfig.chainId} not found in chainAddresses`).to.exist;
         const code = await l1Provider.getCode(chainAddr!.diamondProxy);
         expect(code).to.not.equal("0x");
+        const bridgehub = new Contract(state.l1Addresses!.bridgehub, getAbi("L1Bridgehub"), l1Provider);
+        expect(await bridgehub.getZKChain(chainConfig.chainId)).to.equal(chainAddr!.diamondProxy);
+        const diamond = new Contract(chainAddr!.diamondProxy, getAbi("IZKChain"), l1Provider);
+        expect((await diamond.getChainId()).toNumber()).to.equal(chainConfig.chainId);
+        expect(await diamond.getChainTypeManager()).to.equal(state.ctmAddresses!.chainTypeManager);
       });
     }
   });
 
   describe("L2 system contracts", () => {
-    const expectedContracts = [
-      { addr: L2_BRIDGEHUB_ADDR, name: "L2Bridgehub" },
-      { addr: L2_ASSET_ROUTER_ADDR, name: "L2AssetRouter" },
-      { addr: L2_NATIVE_TOKEN_VAULT_ADDR, name: "L2NativeTokenVault" },
-      { addr: L2_ASSET_TRACKER_ADDR, name: "L2AssetTracker" },
-      { addr: L2_MESSAGE_ROOT_ADDR, name: "L2MessageRoot" },
-      { addr: L2_CHAIN_ASSET_HANDLER_ADDR, name: "L2ChainAssetHandler" },
-      { addr: INTEROP_CENTER_ADDR, name: "InteropCenter" },
-      { addr: L2_INTEROP_HANDLER_ADDR, name: "L2InteropHandler" },
-      { addr: L2_MESSAGE_VERIFICATION_ADDR, name: "L2MessageVerification" },
-    ];
+    // The harness deliberately installs MockL2MessageVerification, MockL1MessengerHook,
+    // MockMintBaseTokenHook and MockContractDeployer; compare them against their mock artifacts.
+    const expectedContracts = PREDEPLOY_SYSTEM_CONTRACTS;
+    const expectedBytecodes = new Map<string, string>();
+
+    before(() => {
+      // Snapshots use the metadata-free anvil-interop profile. Build matching references in
+      // isolated output/cache directories so coverage's default-profile artifacts stay intact.
+      const root = path.resolve(__dirname, "../../../..");
+      const output = path.join(
+        root,
+        "test/anvil-interop/outputs",
+        `predeploy-identity${process.env.ANVIL_INTEROP_RUN_SUFFIX || ""}`
+      );
+      const buildArgs = ["--out", path.join(output, "out"), "--cache-path", path.join(output, "cache")];
+      const options = {
+        cwd: root,
+        env: { ...process.env, FOUNDRY_PROFILE: "anvil-interop" },
+        encoding: "utf8" as const,
+        maxBuffer: 32 * 1024 * 1024,
+      };
+      execFileSync("forge", ["build", "--skip", "test", "--skip", "script", ...buildArgs], options);
+      const artifactNames = [...expectedContracts.map(({ contractName }) => contractName), "L2ChainAssetHandlerDev"];
+      for (const contractName of artifactNames) {
+        expectedBytecodes.set(
+          contractName,
+          execFileSync("forge", ["inspect", contractName, "deployedBytecode", ...buildArgs], options).trim()
+        );
+      }
+    });
 
     const config = runner.getConfig();
     for (const chainConfig of config.chains.filter((c) => c.role !== "l1")) {
@@ -104,10 +119,19 @@ describe("01 - Deployment Verification", function () {
         });
 
         for (const contract of expectedContracts) {
-          it(`has ${contract.name} at ${contract.addr}`, async () => {
-            const code = await l2Provider.getCode(contract.addr);
-            expect(code, `${contract.name} not deployed on chain ${chainConfig.chainId}`).to.not.equal("0x");
-            expect(code).to.not.equal("0x0");
+          it(`has ${contract.contractName} at ${contract.address}`, async () => {
+            const code = await l2Provider.getCode(contract.address);
+            // Gateway setup deliberately replaces this predeploy to enable test migrations.
+            const artifactName =
+              chainConfig.role === "gateway" && contract.contractName === "L2ChainAssetHandler"
+                ? "L2ChainAssetHandlerDev"
+                : contract.contractName;
+            const expectedCode = expectedBytecodes.get(artifactName)!;
+            expect(expectedCode, `${contract.contractName} runtime artifact must exist`).to.not.equal("0x");
+            expect(
+              ethers.utils.keccak256(code),
+              `${contract.contractName} runtime identity on chain ${chainConfig.chainId}`
+            ).to.equal(ethers.utils.keccak256(expectedCode));
           });
         }
       });
@@ -118,9 +142,10 @@ describe("01 - Deployment Verification", function () {
     it("test tokens deployed on all L2 chains", () => {
       expect(state.testTokens).to.exist;
       for (const l2Chain of state.chains!.l2) {
-        expect(state.testTokens![l2Chain.chainId], `Test token not deployed on chain ${l2Chain.chainId}`).to.be.a(
-          "string"
-        );
+        expect(
+          ethers.utils.isAddress(state.testTokens![l2Chain.chainId]),
+          `Test token address on chain ${l2Chain.chainId}`
+        ).to.equal(true);
       }
     });
 
@@ -128,9 +153,7 @@ describe("01 - Deployment Verification", function () {
     for (const chainConfig of config.chains.filter((c) => c.role !== "l1")) {
       it(`test token on chain ${chainConfig.chainId} (${chainConfig.role}) has code`, async () => {
         const tokenAddr = state.testTokens![chainConfig.chainId];
-        if (!tokenAddr) {
-          return; // Skip if token wasn't deployed (will be caught by prior test)
-        }
+        expect(tokenAddr, `Test token required on chain ${chainConfig.chainId}`).to.match(/^0x[0-9a-fA-F]{40}$/);
         const chain = state.chains!.l2.find((c) => c.chainId === chainConfig.chainId);
         const provider = createProvider(chain!.rpcUrl);
         const code = await provider.getCode(tokenAddr);

--- a/l1-contracts/test/anvil-interop/test/hardhat/02-direct-bridge.spec.ts
+++ b/l1-contracts/test/anvil-interop/test/hardhat/02-direct-bridge.spec.ts
@@ -1,11 +1,30 @@
 import { expect } from "chai";
-import { ethers } from "ethers";
+import { Contract, ethers } from "ethers";
 import { DeploymentRunner } from "../../src/deployment-runner";
 import { depositETHToL2 } from "../../src/helpers/l1-deposit-helper";
 import { withdrawETHFromL2 } from "../../src/helpers/l2-withdrawal-helper";
 import { getL1BridgedOut, getL1BaseTokenAssetId } from "../../src/helpers/bridged-out-helper";
-import { ANVIL_DEFAULT_ACCOUNT_ADDR, ANVIL_RECIPIENT_ADDR } from "../../src/core/const";
+import {
+  ANVIL_INTEROP_BASE_TOKEN_PRIORITY_TX_GAS_LIMIT,
+  ANVIL_INTEROP_PRIORITY_TX_L1_GAS_PRICE_WEI,
+  ANVIL_INTEROP_REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
+  ANVIL_DEFAULT_ACCOUNT_ADDR,
+  ANVIL_RECIPIENT_ADDR,
+  INTEROP_CENTER_ADDR,
+} from "../../src/core/const";
 import { getL2Chain, getChainIdByRole, createProvider } from "../../src/core/utils";
+
+import { getAbi } from "../../src/core/contracts";
+import {
+  expectBalanceDelta,
+  expectNativeSpend,
+  expectSuccessfulReceipt,
+  expectEvent,
+  randomBigNumber,
+} from "../../src/helpers/balance-helpers";
+
+const ETH_AMOUNT_MIN = ethers.utils.parseEther("0.1");
+const ETH_AMOUNT_MAX = ethers.utils.parseEther("0.5");
 
 describe("02 - Direct L1<->L2 Bridge (direct-settled chain)", function () {
   this.timeout(0);
@@ -27,7 +46,7 @@ describe("02 - Direct L1<->L2 Bridge (direct-settled chain)", function () {
       const l1Provider = createProvider(state.chains!.l1!.rpcUrl);
       const senderAddr = ANVIL_DEFAULT_ACCOUNT_ADDR;
       const recipientAddr = ANVIL_RECIPIENT_ADDR;
-      const amount = ethers.utils.parseEther("1.0");
+      const amount = randomBigNumber(ETH_AMOUNT_MIN, ETH_AMOUNT_MAX);
       const l2Chain = getL2Chain(state.chains!, directSettledChainId);
       const l2Provider = createProvider(l2Chain.rpcUrl);
 
@@ -40,6 +59,16 @@ describe("02 - Direct L1<->L2 Bridge (direct-settled chain)", function () {
       const ethAssetId = await getL1BaseTokenAssetId(state.chains!.l1!.rpcUrl, l1Ntv);
       const bridgedOutBefore = await getL1BridgedOut(state.chains!.l1!.rpcUrl, l1Ntv, ethAssetId);
 
+      const bridgehub = new Contract(state.l1Addresses!.bridgehub, getAbi("L1Bridgehub"), l1Provider);
+      const expectedMintValue = amount.add(
+        await bridgehub.l2TransactionBaseCost(
+          directSettledChainId,
+          ANVIL_INTEROP_PRIORITY_TX_L1_GAS_PRICE_WEI,
+          ANVIL_INTEROP_BASE_TOKEN_PRIORITY_TX_GAS_LIMIT,
+          ANVIL_INTEROP_REQUIRED_L2_GAS_PRICE_PER_PUBDATA
+        )
+      );
+
       const result = await depositETHToL2({
         l1RpcUrl: state.chains!.l1!.rpcUrl,
         l2RpcUrl: l2Chain.rpcUrl,
@@ -49,7 +78,18 @@ describe("02 - Direct L1<->L2 Bridge (direct-settled chain)", function () {
         recipient: recipientAddr,
       });
 
-      expect(result.l1TxHash).to.not.be.null;
+      const l1Receipt = await expectSuccessfulReceipt(l1Provider, result.l1TxHash, "deposit L1");
+      await expectSuccessfulReceipt(l2Provider, result.l2TxHash, "deposit L2 relay");
+      const initiated = expectEvent(
+        l1Receipt,
+        "L1AssetRouter",
+        state.l1Addresses!.l1SharedBridge,
+        "BridgehubDepositBaseTokenInitiated"
+      );
+      expect(initiated.chainId.toNumber()).to.equal(directSettledChainId);
+      expect(initiated.from).to.equal(senderAddr);
+      expect(initiated.assetId).to.equal(ethAssetId);
+      expect(initiated.amount.toString()).to.equal(expectedMintValue.toString());
 
       const senderL1After = await l1Provider.getBalance(senderAddr);
       const recipientL2After = await l2Provider.getBalance(recipientAddr);
@@ -58,25 +98,20 @@ describe("02 - Direct L1<->L2 Bridge (direct-settled chain)", function () {
       const bridgedOutAfter = await getL1BridgedOut(state.chains!.l1!.rpcUrl, l1Ntv, ethAssetId);
       const bridgedOutDelta = bridgedOutAfter.sub(bridgedOutBefore);
       expect(
-        bridgedOutDelta.eq(result.mintValue),
-        `bridgedOut[ETH] should increase by ${result.mintValue.toString()}, got ${bridgedOutDelta.toString()}`
+        bridgedOutDelta.eq(expectedMintValue),
+        `bridgedOut[ETH] should increase by ${expectedMintValue.toString()}, got ${bridgedOutDelta.toString()}`
       ).to.equal(true);
 
-      // Sender's L1 ETH balance should decrease (by at least mintValue; gas costs add to the decrease)
-      const senderL1Delta = senderL1After.sub(senderL1Before);
-      expect(
-        senderL1Delta.lte(result.mintValue.mul(-1)),
-        `Sender L1 ETH balance should decrease by at least ${result.mintValue.toString()}, got delta ${senderL1Delta.toString()}`
-      ).to.equal(true);
+      expectNativeSpend(
+        { native: senderL1Before },
+        { native: senderL1After },
+        expectedMintValue,
+        l1Receipt,
+        "deposit sender L1"
+      );
 
-      // Recipient's L2 ETH balance should increase
-      const recipientL2Delta = recipientL2After.sub(recipientL2Before);
-      expect(
-        recipientL2Delta.gt(0),
-        `Recipient L2 ETH balance should increase after deposit, got delta ${recipientL2Delta.toString()}`
-      ).to.equal(true);
-
-      console.log(`   Recipient L2 ETH balance delta: ${ethers.utils.formatEther(recipientL2Delta)} ETH`);
+      // The Anvil priority relay forwards l2Value exactly; bootloader fee refunds are not simulated.
+      expectBalanceDelta(recipientL2Before, recipientL2After, amount, "deposit recipient L2");
     });
   });
 
@@ -84,8 +119,11 @@ describe("02 - Direct L1<->L2 Bridge (direct-settled chain)", function () {
     it("withdraws ETH from L2 to L1", async () => {
       const l1Provider = createProvider(state.chains!.l1!.rpcUrl);
       const recipientAddr = ANVIL_RECIPIENT_ADDR;
-      const amount = ethers.utils.parseEther("0.5");
+      const amount = randomBigNumber(ETH_AMOUNT_MIN, ETH_AMOUNT_MAX);
       const l2Chain = getL2Chain(state.chains!, directSettledChainId);
+
+      const l2Provider = createProvider(l2Chain.rpcUrl);
+      const senderL2Before = await l2Provider.getBalance(ANVIL_DEFAULT_ACCOUNT_ADDR);
 
       // Snapshot recipient's L1 balance
       const recipientL1Before = await l1Provider.getBalance(recipientAddr);
@@ -104,7 +142,37 @@ describe("02 - Direct L1<->L2 Bridge (direct-settled chain)", function () {
         l1Recipient: recipientAddr,
       });
 
-      expect(result.l2TxHash).to.not.be.null;
+      const l2Receipt = await expectSuccessfulReceipt(l2Provider, result.l2TxHash, "withdrawal L2");
+      const l1Receipt = await expectSuccessfulReceipt(l1Provider, result.l1TxHash, "withdrawal L1 finalization");
+      const senderL2After = await l2Provider.getBalance(ANVIL_DEFAULT_ACCOUNT_ADDR);
+      expectNativeSpend(
+        { native: senderL2Before },
+        { native: senderL2After },
+        amount,
+        l2Receipt,
+        "withdrawal sender L2"
+      );
+      const sent = expectEvent(l2Receipt, "InteropCenter", INTEROP_CENTER_ADDR, "InteropBundleSent");
+      expect(sent.interopBundle.sourceChainId.toNumber()).to.equal(directSettledChainId);
+      expect(sent.interopBundle.destinationChainId.toNumber()).to.equal(state.chains!.l1!.chainId);
+      expect(sent.interopBundle.calls).to.have.length(1);
+      const nullifier = new Contract(state.l1Addresses!.l1NullifierProxy, getAbi("L1Nullifier"), l1Provider);
+      const handlerAddress = await nullifier.l1InteropHandler();
+      const executed = expectEvent(l1Receipt, "L1InteropHandler", handlerAddress, "BundleExecuted");
+      expect(executed.bundleHash).to.equal(sent.interopBundleHash);
+      const finalized = expectEvent(
+        l1Receipt,
+        "L1AssetRouter",
+        state.l1Addresses!.l1SharedBridge,
+        "DepositFinalizedAssetRouter"
+      );
+      expect(finalized.sourceChainId.toNumber()).to.equal(directSettledChainId);
+      expect(finalized.assetId).to.equal(ethAssetId);
+      const minted = expectEvent(l1Receipt, "L1NativeTokenVault", l1Ntv, "BridgeMint");
+      expect(minted.chainId.toNumber()).to.equal(directSettledChainId);
+      expect(minted.assetId).to.equal(ethAssetId);
+      expect(minted.receiver).to.equal(recipientAddr);
+      expect(minted.amount.toString()).to.equal(amount.toString());
 
       const recipientL1After = await l1Provider.getBalance(recipientAddr);
 

--- a/l1-contracts/test/anvil-interop/test/hardhat/03-interop-transfer.spec.ts
+++ b/l1-contracts/test/anvil-interop/test/hardhat/03-interop-transfer.spec.ts
@@ -1,22 +1,39 @@
 import { expect } from "chai";
-import { BigNumber } from "ethers";
+import { ethers } from "ethers";
 import { executeTokenTransfer } from "../../src/helpers/token-transfer";
 import { DeploymentRunner } from "../../src/deployment-runner";
-import { getChainIdByRole, getChainIdsByRole } from "../../src/core/utils";
+import { getChainIdByRole, getChainIdsByRole, getL2RpcUrl, createProvider } from "../../src/core/utils";
 
-async function expectTransferToRevert(promise: Promise<unknown>, expectedSubstring?: string): Promise<void> {
-  let rejected = false;
-  try {
-    await promise;
-  } catch (error) {
-    rejected = true;
-    if (expectedSubstring) {
-      const message = error instanceof Error ? error.message : String(error);
-      expect(message).to.contain(expectedSubstring);
-    }
-  }
-  expect(rejected, "Expected transfer to revert").to.equal(true);
-}
+import {
+  customError,
+  expectRevert,
+  captureBalance,
+  getTokenBalance,
+  getTokenAddressForAsset,
+  approveTokenForNtv,
+  expectBalanceDelta,
+  expectNativeSpend,
+  expectSuccessfulReceipt,
+  expectEvent,
+  randomBigNumber,
+} from "../../src/helpers/balance-helpers";
+
+import {
+  ANVIL_DEFAULT_ACCOUNT_ADDR,
+  INTEROP_CENTER_ADDR,
+  L2_INTEROP_HANDLER_ADDR,
+  L2_NATIVE_TOKEN_VAULT_ADDR,
+  BundleStatus,
+} from "../../src/core/const";
+import { encodeNtvAssetId } from "../../src/core/data-encoding";
+import {
+  getInteropProtocolFee,
+  registerL2NativeTokenIfNeeded,
+  getBundleStatus,
+} from "../../src/helpers/interop-helpers";
+
+const TOKEN_AMOUNT_MIN = ethers.utils.parseUnits("1", 18);
+const TOKEN_AMOUNT_MAX = ethers.utils.parseUnits("10", 18);
 
 describe("03 - Interop Transfer", function () {
   this.timeout(0);
@@ -42,107 +59,146 @@ describe("03 - Interop Transfer", function () {
 
   // Happy path: transfers between chains that share the gateway settlement layer succeed.
 
-  it("transfers tokens from first GW-settled chain to second GW-settled chain", async () => {
-    const sourceToken = state.testTokens![gwSettledChainIds[0]];
-    const result = await executeTokenTransfer({
-      sourceChainId: gwSettledChainIds[0],
-      targetChainId: gwSettledChainIds[1],
-      amount: "10",
-      sourceTokenAddress: sourceToken,
-      logger: (line: string) => console.log(`[interop] ${line}`),
-    });
-
-    expect(result.sourceTxHash).to.not.be.null;
-    expect(result.targetTxHash).to.not.be.null;
-
-    const sourceBalanceDelta = BigNumber.from(result.sourceBalanceBefore).sub(result.sourceBalanceAfter);
-    const destinationBalanceDelta = BigNumber.from(result.destinationBalanceAfter).sub(result.destinationBalanceBefore);
-
-    expect(sourceBalanceDelta.eq(result.amountWei), "source chain burned amount mismatch").to.eq(true);
-    expect(destinationBalanceDelta.eq(result.amountWei), "destination chain minted amount mismatch").to.eq(true);
-  });
-
-  it("transfers tokens from second GW-settled chain to first GW-settled chain", async () => {
-    const sourceToken = state.testTokens![gwSettledChainIds[1]];
-    const result = await executeTokenTransfer({
-      sourceChainId: gwSettledChainIds[1],
-      targetChainId: gwSettledChainIds[0],
-      amount: "5",
-      sourceTokenAddress: sourceToken,
-      logger: (line: string) => console.log(`[interop] ${line}`),
-    });
-
-    expect(result.sourceTxHash).to.not.be.null;
-    expect(result.targetTxHash).to.not.be.null;
-
-    const sourceBalanceDelta = BigNumber.from(result.sourceBalanceBefore).sub(result.sourceBalanceAfter);
-    const destinationBalanceDelta = BigNumber.from(result.destinationBalanceAfter).sub(result.destinationBalanceBefore);
-
-    expect(sourceBalanceDelta.eq(result.amountWei), "source chain burned amount mismatch").to.eq(true);
-    expect(destinationBalanceDelta.eq(result.amountWei), "destination chain minted amount mismatch").to.eq(true);
-  });
-
-  it("transfers tokens between two different GW-settled chains (reverse direction)", async () => {
-    const sourceToken = state.testTokens![gwSettledChainIds[0]];
-    const result = await executeTokenTransfer({
-      sourceChainId: gwSettledChainIds[0],
-      targetChainId: gwSettledChainIds[1],
-      amount: "3",
-      sourceTokenAddress: sourceToken,
-      logger: (line: string) => console.log(`[interop] ${line}`),
-    });
-
-    expect(result.sourceTxHash).to.not.be.null;
-    expect(result.targetTxHash).to.not.be.null;
-
-    const sourceBalanceDelta = BigNumber.from(result.sourceBalanceBefore).sub(result.sourceBalanceAfter);
-    const destinationBalanceDelta = BigNumber.from(result.destinationBalanceAfter).sub(result.destinationBalanceBefore);
-
-    expect(sourceBalanceDelta.eq(result.amountWei), "source chain burned amount mismatch").to.eq(true);
-    expect(destinationBalanceDelta.eq(result.amountWei), "destination chain minted amount mismatch").to.eq(true);
-  });
-
-  // Registration paths: transfers that cross a settlement-layer boundary (GW-settled -> gateway, and
-  // direct-settled <-> gateway/GW-settled) are not registered and must revert. Note: the reverse
-  // direction (gateway -> GW-settled) IS a valid interop path — the gateway is a full interop
-  // participant with the chains that settle on it — and is exercised by the happy-path tests' cluster.
-
-  it("rejects transfers from GW-settled chains to the gateway chain", async () => {
-    const sourceToken = state.testTokens![gwSettledChainIds[0]];
-    await expectTransferToRevert(
-      executeTokenTransfer({
-        sourceChainId: gwSettledChainIds[0],
-        targetChainId: gatewayChainId,
-        amount: "5",
+  for (const { title, sourceIndex, targetIndex } of [
+    {
+      title: "transfers tokens from first GW-settled chain to second GW-settled chain",
+      sourceIndex: 0,
+      targetIndex: 1,
+    },
+    {
+      title: "transfers tokens from second GW-settled chain to first GW-settled chain",
+      sourceIndex: 1,
+      targetIndex: 0,
+    },
+    { title: "repeats a transfer to an existing bridged token on a GW-settled chain", sourceIndex: 0, targetIndex: 1 },
+  ]) {
+    it(title, async () => {
+      const sourceChainId = gwSettledChainIds[sourceIndex];
+      const targetChainId = gwSettledChainIds[targetIndex];
+      const sourceToken = state.testTokens![sourceChainId];
+      const amountWei = randomBigNumber(TOKEN_AMOUNT_MIN, TOKEN_AMOUNT_MAX);
+      const sourceProvider = createProvider(getL2RpcUrl(state, sourceChainId));
+      const targetProvider = createProvider(getL2RpcUrl(state, targetChainId));
+      const assetId = encodeNtvAssetId(sourceChainId, sourceToken);
+      await registerL2NativeTokenIfNeeded(sourceProvider, sourceToken);
+      await approveTokenForNtv(sourceProvider, sourceToken, amountWei);
+      const fee = await getInteropProtocolFee(sourceProvider);
+      const sourceBefore = await captureBalance(sourceProvider, sourceToken);
+      const destinationTokenBefore = await getTokenAddressForAsset(targetProvider, assetId);
+      const destinationBefore = await getTokenBalance(
+        targetProvider,
+        destinationTokenBefore,
+        ANVIL_DEFAULT_ACCOUNT_ADDR
+      );
+      const result = await executeTokenTransfer({
+        sourceChainId,
+        targetChainId,
+        amount: ethers.utils.formatUnits(amountWei, 18),
         sourceTokenAddress: sourceToken,
         logger: (line: string) => console.log(`[interop] ${line}`),
-      })
+      });
+
+      const sourceReceipt = await expectSuccessfulReceipt(sourceProvider, result.sourceTxHash, "interop source");
+      const targetReceipt = await expectSuccessfulReceipt(targetProvider, result.targetTxHash, "interop destination");
+      const sourceAfter = await captureBalance(sourceProvider, sourceToken);
+      const destinationToken = await getTokenAddressForAsset(targetProvider, assetId);
+      const destinationAfter = await getTokenBalance(targetProvider, destinationToken, ANVIL_DEFAULT_ACCOUNT_ADDR);
+      expectBalanceDelta(sourceBefore.token!, sourceAfter.token!, amountWei.mul(-1), "interop source token");
+      expectBalanceDelta(destinationBefore, destinationAfter, amountWei, "interop destination token");
+      expectNativeSpend(sourceBefore, sourceAfter, fee, sourceReceipt, "interop source fee");
+
+      const sent = expectEvent(sourceReceipt, "InteropCenter", INTEROP_CENTER_ADDR, "InteropBundleSent");
+      expect(sent.interopBundle.sourceChainId.toNumber()).to.equal(sourceChainId);
+      expect(sent.interopBundle.destinationChainId.toNumber()).to.equal(targetChainId);
+      expect(sent.interopBundle.calls).to.have.length(1);
+      const executed = expectEvent(targetReceipt, "L2InteropHandler", L2_INTEROP_HANDLER_ADDR, "BundleExecuted");
+      expect(executed.bundleHash).to.equal(sent.interopBundleHash);
+      expect(await getBundleStatus(targetProvider, sent.interopBundleHash)).to.equal(BundleStatus.FullyExecuted);
+      const minted = expectEvent(targetReceipt, "L2NativeTokenVault", L2_NATIVE_TOKEN_VAULT_ADDR, "BridgeMint");
+      expect(minted.chainId.toNumber()).to.equal(sourceChainId);
+      expect(minted.assetId).to.equal(assetId);
+      expect(minted.receiver).to.equal(ANVIL_DEFAULT_ACCOUNT_ADDR);
+      expect(minted.amount.toString()).to.equal(amountWei.toString());
+    });
+  }
+
+  // These destinations are absent from the source Bridgehub's registration set in this
+  // topology. Captured on Anvil: 0x2d159f39, DestinationChainNotRegistered(uint256).
+  it("rejects transfers from GW-settled chains to the gateway chain", async () => {
+    const sourceToken = state.testTokens![gwSettledChainIds[0]];
+    const sourceProvider = createProvider(getL2RpcUrl(state, gwSettledChainIds[0]));
+    const sourceBefore = await captureBalance(sourceProvider, sourceToken);
+    await expectRevert(
+      () =>
+        executeTokenTransfer({
+          sourceChainId: gwSettledChainIds[0],
+          targetChainId: gatewayChainId,
+          amount: "5",
+          sourceTokenAddress: sourceToken,
+          logger: (line: string) => console.log(`[interop] ${line}`),
+        }),
+      "unregistered destination route",
+      customError("InteropCenter", "DestinationChainNotRegistered(uint256)"),
+      createProvider(getL2RpcUrl(state, gwSettledChainIds[0]))
+    );
+    const sourceAfter = await captureBalance(sourceProvider, sourceToken);
+    expectBalanceDelta(
+      sourceBefore.token!,
+      sourceAfter.token!,
+      ethers.constants.Zero,
+      "rejected transfer source token"
     );
   });
 
   it("rejects transfers from direct-settled chains to the gateway chain across settlement layers", async () => {
     const sourceToken = state.testTokens![directSettledChainId];
-    await expectTransferToRevert(
-      executeTokenTransfer({
-        sourceChainId: directSettledChainId,
-        targetChainId: gatewayChainId,
-        amount: "3",
-        sourceTokenAddress: sourceToken,
-        logger: (line: string) => console.log(`[interop] ${line}`),
-      })
+    const sourceProvider = createProvider(getL2RpcUrl(state, directSettledChainId));
+    const sourceBefore = await captureBalance(sourceProvider, sourceToken);
+    await expectRevert(
+      () =>
+        executeTokenTransfer({
+          sourceChainId: directSettledChainId,
+          targetChainId: gatewayChainId,
+          amount: "3",
+          sourceTokenAddress: sourceToken,
+          logger: (line: string) => console.log(`[interop] ${line}`),
+        }),
+      "unregistered destination route",
+      customError("InteropCenter", "DestinationChainNotRegistered(uint256)"),
+      createProvider(getL2RpcUrl(state, directSettledChainId))
+    );
+    const sourceAfter = await captureBalance(sourceProvider, sourceToken);
+    expectBalanceDelta(
+      sourceBefore.token!,
+      sourceAfter.token!,
+      ethers.constants.Zero,
+      "rejected transfer source token"
     );
   });
 
   it("rejects transfers from direct-settled chains to GW-settled chains across settlement layers", async () => {
     const sourceToken = state.testTokens![directSettledChainId];
-    await expectTransferToRevert(
-      executeTokenTransfer({
-        sourceChainId: directSettledChainId,
-        targetChainId: gwSettledChainIds[0],
-        amount: "3",
-        sourceTokenAddress: sourceToken,
-        logger: (line: string) => console.log(`[interop] ${line}`),
-      })
+    const sourceProvider = createProvider(getL2RpcUrl(state, directSettledChainId));
+    const sourceBefore = await captureBalance(sourceProvider, sourceToken);
+    await expectRevert(
+      () =>
+        executeTokenTransfer({
+          sourceChainId: directSettledChainId,
+          targetChainId: gwSettledChainIds[0],
+          amount: "3",
+          sourceTokenAddress: sourceToken,
+          logger: (line: string) => console.log(`[interop] ${line}`),
+        }),
+      "unregistered destination route",
+      customError("InteropCenter", "DestinationChainNotRegistered(uint256)"),
+      createProvider(getL2RpcUrl(state, directSettledChainId))
+    );
+    const sourceAfter = await captureBalance(sourceProvider, sourceToken);
+    expectBalanceDelta(
+      sourceBefore.token!,
+      sourceAfter.token!,
+      ethers.constants.Zero,
+      "rejected transfer source token"
     );
   });
 });

--- a/l1-contracts/test/anvil-interop/test/hardhat/04-gateway-setup.spec.ts
+++ b/l1-contracts/test/anvil-interop/test/hardhat/04-gateway-setup.spec.ts
@@ -3,8 +3,10 @@ import type { providers } from "ethers";
 import { Contract, ethers } from "ethers";
 import { DeploymentRunner } from "../../src/deployment-runner";
 import { getAbi } from "../../src/core/contracts";
-import { L2_BRIDGEHUB_ADDR } from "../../src/core/const";
+import { L2_BRIDGEHUB_ADDR, ETH_TOKEN_ADDRESS } from "../../src/core/const";
 import { getChainIdByRole, getL2Chain, createProvider } from "../../src/core/utils";
+
+import { encodeNtvAssetId } from "../../src/core/data-encoding";
 
 describe("04 - Gateway Deployment Verification (read-only)", function () {
   this.timeout(0);
@@ -40,10 +42,18 @@ describe("04 - Gateway Deployment Verification (read-only)", function () {
       for (const chainConfig of state.chains!.config) {
         if (chainConfig.settlement !== "gateway") continue;
         const baseTokenAssetId = await l2Bridgehub.baseTokenAssetId(chainConfig.chainId);
-        expect(
-          baseTokenAssetId,
-          `Chain ${chainConfig.chainId} (${chainConfig.role}) should be registered on GW L2Bridgehub`
-        ).to.not.equal(ethers.constants.HashZero);
+        const baseToken =
+          chainConfig.baseToken === "custom"
+            ? state.customBaseTokens?.[chainConfig.chainId]
+            : chainConfig.baseToken || ETH_TOKEN_ADDRESS;
+        expect(baseToken, `Base token configured for chain ${chainConfig.chainId}`).to.exist;
+        expect(baseTokenAssetId, `Chain ${chainConfig.chainId} base token registration`).to.equal(
+          encodeNtvAssetId(state.chains!.l1!.chainId, baseToken!)
+        );
+        expect((await l2Bridgehub.settlementLayer(chainConfig.chainId)).toNumber()).to.equal(gwChainId);
+        const diamond = await l2Bridgehub.getZKChain(chainConfig.chainId);
+        const chain = new Contract(diamond, getAbi("IZKChain"), gwProvider);
+        expect((await chain.getChainId()).toNumber()).to.equal(chainConfig.chainId);
       }
     });
 
@@ -71,6 +81,18 @@ describe("04 - Gateway Deployment Verification (read-only)", function () {
       expect(chainAddr, `GW chain ${gwChainId} not found in chainAddresses`).to.exist;
       const code = await l1Provider.getCode(chainAddr!.diamondProxy);
       expect(code).to.not.equal("0x");
+      const bridgehub = new Contract(state.l1Addresses!.bridgehub, getAbi("L1Bridgehub"), l1Provider);
+      expect(await bridgehub.getZKChain(gwChainId)).to.equal(chainAddr!.diamondProxy);
+      expect(await bridgehub.whitelistedSettlementLayers(gwChainId), "Gateway is an allowed settlement layer").to.equal(
+        true
+      );
+      for (const config of state.chains!.config.filter((chain) => chain.role !== "l1")) {
+        const expectedSettlement = config.settlement === "gateway" ? gwChainId : state.chains!.l1!.chainId;
+        expect(
+          (await bridgehub.settlementLayer(config.chainId)).toNumber(),
+          `Chain ${config.chainId} settlement`
+        ).to.equal(expectedSettlement);
+      }
     });
   });
 });

--- a/l1-contracts/test/anvil-interop/test/hardhat/05-gateway-bridge.spec.ts
+++ b/l1-contracts/test/anvil-interop/test/hardhat/05-gateway-bridge.spec.ts
@@ -1,11 +1,30 @@
 import { expect } from "chai";
-import { ethers } from "ethers";
+import { Contract, ethers } from "ethers";
 import { DeploymentRunner } from "../../src/deployment-runner";
 import { depositETHToL2 } from "../../src/helpers/l1-deposit-helper";
 import { withdrawETHFromL2 } from "../../src/helpers/l2-withdrawal-helper";
 import { getL1BridgedOut, getL1BaseTokenAssetId } from "../../src/helpers/bridged-out-helper";
-import { ANVIL_DEFAULT_ACCOUNT_ADDR, ANVIL_RECIPIENT_ADDR } from "../../src/core/const";
+import {
+  ANVIL_INTEROP_BASE_TOKEN_PRIORITY_TX_GAS_LIMIT,
+  ANVIL_INTEROP_PRIORITY_TX_L1_GAS_PRICE_WEI,
+  ANVIL_INTEROP_REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
+  ANVIL_DEFAULT_ACCOUNT_ADDR,
+  ANVIL_RECIPIENT_ADDR,
+  INTEROP_CENTER_ADDR,
+} from "../../src/core/const";
 import { getL1RpcUrl, getL2RpcUrl, getChainIdByRole, getChainIdsByRole, createProvider } from "../../src/core/utils";
+
+import { getAbi } from "../../src/core/contracts";
+import {
+  expectBalanceDelta,
+  expectNativeSpend,
+  expectSuccessfulReceipt,
+  expectEvent,
+  randomBigNumber,
+} from "../../src/helpers/balance-helpers";
+
+const ETH_AMOUNT_MIN = ethers.utils.parseEther("0.1");
+const ETH_AMOUNT_MAX = ethers.utils.parseEther("0.5");
 
 describe("05 - Gateway Bridge (GW-settled chain, via GW)", function () {
   this.timeout(0);
@@ -27,8 +46,11 @@ describe("05 - Gateway Bridge (GW-settled chain, via GW)", function () {
   describe("ETH deposits L1 -> GW-settled chain through gateway", () => {
     it("deposits ETH from L1 to GW-settled chain", async () => {
       const l1Provider = createProvider(getL1RpcUrl(state));
-      const amount = ethers.utils.parseEther("0.5");
+      const amount = randomBigNumber(ETH_AMOUNT_MIN, ETH_AMOUNT_MAX);
       const senderAddr = ANVIL_DEFAULT_ACCOUNT_ADDR;
+      const recipientAddr = ANVIL_RECIPIENT_ADDR;
+      const l2Provider = createProvider(getL2RpcUrl(state, gwSettledChainId));
+      const recipientL2Before = await l2Provider.getBalance(recipientAddr);
 
       const senderL1Before = await l1Provider.getBalance(senderAddr);
 
@@ -39,6 +61,16 @@ describe("05 - Gateway Bridge (GW-settled chain, via GW)", function () {
       const ethAssetId = await getL1BaseTokenAssetId(getL1RpcUrl(state), l1Ntv);
       const bridgedOutBefore = await getL1BridgedOut(getL1RpcUrl(state), l1Ntv, ethAssetId);
 
+      const bridgehub = new Contract(state.l1Addresses!.bridgehub, getAbi("L1Bridgehub"), l1Provider);
+      const expectedMintValue = amount.add(
+        await bridgehub.l2TransactionBaseCost(
+          gwSettledChainId,
+          ANVIL_INTEROP_PRIORITY_TX_L1_GAS_PRICE_WEI,
+          ANVIL_INTEROP_BASE_TOKEN_PRIORITY_TX_GAS_LIMIT,
+          ANVIL_INTEROP_REQUIRED_L2_GAS_PRICE_PER_PUBDATA
+        )
+      );
+
       const result = await depositETHToL2({
         l1RpcUrl: getL1RpcUrl(state),
         l2RpcUrl: getL2RpcUrl(state, gwSettledChainId),
@@ -46,25 +78,42 @@ describe("05 - Gateway Bridge (GW-settled chain, via GW)", function () {
         l1Addresses: state.l1Addresses!,
         amount,
         gwRpcUrl: getL2RpcUrl(state, gwChainId),
+        recipient: recipientAddr,
       });
 
-      expect(result.l1TxHash).to.not.be.null;
+      const l1Receipt = await expectSuccessfulReceipt(l1Provider, result.l1TxHash, "deposit L1");
+      await expectSuccessfulReceipt(l2Provider, result.l2TxHash, "deposit L2 relay");
+      const initiated = expectEvent(
+        l1Receipt,
+        "L1AssetRouter",
+        state.l1Addresses!.l1SharedBridge,
+        "BridgehubDepositBaseTokenInitiated"
+      );
+      expect(initiated.chainId.toNumber()).to.equal(gwSettledChainId);
+      expect(initiated.from).to.equal(senderAddr);
+      expect(initiated.assetId).to.equal(ethAssetId);
+      expect(initiated.amount.toString()).to.equal(expectedMintValue.toString());
 
       const senderL1After = await l1Provider.getBalance(senderAddr);
 
-      // Sender's L1 ETH balance should decrease (by at least mintValue; gas adds to the decrease)
-      const senderL1Delta = senderL1After.sub(senderL1Before);
-      expect(
-        senderL1Delta.lte(result.mintValue.mul(-1)),
-        `Sender L1 ETH should decrease by at least ${result.mintValue.toString()}, got delta ${senderL1Delta.toString()}`
-      ).to.equal(true);
+      expectNativeSpend(
+        { native: senderL1Before },
+        { native: senderL1After },
+        expectedMintValue,
+        l1Receipt,
+        "deposit sender L1"
+      );
+
+      const recipientL2After = await l2Provider.getBalance(recipientAddr);
+      // The Anvil priority relay forwards l2Value exactly; bootloader fee refunds are not simulated.
+      expectBalanceDelta(recipientL2Before, recipientL2After, amount, "gateway deposit recipient L2");
 
       // L1NativeTokenVault.bridgedOut[ETH] should increase by exactly the bridged amount (mintValue).
       const bridgedOutAfter = await getL1BridgedOut(getL1RpcUrl(state), l1Ntv, ethAssetId);
       const bridgedOutDelta = bridgedOutAfter.sub(bridgedOutBefore);
       expect(
-        bridgedOutDelta.eq(result.mintValue),
-        `bridgedOut[ETH] should increase by ${result.mintValue.toString()}, got ${bridgedOutDelta.toString()}`
+        bridgedOutDelta.eq(expectedMintValue),
+        `bridgedOut[ETH] should increase by ${expectedMintValue.toString()}, got ${bridgedOutDelta.toString()}`
       ).to.equal(true);
     });
   });
@@ -72,10 +121,13 @@ describe("05 - Gateway Bridge (GW-settled chain, via GW)", function () {
   describe("ETH withdrawals GW-settled chain -> L1 through gateway", () => {
     it("withdraws ETH from GW-settled chain to L1", async () => {
       const l1Provider = createProvider(getL1RpcUrl(state));
-      const amount = ethers.utils.parseEther("0.2");
+      const amount = randomBigNumber(ETH_AMOUNT_MIN, ETH_AMOUNT_MAX);
       const recipientAddr = ANVIL_RECIPIENT_ADDR;
 
       const recipientL1Before = await l1Provider.getBalance(recipientAddr);
+
+      const l2Provider = createProvider(getL2RpcUrl(state, gwSettledChainId));
+      const senderL2Before = await l2Provider.getBalance(ANVIL_DEFAULT_ACCOUNT_ADDR);
 
       // Snapshot L1NativeTokenVault.bridgedOut[ETH] before finalizing the withdrawal on L1.
       const l1Ntv = state.l1Addresses!.l1NativeTokenVault;
@@ -91,7 +143,37 @@ describe("05 - Gateway Bridge (GW-settled chain, via GW)", function () {
         l1Recipient: recipientAddr,
       });
 
-      expect(result.l2TxHash).to.not.be.null;
+      const l2Receipt = await expectSuccessfulReceipt(l2Provider, result.l2TxHash, "withdrawal L2");
+      const l1Receipt = await expectSuccessfulReceipt(l1Provider, result.l1TxHash, "withdrawal L1 finalization");
+      const senderL2After = await l2Provider.getBalance(ANVIL_DEFAULT_ACCOUNT_ADDR);
+      expectNativeSpend(
+        { native: senderL2Before },
+        { native: senderL2After },
+        amount,
+        l2Receipt,
+        "withdrawal sender L2"
+      );
+      const sent = expectEvent(l2Receipt, "InteropCenter", INTEROP_CENTER_ADDR, "InteropBundleSent");
+      expect(sent.interopBundle.sourceChainId.toNumber()).to.equal(gwSettledChainId);
+      expect(sent.interopBundle.destinationChainId.toNumber()).to.equal(state.chains!.l1!.chainId);
+      expect(sent.interopBundle.calls).to.have.length(1);
+      const nullifier = new Contract(state.l1Addresses!.l1NullifierProxy, getAbi("L1Nullifier"), l1Provider);
+      const handlerAddress = await nullifier.l1InteropHandler();
+      const executed = expectEvent(l1Receipt, "L1InteropHandler", handlerAddress, "BundleExecuted");
+      expect(executed.bundleHash).to.equal(sent.interopBundleHash);
+      const finalized = expectEvent(
+        l1Receipt,
+        "L1AssetRouter",
+        state.l1Addresses!.l1SharedBridge,
+        "DepositFinalizedAssetRouter"
+      );
+      expect(finalized.sourceChainId.toNumber()).to.equal(gwSettledChainId);
+      expect(finalized.assetId).to.equal(ethAssetId);
+      const minted = expectEvent(l1Receipt, "L1NativeTokenVault", l1Ntv, "BridgeMint");
+      expect(minted.chainId.toNumber()).to.equal(gwSettledChainId);
+      expect(minted.assetId).to.equal(ethAssetId);
+      expect(minted.receiver).to.equal(recipientAddr);
+      expect(minted.amount.toString()).to.equal(amount.toString());
 
       const recipientL1After = await l1Provider.getBalance(recipientAddr);
 

--- a/l1-contracts/test/anvil-interop/test/hardhat/06-gateway-interop.spec.ts
+++ b/l1-contracts/test/anvil-interop/test/hardhat/06-gateway-interop.spec.ts
@@ -1,9 +1,37 @@
 import { expect } from "chai";
-import { BigNumber } from "ethers";
+import { ethers } from "ethers";
 import { DeploymentRunner } from "../../src/deployment-runner";
 import { executeTokenTransfer } from "../../src/helpers/token-transfer";
 import type { MultiChainTokenTransferResult } from "../../src/core/types";
-import { getChainIdsByRole } from "../../src/core/utils";
+import { getChainIdsByRole, getL2RpcUrl, createProvider } from "../../src/core/utils";
+
+import {
+  ANVIL_DEFAULT_ACCOUNT_ADDR,
+  INTEROP_CENTER_ADDR,
+  L2_INTEROP_HANDLER_ADDR,
+  L2_NATIVE_TOKEN_VAULT_ADDR,
+  BundleStatus,
+} from "../../src/core/const";
+import { encodeNtvAssetId } from "../../src/core/data-encoding";
+import {
+  getInteropProtocolFee,
+  registerL2NativeTokenIfNeeded,
+  getBundleStatus,
+} from "../../src/helpers/interop-helpers";
+import {
+  captureBalance,
+  getTokenBalance,
+  getTokenAddressForAsset,
+  approveTokenForNtv,
+  expectBalanceDelta,
+  expectNativeSpend,
+  expectSuccessfulReceipt,
+  expectEvent,
+  randomBigNumber,
+} from "../../src/helpers/balance-helpers";
+
+const TOKEN_AMOUNT_MIN = ethers.utils.parseUnits("1", 18);
+const TOKEN_AMOUNT_MAX = ethers.utils.parseUnits("10", 18);
 
 describe("06 - Gateway Interop (GW-settled chains)", function () {
   this.timeout(0);
@@ -27,28 +55,51 @@ describe("06 - Gateway Interop (GW-settled chains)", function () {
   async function transferTokens(params: {
     sourceChainId: number;
     targetChainId: number;
-    amount: string;
     sourceTokenAddress?: string;
   }): Promise<MultiChainTokenTransferResult> {
-    const { sourceChainId, targetChainId, amount } = params;
+    const { sourceChainId, targetChainId } = params;
 
     const sourceToken = params.sourceTokenAddress || state.testTokens![sourceChainId];
 
+    const amountWei = randomBigNumber(TOKEN_AMOUNT_MIN, TOKEN_AMOUNT_MAX);
+    const sourceProvider = createProvider(getL2RpcUrl(state, sourceChainId));
+    const targetProvider = createProvider(getL2RpcUrl(state, targetChainId));
+    const assetId = encodeNtvAssetId(sourceChainId, sourceToken);
+    await registerL2NativeTokenIfNeeded(sourceProvider, sourceToken);
+    await approveTokenForNtv(sourceProvider, sourceToken, amountWei);
+    const fee = await getInteropProtocolFee(sourceProvider);
+    const sourceBefore = await captureBalance(sourceProvider, sourceToken);
+    const destinationTokenBefore = await getTokenAddressForAsset(targetProvider, assetId);
+    const destinationBefore = await getTokenBalance(targetProvider, destinationTokenBefore, ANVIL_DEFAULT_ACCOUNT_ADDR);
     const result = await executeTokenTransfer({
       sourceChainId,
       targetChainId,
-      amount,
+      amount: ethers.utils.formatUnits(amountWei, 18),
       sourceTokenAddress: sourceToken,
       logger: (line: string) => console.log(`[gw-interop] ${line}`),
     });
 
-    expect(result.sourceTxHash).to.not.be.null;
-    expect(result.targetTxHash).to.not.be.null;
+    const sourceReceipt = await expectSuccessfulReceipt(sourceProvider, result.sourceTxHash, "interop source");
+    const targetReceipt = await expectSuccessfulReceipt(targetProvider, result.targetTxHash, "interop destination");
+    const sourceAfter = await captureBalance(sourceProvider, sourceToken);
+    const destinationToken = await getTokenAddressForAsset(targetProvider, assetId);
+    const destinationAfter = await getTokenBalance(targetProvider, destinationToken, ANVIL_DEFAULT_ACCOUNT_ADDR);
+    expectBalanceDelta(sourceBefore.token!, sourceAfter.token!, amountWei.mul(-1), "interop source token");
+    expectBalanceDelta(destinationBefore, destinationAfter, amountWei, "interop destination token");
+    expectNativeSpend(sourceBefore, sourceAfter, fee, sourceReceipt, "interop source fee");
 
-    const sourceBalanceDelta = BigNumber.from(result.sourceBalanceBefore).sub(result.sourceBalanceAfter);
-    const destinationBalanceDelta = BigNumber.from(result.destinationBalanceAfter).sub(result.destinationBalanceBefore);
-    expect(sourceBalanceDelta.eq(result.amountWei), "source chain burned amount mismatch").to.eq(true);
-    expect(destinationBalanceDelta.eq(result.amountWei), "destination chain minted amount mismatch").to.eq(true);
+    const sent = expectEvent(sourceReceipt, "InteropCenter", INTEROP_CENTER_ADDR, "InteropBundleSent");
+    expect(sent.interopBundle.sourceChainId.toNumber()).to.equal(sourceChainId);
+    expect(sent.interopBundle.destinationChainId.toNumber()).to.equal(targetChainId);
+    expect(sent.interopBundle.calls).to.have.length(1);
+    const executed = expectEvent(targetReceipt, "L2InteropHandler", L2_INTEROP_HANDLER_ADDR, "BundleExecuted");
+    expect(executed.bundleHash).to.equal(sent.interopBundleHash);
+    expect(await getBundleStatus(targetProvider, sent.interopBundleHash)).to.equal(BundleStatus.FullyExecuted);
+    const minted = expectEvent(targetReceipt, "L2NativeTokenVault", L2_NATIVE_TOKEN_VAULT_ADDR, "BridgeMint");
+    expect(minted.chainId.toNumber()).to.equal(sourceChainId);
+    expect(minted.assetId).to.equal(assetId);
+    expect(minted.receiver).to.equal(ANVIL_DEFAULT_ACCOUNT_ADDR);
+    expect(minted.amount.toString()).to.equal(amountWei.toString());
 
     return result;
   }
@@ -57,7 +108,6 @@ describe("06 - Gateway Interop (GW-settled chains)", function () {
     await transferTokens({
       sourceChainId: gwSettledChainIds[0],
       targetChainId: gwSettledChainIds[1],
-      amount: "5",
       sourceTokenAddress: state.testTokens![gwSettledChainIds[0]],
     });
   });
@@ -66,7 +116,6 @@ describe("06 - Gateway Interop (GW-settled chains)", function () {
     await transferTokens({
       sourceChainId: gwSettledChainIds[1],
       targetChainId: gwSettledChainIds[0],
-      amount: "3",
       sourceTokenAddress: state.testTokens![gwSettledChainIds[1]],
     });
   });

--- a/l1-contracts/test/anvil-interop/test/hardhat/07-interop-bundles.spec.ts
+++ b/l1-contracts/test/anvil-interop/test/hardhat/07-interop-bundles.spec.ts
@@ -213,9 +213,6 @@ describe("07 - Interop Bundles (GW-settled chains)", function () {
 
     const balAfter = await captureBalance(sourceProvider);
 
-    expect(sendResult.txHash, "single direct call: tx hash should exist").to.not.be.null;
-    expect(sendResult.interopBundle, "single direct call: interopBundle should exist").to.not.be.null;
-
     expectNativeSpend(balBefore, balAfter, msgValue, sendResult.receipt, "single direct call");
     if (protocolFeesBefore) {
       await expectAccumulatedProtocolFeeDelta(
@@ -324,9 +321,6 @@ describe("07 - Interop Bundles (GW-settled chains)", function () {
 
     const balAfter = await captureBalance(sourceProvider, sourceTokenAddress);
 
-    expect(sendResult.txHash, "single indirect call: tx hash should exist").to.not.be.null;
-    expect(sendResult.interopBundle, "single indirect call: interopBundle should exist").to.not.be.null;
-
     expectNativeSpend(balBefore, balAfter, msgValue, sendResult.receipt, "single indirect call");
 
     // Token balance should decrease by exactly tokenAmount
@@ -387,9 +381,6 @@ describe("07 - Interop Bundles (GW-settled chains)", function () {
 
     const balAfter = await captureBalance(sourceProvider);
 
-    expect(sendResult.txHash, "two direct calls: tx hash should exist").to.not.be.null;
-    expect(sendResult.interopBundle, "two direct calls: interopBundle should exist").to.not.be.null;
-
     expectNativeSpend(balBefore, balAfter, msgValue, sendResult.receipt, "two direct calls");
 
     console.log("   [send] Two direct calls bundle sent");
@@ -442,9 +433,6 @@ describe("07 - Interop Bundles (GW-settled chains)", function () {
     });
 
     const balAfter = await captureBalance(sourceProvider, sourceTokenAddress);
-
-    expect(sendResult.txHash, "two indirect calls: tx hash should exist").to.not.be.null;
-    expect(sendResult.interopBundle, "two indirect calls: interopBundle should exist").to.not.be.null;
 
     expectNativeSpend(balBefore, balAfter, msgValue, sendResult.receipt, "two indirect calls");
 
@@ -526,9 +514,6 @@ describe("07 - Interop Bundles (GW-settled chains)", function () {
     });
 
     const balAfter = await captureBalance(sourceProvider, sourceTokenAddress);
-
-    expect(sendResult.txHash, "mixed bundle: tx hash should exist").to.not.be.null;
-    expect(sendResult.interopBundle, "mixed bundle: interopBundle should exist").to.not.be.null;
 
     expectNativeSpend(balBefore, balAfter, msgValue, sendResult.receipt, "mixed bundle");
 
@@ -644,8 +629,6 @@ describe("07 - Interop Bundles (GW-settled chains)", function () {
       bundleAttributes,
       value: ethers.BigNumber.from(0),
     });
-
-    expect(sendResult.txHash).to.not.be.null;
 
     const receipt = await executeBundle(destProvider, sendResult.bundleData, sourceChainId);
     expect(receipt.status).to.equal(1);

--- a/l1-contracts/test/anvil-interop/test/hardhat/08-interop-messages.spec.ts
+++ b/l1-contracts/test/anvil-interop/test/hardhat/08-interop-messages.spec.ts
@@ -192,9 +192,6 @@ describe("08 - Interop Messages (GW-settled chains)", function () {
       value: msgValue,
     });
 
-    expect(result.txHash).to.be.a("string").and.not.equal("");
-    expect(result.interopBundle).to.not.be.null;
-
     const balAfter = await captureBalance(sourceProvider);
     expectNativeSpend(balBefore, balAfter, msgValue, result.receipt, "base token message");
     if (protocolFeesBefore) {
@@ -285,9 +282,6 @@ describe("08 - Interop Messages (GW-settled chains)", function () {
       value: msgValue,
     });
 
-    expect(result.txHash).to.be.a("string").and.not.equal("");
-    expect(result.interopBundle).to.not.be.null;
-
     const balAfter = await captureBalance(sourceProvider, sourceTokenAddress);
 
     // Token balance should decrease by exactly erc20Amount
@@ -346,9 +340,6 @@ describe("08 - Interop Messages (GW-settled chains)", function () {
       attributes,
       value: msgValue,
     });
-
-    expect(result.txHash).to.be.a("string").and.not.equal("");
-    expect(result.interopBundle).to.not.be.null;
 
     const balAfter = await captureBalance(sourceProvider);
     expectNativeSpend(balBefore, balAfter, msgValue, result.receipt, "cross-base-token message");
@@ -411,6 +402,7 @@ describe("08 - Interop Messages (GW-settled chains)", function () {
     const attributes = [indirectCallAttr(amount)];
     const msgValue = customChainInteropFee.add(amount);
 
+    const senderBefore = await captureBalance(customBaseTokenProvider);
     const result = await sendInteropMessage({
       sourceProvider: customBaseTokenProvider,
       recipient,
@@ -419,8 +411,8 @@ describe("08 - Interop Messages (GW-settled chains)", function () {
       value: msgValue,
     });
 
-    expect(result.txHash).to.be.a("string").and.not.equal("");
-    expect(result.interopBundle).to.not.be.null;
+    const senderAfter = await captureBalance(customBaseTokenProvider);
+    expectNativeSpend(senderBefore, senderAfter, msgValue, result.receipt, "custom→era sender");
 
     console.log(`   Custom→ERA message sent: ${result.txHash}`);
 
@@ -497,9 +489,6 @@ describe("08 - Interop Messages (GW-settled chains)", function () {
       attributes,
       value: msgValue,
     });
-
-    expect(result.txHash).to.be.a("string").and.not.equal("");
-    expect(result.interopBundle).to.not.be.null;
 
     const balAfter = await getTokenBalance(sourceProvider, bridgedTokenOnSource, getInteropSourceAddress());
     expect(

--- a/l1-contracts/test/anvil-interop/test/hardhat/09-interop-unbundle.spec.ts
+++ b/l1-contracts/test/anvil-interop/test/hardhat/09-interop-unbundle.spec.ts
@@ -17,6 +17,7 @@ import {
   CallStatus,
   DEFAULT_TX_GAS_LIMIT,
   FAILING_CALL_CALLDATA,
+  FAILING_INTEROP_CALL_REASON,
   L2_ASSET_ROUTER_ADDR,
   L2_INTEROP_HANDLER_ADDR,
 } from "../../src/core/const";
@@ -46,6 +47,8 @@ import {
 } from "../../src/helpers/interop-helpers";
 import type { CallStarter, InteropSendResult } from "../../src/helpers/interop-helpers";
 import {
+  captureBalance,
+  expectNativeSpend,
   getNativeBalance,
   getTokenBalance,
   approveTokenForNtv,
@@ -204,6 +207,7 @@ describe("09 - Interop Unbundle (failing calls)", function () {
     }
 
     const protocolFeesBefore = !isLiveInteropMode() ? await snapshotAccumulatedProtocolFees(sourceProvider) : undefined;
+    const senderBefore = await captureBalance(sourceProvider, sourceTokenAddress);
     const result = await sendInteropBundle({
       sourceProvider,
       destinationChainId: destChainId,
@@ -211,6 +215,10 @@ describe("09 - Interop Unbundle (failing calls)", function () {
       bundleAttributes,
       value: valuePerBundle,
     });
+
+    const senderAfter = await captureBalance(sourceProvider, sourceTokenAddress);
+    expectNativeSpend(senderBefore, senderAfter, valuePerBundle, result.receipt, "failing bundle sender");
+    expectBalanceDelta(senderBefore.token!, senderAfter.token!, tokenAmount.mul(-1), "failing bundle sender token");
 
     if (protocolFeesBefore) {
       await expectAccumulatedProtocolFeeDelta(
@@ -271,7 +279,12 @@ describe("09 - Interop Unbundle (failing calls)", function () {
     const { sendResult, bundleData, bundleHash } = await sendAndPrepareBundle({ withUnbundlerAddress: true });
 
     // First, simulate atomic executeBundle - should revert because call 1 will fail.
-    await expectRevert(() => executeOrSimulateFailingBundle(sendResult), "executeBundle with failing call");
+    await expectRevert(
+      () => executeOrSimulateFailingBundle(sendResult),
+      "executeBundle with failing call",
+      FAILING_INTEROP_CALL_REASON,
+      destProvider
+    );
 
     // Now call verifyBundle - should succeed
     const verifyReceipt = await verifyBundle(destProvider, bundleData, sourceChainId);
@@ -310,7 +323,9 @@ describe("09 - Interop Unbundle (failing calls)", function () {
     const callStatuses = [CallStatus.Unprocessed, CallStatus.Executed, CallStatus.Unprocessed];
     await expectRevert(
       () => unbundleBundle(destProvider, bundleData, callStatuses, getInteropUnbundlerPrivateKey()),
-      "execute a failing call"
+      "execute a failing call",
+      FAILING_INTEROP_CALL_REASON,
+      destProvider
     );
   });
 
@@ -440,7 +455,12 @@ describe("09 - Interop Unbundle (failing calls)", function () {
     const { sendResult, bundleHash, baseAmount, tokenAmount } = await sendAndPrepareBundle({});
 
     // Simulate atomic executeBundle first - should revert (failing call).
-    await expectRevert(() => executeOrSimulateFailingBundle(sendResult), "executeBundle with failing call");
+    await expectRevert(
+      () => executeOrSimulateFailingBundle(sendResult),
+      "executeBundle with failing call",
+      FAILING_INTEROP_CALL_REASON,
+      destProvider
+    );
 
     // Build the final call statuses: execute calls 0 and 2, cancel call 1
     const finalCallStatuses = [CallStatus.Executed, CallStatus.Cancelled, CallStatus.Executed];

--- a/l1-contracts/test/anvil-interop/test/hardhat/13-imt-atomic-swap.spec.ts
+++ b/l1-contracts/test/anvil-interop/test/hardhat/13-imt-atomic-swap.spec.ts
@@ -13,6 +13,7 @@ import { getChainIdsByRole, getL2Chain, impersonateAndRun, createProvider } from
 import { getAbi } from "../../src/core/contracts";
 import {
   ANVIL_DEFAULT_PRIVATE_KEY,
+  ANVIL_RECIPIENT_ADDR,
   BundleStatus,
   INTEROP_CENTER_ADDR,
   L2_ASSET_ROUTER_ADDR,
@@ -26,7 +27,14 @@ import {
   DEFAULT_TX_GAS_LIMIT,
 } from "../../src/core/const";
 import { encodeEvmAddress, encodeEvmChain } from "../../src/core/data-encoding";
-import { customError, expectRevert } from "../../src/helpers/balance-helpers";
+import {
+  customError,
+  expectRevert,
+  expectEvent,
+  captureBalance,
+  expectNativeSpend,
+  expectBalanceDelta,
+} from "../../src/helpers/balance-helpers";
 import {
   atomicBundleAttr,
   interopBundleSaltAttr,
@@ -99,9 +107,6 @@ type ChainCtx = {
   stack: AtomicStack;
 };
 
-const NTV_TOKEN_ADDRESS_ABI = ["function tokenAddress(bytes32 assetId) view returns (address)"];
-const ERC20_BALANCE_ABI = ["function balanceOf(address) view returns (uint256)"];
-
 /** assetId = keccak256(abi.encode(originChainId, L2_NATIVE_TOKEN_VAULT_ADDR, originToken)). */
 function ntvAssetId(originChainId: number, originToken: string): string {
   return ethers.utils.keccak256(
@@ -118,7 +123,9 @@ async function ensureTokenRegistered(ctx: ChainCtx): Promise<void> {
   const vault = new Contract(L2_NATIVE_TOKEN_VAULT_ADDR, getAbi("L2NativeTokenVault"), ctx.user);
   const registered: string = await vault.assetId(ctx.testToken.address);
   if (registered === ethers.constants.HashZero) {
-    await (await vault.registerToken(ctx.testToken.address)).wait();
+    const receipt = await (await vault.registerToken(ctx.testToken.address)).wait();
+    expect(receipt.status, "register swap token").to.equal(1);
+    expect(await vault.assetId(ctx.testToken.address)).to.equal(ntvAssetId(ctx.chainId, ctx.testToken.address));
   }
 }
 
@@ -130,7 +137,11 @@ async function ensureTokenRegistered(ctx: ChainCtx): Promise<void> {
 async function ensureNtvApproval(ctx: ChainCtx, amount: BigNumber): Promise<void> {
   const current: BigNumber = await ctx.testToken.allowance(ctx.user.address, L2_NATIVE_TOKEN_VAULT_ADDR);
   if (current.lt(amount)) {
-    await (await ctx.testToken.connect(ctx.user).approve(L2_NATIVE_TOKEN_VAULT_ADDR, amount)).wait();
+    const receipt = await (await ctx.testToken.connect(ctx.user).approve(L2_NATIVE_TOKEN_VAULT_ADDR, amount)).wait();
+    expect(receipt.status, "approve swap token").to.equal(1);
+    expect((await ctx.testToken.allowance(ctx.user.address, L2_NATIVE_TOKEN_VAULT_ADDR)).toString()).to.equal(
+      amount.toString()
+    );
   }
 }
 
@@ -174,7 +185,7 @@ async function ensureSettlementInteropRoot(
     return;
   }
   await impersonateAndRun(provider, L2_BOOTLOADER_ADDR, async (signer) => {
-    await (
+    const receipt = await (
       await storage.connect(signer).addSingleInteropRoot({
         chainId: DEFAULT_SL_CHAIN_ID,
         blockOrBatchNumber: settlementBlock,
@@ -182,6 +193,8 @@ async function ensureSettlementInteropRoot(
         sides: [ethers.utils.keccak256(ethers.utils.toUtf8Bytes(`settlement-interop-root-${settlementBlock}`))],
       })
     ).wait();
+    expect(receipt.status, "import settlement interop root").to.equal(1);
+    expect((await storage.interopRoots(DEFAULT_SL_CHAIN_ID, settlementBlock)).timestamp.toNumber()).to.equal(timestamp);
   });
 }
 
@@ -315,6 +328,7 @@ describe("13 - IMT atomic swap A <-> B (bundle model)", function () {
     const value = commitValue(flowId, predictedBundleHash);
     const lowNull = await lowNullifierIndexFor(source.stack.tree, value);
 
+    const senderBefore = await captureBalance(source.provider, source.testToken.address);
     const sendResult = await sendInteropBundle({
       sourceProvider: source.provider,
       destinationChainId: dest.chainId,
@@ -326,6 +340,10 @@ describe("13 - IMT atomic swap A <-> B (bundle model)", function () {
       // Atomic sends append to the IMT (~1.1M gas insert) on top of the burn, so they need the larger cap.
       gasLimit: ATOMIC_SEND_BUNDLE_GAS_LIMIT,
     });
+
+    const senderAfter = await captureBalance(source.provider, source.testToken.address);
+    expectNativeSpend(senderBefore, senderAfter, fee, sendResult.receipt, "atomic leg sender");
+    expectBalanceDelta(senderBefore.token!, senderAfter.token!, amount.mul(-1), "atomic leg source token");
 
     // Cross-check the predicted bundleHash against the actual one the InteropCenter emitted.
     expect(sendResult.bundleHash.toLowerCase(), "predicted bundleHash matches emitted").to.equal(
@@ -434,23 +452,33 @@ describe("13 - IMT atomic swap A <-> B (bundle model)", function () {
     // are delta-based for the same reason).
     const abAssetId = ntvAssetId(chainA.chainId, chainA.testToken.address);
     const baAssetId = ntvAssetId(chainB.chainId, chainB.testToken.address);
-    const ntvOnB = new Contract(L2_NATIVE_TOKEN_VAULT_ADDR, NTV_TOKEN_ADDRESS_ABI, chainB.provider);
-    const ntvOnA = new Contract(L2_NATIVE_TOKEN_VAULT_ADDR, NTV_TOKEN_ADDRESS_ABI, chainA.provider);
+    const ntvOnB = new Contract(L2_NATIVE_TOKEN_VAULT_ADDR, getAbi("L2NativeTokenVault"), chainB.provider);
+    const ntvOnA = new Contract(L2_NATIVE_TOKEN_VAULT_ADDR, getAbi("L2NativeTokenVault"), chainA.provider);
     const shimAonBAddrBefore: string = await ntvOnB.tokenAddress(abAssetId);
     const shimAonBBefore: BigNumber =
       shimAonBAddrBefore === ethers.constants.AddressZero
         ? BigNumber.from(0)
-        : await new Contract(shimAonBAddrBefore, ERC20_BALANCE_ABI, chainB.provider).balanceOf(user);
+        : await new Contract(shimAonBAddrBefore, getAbi("TestnetERC20Token"), chainB.provider).balanceOf(user);
     const shimBonAAddrBefore: string = await ntvOnA.tokenAddress(baAssetId);
     const shimBonABefore: BigNumber =
       shimBonAAddrBefore === ethers.constants.AddressZero
         ? BigNumber.from(0)
-        : await new Contract(shimBonAAddrBefore, ERC20_BALANCE_ABI, chainA.provider).balanceOf(user);
+        : await new Contract(shimBonAAddrBefore, getAbi("TestnetERC20Token"), chainA.provider).balanceOf(user);
 
     const handlerB = chainB.stack.interopHandler.connect(chainB.user);
     const handlerA = chainA.stack.interopHandler.connect(chainA.user);
-    await (await handlerB.executeAtomicBundle(ab.bundleData, finality, { gasLimit: DEFAULT_TX_GAS_LIMIT })).wait();
-    await (await handlerA.executeAtomicBundle(ba.bundleData, finality, { gasLimit: DEFAULT_TX_GAS_LIMIT })).wait();
+    const receiptB = await (
+      await handlerB.executeAtomicBundle(ab.bundleData, finality, { gasLimit: DEFAULT_TX_GAS_LIMIT })
+    ).wait();
+    const receiptA = await (
+      await handlerA.executeAtomicBundle(ba.bundleData, finality, { gasLimit: DEFAULT_TX_GAS_LIMIT })
+    ).wait();
+    expect(expectEvent(receiptB, "L2InteropHandler", L2_INTEROP_HANDLER_ADDR, "BundleExecuted").bundleHash).to.equal(
+      hAB
+    );
+    expect(expectEvent(receiptA, "L2InteropHandler", L2_INTEROP_HANDLER_ADDR, "BundleExecuted").bundleHash).to.equal(
+      hBA
+    );
 
     // Destination bundles are FullyExecuted; source legs remain Committed (terminal on the happy path).
     expect(await handlerB.bundleStatus(hAB)).to.equal(BundleStatus.FullyExecuted, "AB executed on B");
@@ -462,7 +490,11 @@ describe("13 - IMT atomic swap A <-> B (bundle model)", function () {
     // B receives a bridged shim for A's token (assetId of A.testToken on chain A).
     const shimAonB = await ntvOnB.tokenAddress(abAssetId);
     expect(shimAonB).to.not.equal(ethers.constants.AddressZero, "shim for A's token deployed on B");
-    const shimAonBAfter: BigNumber = await new Contract(shimAonB, ERC20_BALANCE_ABI, chainB.provider).balanceOf(user);
+    const shimAonBAfter: BigNumber = await new Contract(
+      shimAonB,
+      getAbi("TestnetERC20Token"),
+      chainB.provider
+    ).balanceOf(user);
     expect(shimAonBAfter.sub(shimAonBBefore).toString()).to.equal(
       aAmount.toString(),
       "recipient on B received aAmount"
@@ -471,7 +503,11 @@ describe("13 - IMT atomic swap A <-> B (bundle model)", function () {
     // A receives a bridged shim for B's token.
     const shimBonA = await ntvOnA.tokenAddress(baAssetId);
     expect(shimBonA).to.not.equal(ethers.constants.AddressZero, "shim for B's token deployed on A");
-    const shimBonAAfter: BigNumber = await new Contract(shimBonA, ERC20_BALANCE_ABI, chainA.provider).balanceOf(user);
+    const shimBonAAfter: BigNumber = await new Contract(
+      shimBonA,
+      getAbi("TestnetERC20Token"),
+      chainA.provider
+    ).balanceOf(user);
     expect(shimBonAAfter.sub(shimBonABefore).toString()).to.equal(
       bAmount.toString(),
       "recipient on A received bAmount"
@@ -487,7 +523,7 @@ describe("13 - IMT atomic swap A <-> B (bundle model)", function () {
     // root created after the flow's deadline has been imported (the flow could already be timed out).
     const settlementInteropRootBlock = 201;
 
-    const refundRecipient = chainB.user.address; // irrelevant for refund; distinct dest recipient
+    const refundRecipient = ANVIL_RECIPIENT_ADDR;
     const aTimeoutAmount = ethers.utils.parseUnits("3", TEST_TOKEN_DECIMALS);
     const bTimeoutAmount = ethers.utils.parseUnits("5", TEST_TOKEN_DECIMALS);
 
@@ -507,6 +543,7 @@ describe("13 - IMT atomic swap A <-> B (bundle model)", function () {
     const flowId = computeFlowId(flowPreimage);
 
     // ── Commit only the AB leg on A. B never commits BA. ─────────────────────────────────────
+    const recipientBefore: BigNumber = await chainA.testToken.balanceOf(refundRecipient);
     const aBalanceBefore: BigNumber = await chainA.testToken.balanceOf(user);
     const ab = await sendAtomicLeg({
       source: chainA,
@@ -552,6 +589,7 @@ describe("13 - IMT atomic swap A <-> B (bundle model)", function () {
         { gasLimit: DEFAULT_TX_GAS_LIMIT }
       )
     ).wait();
+    expect(refundAuth.status, "authorize refund transaction").to.equal(1);
     expect(await chainA.stack.manager.legState(flowId, hAB)).to.equal(LegState.Revertable, "AB revertable on A");
     expect(
       refundAuth.logs
@@ -562,6 +600,13 @@ describe("13 - IMT atomic swap A <-> B (bundle model)", function () {
 
     // ── claimRefund on A -> depositor recovers the burned tokens; state Reverted. ────────────
     const claim = await (await managerA.claimRefund(flowId, ab.bundleData, { gasLimit: DEFAULT_TX_GAS_LIMIT })).wait();
+    expect(claim.status, "claim refund transaction").to.equal(1);
+    expectBalanceDelta(
+      recipientBefore,
+      await chainA.testToken.balanceOf(refundRecipient),
+      ethers.constants.Zero,
+      "refund must return to depositor, not destination recipient"
+    );
     expect(await chainA.stack.manager.legState(flowId, hAB)).to.equal(LegState.Reverted, "AB reverted on A");
 
     const aAfterRefund: BigNumber = await chainA.testToken.balanceOf(user);
@@ -604,7 +649,7 @@ describe("13 - IMT atomic swap A <-> B (bundle model)", function () {
     const deadline = 2_000;
     const settlementInteropRootBlock = 202;
 
-    const refundRecipient = chainB.user.address;
+    const refundRecipient = ANVIL_RECIPIENT_ADDR;
     const aTimeoutAmount = ethers.utils.parseUnits("2", TEST_TOKEN_DECIMALS);
     const bTimeoutAmount = ethers.utils.parseUnits("4", TEST_TOKEN_DECIMALS);
 
@@ -622,6 +667,7 @@ describe("13 - IMT atomic swap A <-> B (bundle model)", function () {
     const flowPreimage = flowPreimageOf(legHashesAsc, chainIdsAsc, deadline);
     const flowId = computeFlowId(flowPreimage);
 
+    const recipientBefore: BigNumber = await chainA.testToken.balanceOf(refundRecipient);
     const aBalanceBefore: BigNumber = await chainA.testToken.balanceOf(user);
     const ab = await sendAtomicLeg({
       source: chainA,
@@ -652,7 +698,7 @@ describe("13 - IMT atomic swap A <-> B (bundle model)", function () {
     const missingIdx = legHashesAsc[0] === hBA ? 0 : 1;
 
     const managerA = chainA.stack.manager.connect(chainA.user);
-    await (
+    const refundAuth = await (
       await managerA.authorizeRefund(
         atomicFlowTuple({ flowId, preimage: flowPreimage }),
         missingIdx,
@@ -660,9 +706,23 @@ describe("13 - IMT atomic swap A <-> B (bundle model)", function () {
         { gasLimit: DEFAULT_TX_GAS_LIMIT }
       )
     ).wait();
+    expect(refundAuth.status, "authorize refund transaction").to.equal(1);
+    expect(
+      expectEvent(refundAuth, "AtomicFlowManager", L2_ATOMIC_FLOW_MANAGER_ADDR, "FlowRefundAuthorized").bundleHash
+    ).to.equal(hAB);
     expect(await chainA.stack.manager.legState(flowId, hAB)).to.equal(LegState.Revertable, "AB revertable on A");
 
-    await (await managerA.claimRefund(flowId, ab.bundleData, { gasLimit: DEFAULT_TX_GAS_LIMIT })).wait();
+    const claim = await (await managerA.claimRefund(flowId, ab.bundleData, { gasLimit: DEFAULT_TX_GAS_LIMIT })).wait();
+    expect(claim.status, "claim refund transaction").to.equal(1);
+    expect(expectEvent(claim, "AtomicFlowManager", L2_ATOMIC_FLOW_MANAGER_ADDR, "FlowRefunded").bundleHash).to.equal(
+      hAB
+    );
+    expectBalanceDelta(
+      recipientBefore,
+      await chainA.testToken.balanceOf(refundRecipient),
+      ethers.constants.Zero,
+      "refund must return to depositor, not destination recipient"
+    );
     expect(await chainA.stack.manager.legState(flowId, hAB)).to.equal(LegState.Reverted, "AB reverted on A");
     expect((await chainA.testToken.balanceOf(user)).toString()).to.equal(
       aBalanceBefore.toString(),


### PR DESCRIPTION
## What ❔

Harden the existing anvil-interop specs so incorrect balances, failed destination transactions, wrong predeploys and unrelated exceptions fail the suite. All changes are under `l1-contracts/test/anvil-interop/`.

- **Unqualified reverts:** spec 03 now requires `InteropCenter.DestinationChainNotRegistered(uint256)` for all three unsupported routes. Each route was run to capture selector `0x2d159f39` before setting the expectation. Spec 09's three broad failure assertions now require the distinctive reason emitted by its existing EVM receiver fixture. `expectRevert` requires a reason and matches revert bytes, including ethers' preview-decoding and returned-`eth_call` forms; an error message merely mentioning the selector cannot pass.
- **Imprecise or self-reported balances:** specs 02/05 check exact recipient credits, sender spend including receipt gas, and vault accounting. Deposit mint value is independently calculated from the Bridgehub base cost and input amount. Specs 03/06 snapshot balances independently of the transfer helper and verify the input amount, protocol fee, destination credit and final bundle status. Transfer amounts are randomized within small safe ranges.
- **Vacuous hash/presence checks:** nullable destination hashes must resolve to successful receipts. Trivial hash/bundle checks were removed across 02/03/05/06/07/08. Spec 01 asserts missing-token preconditions and checks all 25 predeploy runtimes on all five L2 chains against exact artifacts. Specs 01/04 also verify chain identity, CTM, base-token registration and settlement designation.
- **Missing events and transaction outcomes:** assertions check event emitter and cardinality plus relevant chain, asset, recipient, amount or bundle hash for deposit initiation, withdrawal finalization, bundle send/execution/verification/unbundling, and refunds. Shared interop helpers check successful receipts; direct waits in spec 13 now have status checks.
- **Additional real gaps in later specs:** spec 08 checks the custom-base-token sender's spend. Specs 09/13 check the sender's actual burn/spend before recovery. Spec 13 uses a distinct destination recipient and proves the refund goes back to the depositor, and loads its previously inline ABIs through `getAbi`.

Only two small reusable assertion helpers were added, alongside the existing toolkit: `expectSuccessfulReceipt` and `expectEvent`.

## Why ❔

EVM-1309: previously a positive-but-wrong deposit credit, a reverted destination hash, or an unrelated RPC/setup error could satisfy tests claiming successful bridging or route rejection.

### Findings from strengthened assertions

- Exact runtime checks exposed an additional intentional substitution beyond the four listed mocks: gateway setup installs **L2ChainAssetHandlerDev**, enabling migrations disabled in production. The gateway assertion matches that Dev artifact exactly; other chains still require the production artifact.
- Snapshots use metadata-free bytecode. Spec 01 builds reference artifacts with the same `anvil-interop` profile in separate output/cache directories, preserving coverage's default artifacts. No metadata is stripped from comparisons and no snapshots were regenerated.
- Precise failing-call checks exposed discarded revert bytes in the existing recovery helper when ethers returns `eth_call` data without throwing. That recovery is now checked and fixed.
- **No unresolved contract-behavior failures.** No Solidity changes or weakened assertions were needed.

### Deliberately retained / deferred

- Mock proof authentication, native mint/supply behavior, bootloader refunds, real proxy deployment and additional settlement/DA topologies remain outside this test-quality change. The one-page `docs/prod-divergences.md` records these observations for EVM-1422.
- Existing explicit skips for unavailable live/optional token fixtures remain. The full shared-state validation below had **no skips**. Existing L1 proxy and test-token code-presence checks remain; exact runtime identity here covers the fixed-address system predeploys.
- No spec files were added or renamed. Chain topology, CI matrix, deployment harness and chain-state snapshots are unchanged.

### Validation

- Full ten-spec suite from committed snapshots, isolated offset 1000 with `ANVIL_INTEROP_KEEP_CHAINS=1 yarn test:hardhat:interop`: **185 passing, 0 skipped** (142 seconds including setup).
- `yarn tsc --noEmit`: clean; an additional type check including all Hardhat specs also passed.
- `yarn test:unit`: **48 passing**.
- `yarn test:foundry`: **2,470 passing** after building the required DA artifacts.
- ESLint, Prettier and `git diff --check`: clean for the changed files.
- 21 local assertion controls passed, including wrong/embedded selectors, unrelated RPC errors, missing/reverted receipts, wrong/duplicate event emitters and one-wei balance errors.
- Chains cleaned up with the scoped `cleanup.sh` using the task's offset and run suffix.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
