### PR TITLE
feat: raise max chain execution delay cap to 30 days

### DIFF
--- a/l1-contracts/contracts/common/Config.sol
+++ b/l1-contracts/contracts/common/Config.sol
@@ -292,4 +292,4 @@ uint256 constant PACKED_NUMBER_OF_L2_TRANSACTIONS_LOG_SPLIT_BITS = 128;
 /// @dev The maximal execution delay configurable in the `ValidatorTimelock`.
 /// @dev Footgun prevention only, not a trust guarantee: governance can upgrade the timelock, and outside
 /// stage 1 a chain admin can revoke the validator roles and stall execution anyway.
-uint32 constant MAX_VALIDATOR_TIMELOCK_EXECUTION_DELAY = 7 days;
+uint32 constant MAX_VALIDATOR_TIMELOCK_EXECUTION_DELAY = 30 days;

--- a/l1-contracts/test/foundry/l1/unit/concrete/ValidatorTimelock/ValidatorTimelock.t.sol
+++ b/l1-contracts/test/foundry/l1/unit/concrete/ValidatorTimelock/ValidatorTimelock.t.sol
@@ -664,7 +664,7 @@ contract ValidatorTimelockTest is Test {
     /// @dev The cap is inclusive.
     function test_increaseChainExecutionDelay_upToMax() public {
         uint32 maxDelay = validator.MAX_EXECUTION_DELAY();
-        assertEq(maxDelay, 7 days);
+        assertEq(maxDelay, 30 days);
 
         _setChainAdmin(bob);
         vm.prank(bob);


### PR DESCRIPTION
## What ❔

Raises `MAX_VALIDATOR_TIMELOCK_EXECUTION_DELAY` in `l1-contracts/contracts/common/Config.sol` from `7 days` to `30 days`, so a chain admin can configure an execution delay of up to a month instead of a week.

## Why ❔

The previous one-week cap was too restrictive for chains that want a longer self-imposed execution delay. The constant is footgun prevention rather than a trust guarantee, so a larger ceiling does not weaken any security assumption.

## Changes

- `l1-contracts/contracts/common/Config.sol`: `MAX_VALIDATOR_TIMELOCK_EXECUTION_DELAY` is now `30 days`. (Solidity has no `months` time unit, so a month is expressed as `30 days`.)
- `l1-contracts/test/foundry/l1/unit/concrete/ValidatorTimelock/ValidatorTimelock.t.sol`: updated the single hardcoded assertion on the cap value. All other tests read `MAX_EXECUTION_DELAY()` from the contract and needed no change.

`zkstack-out` only holds `IValidatorTimelock.sol`'s ABI, which is unaffected, so no artifact regeneration is required.

## Testing

All 48 `ValidatorTimelock` foundry tests pass:

```
forge test --match-path "test/foundry/l1/unit/concrete/ValidatorTimelock/*"
Suite result: ok. 48 passed; 0 failed; 0 skipped
```

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PR title).
- [x] Tests for the changes have been added / updated.
- [x] Code has been formatted via `yarn lint:fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzUekTCLZ78SdViKttKt1a