### PR TITLE
fix(ci): unblock v31 deployment provenance and ownership tests

### DIFF
--- a/l1-contracts/test/foundry/l1/integration/UpgradeTestShared.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/UpgradeTestShared.t.sol
@@ -281,7 +281,16 @@ contract UpgradeIntegrationTestBase is Test {
 
     function executeCTMAdminCalls() internal virtual {
         require(_ctmAdminCallsPrepared, "CTM admin calls not prepared");
-        executeOwnableCallsAsCurrentOwner(_ctmAdminCalls);
+        require(_ctmAdminCalls.length != 0, "CTM admin calls are empty");
+        // Match the generated bundle: the ProxyAdmin's owner executes the whole
+        // batch, including acceptOwnership as the ServerNotifier's pending owner.
+        // Selecting each target's current owner breaks two-step ownership transfers.
+        address chainAdmin = getOwnableOwner(_ctmAdminCalls[0].target);
+        address ownerAdmin = _chainAdminMulticallOwner(chainAdmin);
+        Call[] memory calls = _ctmAdminCalls;
+        vm.startBroadcast(ownerAdmin);
+        IChainAdminMulticall(chainAdmin).multicall(calls, true);
+        vm.stopBroadcast();
     }
 
     function _cacheCTMAdminCalls(Call[] memory _calls) private {
@@ -292,28 +301,6 @@ contract UpgradeIntegrationTestBase is Test {
             cachedCall.target = _calls[i].target;
             cachedCall.value = _calls[i].value;
             cachedCall.data = _calls[i].data;
-        }
-    }
-
-    function executeOwnableCallsAsCurrentOwner(Call[] storage _calls) internal {
-        for (uint256 i = 0; i < _calls.length; i++) {
-            Call memory call = _calls[i];
-            address owner = getOwnableOwner(call.target);
-
-            if (owner.code.length == 0) {
-                vm.startBroadcast(owner);
-                (bool success, ) = payable(call.target).call{value: call.value}(call.data);
-                assertTrue(success, "Ownable admin call failed");
-                vm.stopBroadcast();
-            } else {
-                Call[] memory singleCall = new Call[](1);
-                singleCall[0] = call;
-
-                address ownerAdmin = _chainAdminMulticallOwner(owner);
-                vm.startBroadcast(ownerAdmin);
-                IChainAdminMulticall(owner).multicall(singleCall, true);
-                vm.stopBroadcast();
-            }
         }
     }
 

--- a/l1-contracts/test/foundry/l1/integration/UpgradeTestv31_Local.t.sol
+++ b/l1-contracts/test/foundry/l1/integration/UpgradeTestv31_Local.t.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.24;
 // solhint-disable no-console, gas-custom-errors
 
 import {console2 as console} from "forge-std/Script.sol";
+import {Vm} from "forge-std/Vm.sol";
+import {Ownable2Step} from "@openzeppelin/contracts-v4/access/Ownable2Step.sol";
 
 import {CTMUpgrade_v31} from "../../../../deploy-scripts/upgrade/v31/CTMUpgrade_v31.s.sol";
 import {CoreUpgrade_v31} from "../../../../deploy-scripts/upgrade/v31/CoreUpgrade_v31.s.sol";
@@ -131,6 +133,37 @@ contract UpgradeIntegrationTest_Local is
     address private _serverNotifierProxy;
     address private _serverNotifierProxyAdmin;
     address private _expectedServerNotifierProxyAdminOwner;
+
+    function executeCTMAdminCalls() internal override {
+        Ownable2Step notifier = Ownable2Step(_serverNotifierProxy);
+        address pendingOwner = notifier.pendingOwner();
+        assertEq(pendingOwner, _expectedServerNotifierProxyAdminOwner, "Unexpected pending notifier owner");
+        address previousOwner = notifier.owner();
+        vm.recordLogs();
+        super.executeCTMAdminCalls();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bool ownershipTransferred;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (
+                logs[i].emitter == _serverNotifierProxy &&
+                logs[i].topics[0] == keccak256("OwnershipTransferred(address,address)")
+            ) {
+                assertEq(logs[i].topics[1], bytes32(uint256(uint160(previousOwner))));
+                assertEq(logs[i].topics[2], bytes32(uint256(uint160(pendingOwner))));
+                ownershipTransferred = true;
+            }
+        }
+        assertTrue(ownershipTransferred, "Missing notifier ownership transfer event");
+        assertEq(notifier.pendingOwner(), address(0), "Notifier ownership transfer still pending");
+    }
+
+    function test_CTMAdminCalls_AfterOwnershipAccepted() public {
+        // A subsequent preparation must not attempt to accept ownership again.
+        Call[] memory calls = ctmUpgrade.prepareDefaultCTMAdminCalls();
+        assertEq(calls.length, 1, "Already accepted ownership should only require the proxy upgrade");
+        assertEq(calls[0].target, _serverNotifierProxyAdmin, "Unexpected CTM admin target");
+        assertEq(calls[0].value, 0, "Unexpected CTM admin value");
+    }
 
     /// @notice Override to inject the mocked Core upgrade (skips setAssetTracker call).
     function createCoreUpgrade() internal override returns (CoreUpgrade_v31) {
@@ -278,6 +311,11 @@ contract UpgradeIntegrationTest_Local is
         );
 
         if (_serverNotifierProxy != address(0)) {
+            assertEq(
+                getOwnableOwner(_serverNotifierProxy),
+                _expectedServerNotifierProxyAdminOwner,
+                "ServerNotifier ownership not accepted by ChainAdmin"
+            );
             assertEq(
                 getOwnableOwner(_serverNotifierProxyAdmin),
                 _expectedServerNotifierProxyAdminOwner,

--- a/protocol-ops/src/commands/ecosystem/bundle.rs
+++ b/protocol-ops/src/commands/ecosystem/bundle.rs
@@ -80,7 +80,9 @@ const CONTRACT_SOURCE_PATHSPECS: [&str; 12] = [
     "l1-contracts/contracts",
     "l1-contracts/deploy-scripts",
     "l1-contracts/upgrade-envs/permanent-values",
-    "l1-contracts/upgrade-envs/v0.31.0-interopB/*.toml",
+    // Git's default wildcard can cross directory separators. Use glob magic
+    // so generated output/<env>/ecosystem.toml is not mistaken for an input.
+    ":(glob)l1-contracts/upgrade-envs/v0.31.0-interopB/*.toml",
     "l2-contracts/contracts",
     "protocol-ops/src",
     "system-contracts/contracts",
@@ -1038,6 +1040,63 @@ pub fn run_verify_bundle(args: VerifyBundleArgs) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn source_provenance_excludes_generated_outputs_but_tracks_inputs() {
+        let repo = tempfile::tempdir().unwrap();
+        let input = "l1-contracts/upgrade-envs/v0.31.0-interopB/mainnet.toml";
+        let output = "l1-contracts/upgrade-envs/v0.31.0-interopB/output/mainnet/ecosystem.toml";
+        let source = "l1-contracts/contracts/Example.sol";
+        for path in [input, output, source] {
+            write(&repo.path().join(path), "original\n");
+        }
+        for args in [vec!["init"], vec!["add", "."]] {
+            assert!(try_capture("git", &args, repo.path()).is_some());
+        }
+        assert!(try_capture(
+            "git",
+            &[
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=test@example.invalid",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-m",
+                "fixture"
+            ],
+            repo.path(),
+        )
+        .is_some());
+        let status = || {
+            try_capture(
+                "git",
+                &[
+                    &["status", "--porcelain", "--"][..],
+                    &CONTRACT_SOURCE_PATHSPECS[..],
+                ]
+                .concat(),
+                repo.path(),
+            )
+            .unwrap()
+        };
+        assert!(status().is_empty());
+        write(&repo.path().join(output), "regenerated\n");
+        assert!(
+            status().is_empty(),
+            "generated TOML must not mark sources dirty"
+        );
+        for path in [input, source] {
+            write(&repo.path().join(path), "changed\n");
+            assert!(
+                status().contains(path),
+                "modified input must mark sources dirty: {path}"
+            );
+            write(&repo.path().join(path), "original\n");
+            assert!(status().is_empty());
+        }
+    }
 
     const TARGET: &str = "0x0000000000000000000000000000000000000002";
 


### PR DESCRIPTION
## Summary

Fix the remaining `UpgradeIntegrationTest_Local.setUp()` failure in #2461. This PR targets `sb-v31-bundle-handoff`, not the release branch directly.

The generated CTM admin bundle upgrades the ServerNotifier proxy and accepts its pending ownership transfer in one ChainAdmin multicall. The integration harness instead selected each target's current owner independently, so it invoked `acceptOwnership()` as the old owner and reverted with `Ownable2Step: caller is not the new owner` (wrapped as `Ownable admin call failed`).

- Execute the complete cached CTM admin batch through the ProxyAdmin's owning ChainAdmin, matching the generated bundle.
- Assert the notifier's ownership-transfer event, final owner and cleared pending owner, while retaining ProxyAdmin ownership and implementation assertions.
- Cover preparation after ownership has already been accepted, when only the proxy upgrade should be emitted.

Also fix the deployment provenance blocker found in run 34121950790. Git's default `*.toml` pathspec recursively matched the generated `output/mainnet/ecosystem.toml`, incorrectly marking the proven bundle's sources dirty. Use an explicit Git glob pathspec limited to the direct input TOMLs. Add a regression test covering clean sources, regenerated tracked output, modified config inputs, and modified contract sources. The deployment's dirty-source rejection remains unchanged.

Changes are confined to the test harness and bundle source-provenance classification. No production contracts, generated calldata, or contract-hash files change. The failed deployment stopped before signing any mainnet transactions; a fresh generation and handoff proof are required before retrying.

## Validation

- Reproduced the original ownership failure on `3e58127f4478439b27f02658ab7239c00009fb75` with a verbose local trace.
- Focused local upgrade regression tests: 2 passed.
- Full repository L1 Foundry test command (`--threads 1 --ffi`, excluding the configured mainnet-fork test and ChainRegistrarTest): **2,629 passed, 0 failed**, across 289 suites.
- Solidity lint, TypeScript lint, repository formatting, and `git diff --check`: passed.
- After the provenance fix: all 58 Rust tests, Clippy with warnings denied, and all 2,629 L1 tests passed locally.
