### PR TITLE
fix(ci): route DA verification and retry Etherscan requests

### DIFF
--- a/.github/tests/deploy-verify-only.test.cjs
+++ b/.github/tests/deploy-verify-only.test.cjs
@@ -1,5 +1,5 @@
 const assert = require("node:assert/strict");
-const { readFileSync, writeFileSync, mkdtempSync, rmSync } = require("node:fs");
+const { readFileSync, writeFileSync, mkdtempSync, mkdirSync, existsSync, rmSync } = require("node:fs");
 const { tmpdir } = require("node:os");
 const { join } = require("node:path");
 const { spawnSync } = require("node:child_process");
@@ -33,13 +33,26 @@ function runVerification(log, key = "test-placeholder") {
   const directory = mkdtempSync(join(tmpdir(), "verify-only-test-"));
   try {
     if (log !== null) writeFileSync(join(directory, "extra-verification-logs.txt"), log);
+    mkdirSync(join(directory, "l1-contracts"));
+    mkdirSync(join(directory, "da-contracts"));
     // Isolate orchestration from Etherscan/Foundry: no network or signing in these tests.
-    const mock = 'forge() { printf "%s\\n" "$*" >> "$DEPLOY_BUNDLE_DIR/calls"; [[ "$*" != *bad* ]]; }\n';
+    const mock = `forge() {
+      printf '%s|%s\\n' "$(basename "$PWD")" "$*" >> "$DEPLOY_BUNDLE_DIR/calls"
+      if [[ "$*" == *flaky* ]] && [ ! -f "$DEPLOY_BUNDLE_DIR/retried" ]; then
+        touch "$DEPLOY_BUNDLE_DIR/retried"
+        return 1
+      fi
+      [[ "$*" != *bad* ]]
+    }
+    sleep() { :; }
+    `;
     const result = spawnSync("bash", ["-c", mock + verification.run], {
       encoding: "utf8",
+      cwd: join(directory, "l1-contracts"),
       env: { ...process.env, ETHERSCAN_API_KEY: key, ETHERSCAN_CHAIN: "mainnet", DEPLOY_BUNDLE_DIR: directory },
     });
-    return result;
+    const calls = join(directory, "calls");
+    return { ...result, calls: existsSync(calls) ? readFileSync(calls, "utf8").trim().split("\n") : [] };
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
@@ -49,12 +62,37 @@ test("all successful commands pass and duplicate commands are removed", () => {
   const result = runVerification("forge verify-contract good Example\nforge verify-contract good Example\n");
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /1 succeeded, 0 failed/);
+  assert.equal(result.calls.length, 1);
 });
 
 test("a verification failure fails the step without skipping remaining contracts", () => {
   const result = runVerification("forge verify-contract bad Example\nforge verify-contract good Example\n");
   assert.equal(result.status, 1);
   assert.match(result.stdout, /1 succeeded, 1 failed/);
+  assert.equal(result.calls.filter((call) => call.includes("bad")).length, 3);
+  assert.equal(result.calls.filter((call) => call.includes("good")).length, 1);
+});
+
+test("DA contracts use their own workspace without changing recorded constructor arguments", () => {
+  const result = runVerification(
+    "forge verify-contract first EIP7702Checker\n" +
+      "forge verify-contract second RollupL1DAValidator --constructor-args 0x1234\n" +
+      "forge verify-contract third CommitterFacet --constructor-args 0x5678\n"
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(result.calls, [
+    "da-contracts|verify-contract first EIP7702Checker --chain mainnet --watch --retries 8 --delay 20",
+    "da-contracts|verify-contract second RollupL1DAValidator --constructor-args 0x1234 --chain mainnet --watch --retries 8 --delay 20",
+    "l1-contracts|verify-contract third CommitterFacet --constructor-args 0x5678 --chain mainnet --watch --retries 8 --delay 20",
+  ]);
+});
+
+test("a transient initial request failure is retried and counted once", () => {
+  const result = runVerification("forge verify-contract flaky CommitterFacet\n");
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.calls.length, 2);
+  assert.equal(result.calls[0], result.calls[1]);
+  assert.match(result.stdout, /1 succeeded, 0 failed/);
 });
 
 test("missing key, missing log, and empty verification list fail closed", () => {

--- a/.github/workflows/deploy-ecosystem-upgrade.yaml
+++ b/.github/workflows/deploy-ecosystem-upgrade.yaml
@@ -469,13 +469,35 @@ jobs:
           # normal deployments tolerate them, verification-only runs do not.
           verified=0
           failed=0
+          readonly verification_attempts=3
+          readonly verification_retry_delay=10
           while IFS= read -r cmd; do
             echo "--- $cmd"
-            if eval "$cmd --chain $CHAIN --watch --retries 8 --delay 20"; then
+            # These contracts are built by da-contracts, not l1-contracts.
+            # Keep the recorded address and constructor arguments unchanged.
+            read -r _forge _verify _address contract _rest <<< "$cmd"
+            verification_root="$PWD"
+            case "$contract" in
+              EIP7702Checker|RollupL1DAValidator) verification_root="../da-contracts" ;;
+            esac
+            success=false
+            for ((attempt=1; attempt<=verification_attempts; attempt++)); do
+              # --retries covers verification polling, but not an initial ABI
+              # request timeout. Retry the complete idempotent submission too.
+              if (cd "$verification_root" && eval "$cmd --chain $CHAIN --watch --retries 8 --delay 20"); then
+                success=true
+                break
+              fi
+              if [ "$attempt" -lt "$verification_attempts" ]; then
+                echo "Retrying verification ($attempt/$verification_attempts): $contract"
+                sleep "$verification_retry_delay"
+              fi
+            done
+            if [ "$success" = true ]; then
               echo "  OK"
               verified=$((verified + 1))
             else
-              echo "::warning::verification failed (re-run once Etherscan indexes the code): $cmd"
+              echo "::warning::verification failed after $verification_attempts attempts: $cmd"
               failed=$((failed + 1))
             fi
           done < <(grep 'forge verify-contract' "$LOG" | sed 's/^.*forge verify-contract/forge verify-contract/' | sort -u)


### PR DESCRIPTION
## What

Fix the four failures from verification-only run [34131648557](https://github.com/matter-labs/era-contracts/actions/runs/34131648557).

- Run EIP7702Checker and RollupL1DAValidator verification from `da-contracts`, where their sources and build configuration live. Other contracts remain in `l1-contracts`.
- Retry a complete verification command up to three times, with a ten-second delay. Foundry's polling retries did not cover the initial CommitterFacet ABI request timeout.
- Preserve every recorded address and constructor argument. Exhausted failures still fail verification-only runs; signing and broadcasting remain disabled.

## Validation

- Six workflow regression tests passed, covering workspace selection, constructor arguments, transient retry, retry exhaustion, deduplication, missing inputs, and no-signing guards.
- Both DA contracts successfully resolve with `forge verify-contract --show-standard-json-input` from their workspace, without network submissions.
- All 2,629 L1 tests passed; Solidity/TypeScript lint, formatting, workflow YAML/shell parsing, and `git diff --check` passed.

The follow-up [verification-only run 34136803019](https://github.com/matter-labs/era-contracts/actions/runs/34136803019) succeeded using the existing mainnet generation artifact 34125154681: **57 commands succeeded, 0 failed**. Foundry recognized all 57 addresses as already verified (including Etherscan similar matches, not a claim of 57 exact matches). Signer loading and broadcasting were skipped; the deployer nonce remains 86. No regeneration, deployment, or governance execution was performed.
