### PR TITLE
fix: wait for impersonated relay receipts by hash

### DIFF
--- a/l1-contracts/test/anvil-interop/src/core/utils.ts
+++ b/l1-contracts/test/anvil-interop/src/core/utils.ts
@@ -361,7 +361,9 @@ export async function relayTx(
         gasLimit: 30_000_000,
         ...(value && !value.isZero() ? { value } : {}),
       });
-      const receipt = await tx.wait();
+      // These impersonated relays are never replaced. Waiting by hash avoids ethers v5
+      // replacement watchers issuing RPCs after the receipt resolves and Anvil shuts down.
+      const receipt = await provider.waitForTransaction(tx.hash);
       return { txHash: receipt.transactionHash, success: receipt.status === 1, receipt };
     });
   } catch (error) {


### PR DESCRIPTION
Impersonated Anvil relays are never replaced, but ethers v5 `tx.wait()` starts replacement watchers that can issue RPCs after a receipt resolves and the chains shut down. Wait for the transaction by hash instead; receipt status and return values are unchanged.

Extracts the existing relayer fix from #2440 onto `draft/v0.34.0`. The coverage gate added in #2469 treats `src/core/utils.ts` as measurement tooling, so this needs a maintainer-reviewed baseline transition before #2440 can compare against the base. The gate is left intact; this prerequisite PR will itself report the tooling-change guard until that transition is approved.

Validated with the identical helper in #2440: two fresh six-chain deployments reproduce under the CI state comparison, all 10 interop groups pass, and Solidity/TypeScript lint and formatting pass. One file changes; no contract or snapshot changes.
