### PR TITLE
feat(examples): SampleDepositor / SampleWithdrawer bridging example

### DIFF
--- a/l1-contracts/examples/sample-depositor/README.md
+++ b/l1-contracts/examples/sample-depositor/README.md
@@ -90,8 +90,14 @@ prints the addresses (they are also in `broadcast/DeploySampleDepositor.s.sol/11
 
 ```bash
 export L2_RPC_URL=https://...
-forge script examples/sample-depositor/script/DeploySampleWithdrawer.s.sol --rpc-url $L2_RPC_URL --broadcast
+forge script examples/sample-depositor/script/DeploySampleWithdrawer.s.sol --rpc-url $L2_RPC_URL --broadcast \
+  --gas-estimate-multiplier 600
 ```
+
+On ZKsync OS chains `eth_estimateGas` does not account for the pubdata a transaction publishes (contract
+bytecode above all), so forge's default headroom runs out of gas: this deployment estimated at 1.3M gas and
+consumed 5.0M on the testnet. Scale the estimate generously for every transaction sent to the ZK chain; unused
+gas is refunded.
 
 ### 3. Bridge tokens to the withdrawer
 
@@ -104,7 +110,16 @@ The script quotes the L2 gas with `Bridgehub.l2TransactionBaseCost` at `L1_GAS_P
 `L2_GAS_LIMIT` (default 2,000,000) and sends that much ETH along; the surplus is refunded on L2 to
 `REFUND_RECIPIENT` (default: the owner). The quote must not be below the gas price the L1 transaction is mined
 with, otherwise the Bridgehub rejects the deposit. The chain's server executes the priority transaction within a
-few minutes; the bridged token then shows up at
+few minutes. Its L2 hash is the `txHash` of the `NewPriorityRequest` event in the L1 receipt (the hash forge
+prints comes from its simulation and differs):
+
+```bash
+cast receipt <l1 tx hash> --json --rpc-url $L1_RPC_URL | jq -r \
+  '.logs[] | select(.topics[0]=="0x4531cd5795773d7101c17bdeb9f5ab7f47d7056017506f937083be5d6e77a382") | "0x"+.data[66:130]'
+cast receipt <that hash> status --rpc-url $L2_RPC_URL
+```
+
+The bridged token then shows up at
 
 ```bash
 cast call 0x0000000000000000000000000000000000010004 "l2TokenAddress(address)(address)" $TOKEN --rpc-url $L2_RPC_URL
@@ -115,7 +130,8 @@ cast call <l2 token> "balanceOf(address)(uint256)" <withdrawer> --rpc-url $L2_RP
 
 ```bash
 WITHDRAWER=0x... L1_TOKEN=$TOKEN AMOUNT=10000000 L1_RECIPIENT=0x... \
-  forge script examples/sample-depositor/script/WithdrawToL1.s.sol --rpc-url $L2_RPC_URL --broadcast
+  forge script examples/sample-depositor/script/WithdrawToL1.s.sol --rpc-url $L2_RPC_URL --broadcast \
+  --gas-estimate-multiplier 600
 ```
 
 `L1_TOKEN` is resolved to the bridged token through the `L2NativeTokenVault`; pass `L2_TOKEN` to name it directly.

--- a/l1-contracts/examples/sample-depositor/README.md
+++ b/l1-contracts/examples/sample-depositor/README.md
@@ -150,6 +150,17 @@ L2_WITHDRAWAL_TX_HASH=<tx hash of step 4> \
 The script waits for the proof (up to `PROOF_TIMEOUT_MS`, default 60 min), simulates `executeBundle`, sends it,
 and checks that the bundle is `FullyExecuted`. The recipient then holds the tokens on L1.
 
+## Verified on live chains
+
+The flow above was run on 2026-09-11 against Sepolia and the ZKsync OS testnet alpha chain (8022833, direct
+L1 settlement, v33 ecosystem): a fresh test token and depositor on Sepolia (`0x922675abab3afe357f5fd0a0b6feadaf859056df`,
+`0x7d638686c9e3bb100b5ee1962f6690d349252ae5`), the withdrawer on the alpha chain (`0x7d638686c9e3bb100b5ee1962f6690d349252ae5`), a 1000-token deposit
+(L1 tx `0x8e27e2401c0123128eb78790ae75c17a26c42d8f726f154a90e69e2b8d32e16b`, executed on L2 within ~2 minutes, bridged token
+`0x85175cBd5ac1Ea0E3D518b6b05B43780E5b433d6`), then three withdrawals (100 / 250 / 400) to two L1 recipients, each finalized
+with `finalize-withdrawal.ts` ~25 minutes after its L2 block (first one: L2 tx
+`0x4aec5b84a70e9745ec053642f560b9ac6c5eb9a6ff35a9da12c95aef2f78a328`, L1 finalization `0x32027b11b375dff2db51820d1ab43027e55a4711b65e5521e1be1a087b3d3d91`).
+Final `bridgedOut` on L1 equalled the 250 tokens left on L2.
+
 ## Limitations
 
 - Only ZK chains whose base token is ETH are supported: the depositor pays the L2 gas with the ETH sent along.

--- a/l1-contracts/examples/sample-depositor/README.md
+++ b/l1-contracts/examples/sample-depositor/README.md
@@ -1,0 +1,142 @@
+# Sample: bridge an ERC20 to a contract on a ZK chain and withdraw it back
+
+Two small contracts that exercise the v33 deposit and withdrawal paths end to end:
+
+- **`SampleDepositor`** (L1) holds an ERC20 (for example USDC on Sepolia) and has a function that bridges a given
+  amount to an address on a ZK chain. The deposit is `Bridgehub.requestL2TransactionTwoBridges` with the
+  `L1AssetRouter` as the second bridge; the `L1NativeTokenVault` pulls the tokens from the depositor and the L2
+  priority transaction mints the bridged token to the receiver.
+- **`SampleWithdrawer`** (L2) receives the bridged token and has a function that withdraws a given amount to an L1
+  address. A withdrawal is a non-atomic interop bundle sent to the L1 chain id (`InteropCenter.sendBundle`); its single
+  indirect call makes the `L2AssetRouter` burn the tokens from the withdrawer. The bundle is executed on L1 by the
+  `L1InteropHandler` once the chain has published the message-inclusion proof (`executeBundle`). Each bundle salt can
+  be used once per sender, so the withdrawer salts every bundle with its withdrawal counter.
+
+Everything is deployed and driven with forge scripts, so the same commands work against the local anvil-interop
+chains and against Sepolia. The pieces a chain's server does in production are covered by TypeScript: the
+anvil-interop harness relays the priority transaction and mocks the inclusion proof locally, and
+`scripts/finalize-withdrawal.ts` waits for the real proof and finalizes on a live L1.
+
+```
+examples/sample-depositor/
+├── contracts/
+│   ├── SampleDepositor.sol            L1: holds the ERC20, bridges it to a ZK chain
+│   └── SampleWithdrawer.sol           L2: receives the bridged token, withdraws it to L1
+├── script/
+│   ├── DeploySampleDepositor.s.sol    L1: deploy (+ optionally deploy a test token) and fund the depositor
+│   ├── DeploySampleWithdrawer.s.sol   L2: deploy the withdrawer
+│   ├── BridgeToL2.s.sol               L1: SampleDepositor.bridgeTo(...)
+│   └── WithdrawToL1.s.sol             L2: SampleWithdrawer.withdraw(...)
+├── scripts/
+│   └── finalize-withdrawal.ts         live chains: wait for the proof, execute the bundle on L1
+└── test/
+    ├── sample-depositor.spec.ts       the anvil-interop run: deposit, then three withdrawals
+    └── forge-broadcast.ts             reads addresses / tx hashes from forge's broadcast output
+```
+
+## Running locally (anvil-interop)
+
+The test starts the pregenerated anvil-interop chains, deploys both contracts with the forge scripts, bridges
+1000 test tokens from the depositor to the withdrawer, and then sends three withdrawals (100, 250 and 400 tokens
+to two L1 recipients), finalizing each on L1 and checking balances, `bridgedOut` and the bundle statuses.
+
+```bash
+cd l1-contracts
+forge build                       # once; the harness reads ABIs from out/
+yarn example:sample-depositor     # about a minute: chains + deploy + deposit + 3 withdrawals
+```
+
+Useful variations (see `test/anvil-interop/README.md` for the harness flags):
+
+```bash
+# Keep the chains running afterwards, e.g. to inspect them with cast
+yarn example:sample-depositor --keep-chains
+
+# Re-run only the spec against chains that are still running
+ANVIL_INTEROP_SKIP_SETUP=1 ANVIL_INTEROP_SKIP_CLEANUP=1 \
+  yarn hardhat test examples/sample-depositor/test/sample-depositor.spec.ts --network hardhat --no-compile
+
+# Use a gateway-settled chain (12 or 13) instead of the direct-settled chain 10
+SAMPLE_L2_CHAIN_ID=12 yarn example:sample-depositor
+
+# Avoid port clashes with another anvil-interop run
+ANVIL_INTEROP_PORT_OFFSET=3000 yarn example:sample-depositor
+```
+
+Every transaction is printed as a `cast run <hash> -r <rpc>` command for tracing while the chains are up.
+
+## Running against Sepolia and a live ZK chain
+
+The forge scripts are configured through environment variables. Every script also needs `PRIVATE_KEY`; the
+deployer of a contract becomes its owner, and only the owner can bridge / withdraw.
+
+### 1. Deploy and fund the depositor on Sepolia
+
+```bash
+cd l1-contracts
+export PRIVATE_KEY=0x...                      # funded on Sepolia
+export L1_RPC_URL=https://sepolia...
+export BRIDGEHUB=0x...                        # the ecosystem's L1 Bridgehub
+export TOKEN=0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238   # USDC on Sepolia (6 decimals)
+FUND_AMOUNT=100000000 \
+  forge script examples/sample-depositor/script/DeploySampleDepositor.s.sol --rpc-url $L1_RPC_URL --broadcast
+```
+
+`FUND_AMOUNT` is transferred from the deployer to the depositor (here 100 USDC), so the deployer must hold it.
+Leave `TOKEN` unset to deploy a mintable `TestnetERC20Token` instead; `FUND_AMOUNT` is then minted. The script
+prints the addresses (they are also in `broadcast/DeploySampleDepositor.s.sol/11155111/run-latest.json`).
+
+### 2. Deploy the withdrawer on the ZK chain
+
+```bash
+export L2_RPC_URL=https://...
+forge script examples/sample-depositor/script/DeploySampleWithdrawer.s.sol --rpc-url $L2_RPC_URL --broadcast
+```
+
+### 3. Bridge tokens to the withdrawer
+
+```bash
+DEPOSITOR=0x... L2_CHAIN_ID=<zk chain id> L2_RECEIVER=<withdrawer> AMOUNT=50000000 \
+  forge script examples/sample-depositor/script/BridgeToL2.s.sol --rpc-url $L1_RPC_URL --broadcast
+```
+
+The script quotes the L2 gas with `Bridgehub.l2TransactionBaseCost` at `L1_GAS_PRICE_WEI` (default 50 gwei) for
+`L2_GAS_LIMIT` (default 2,000,000) and sends that much ETH along; the surplus is refunded on L2 to
+`REFUND_RECIPIENT` (default: the owner). The quote must not be below the gas price the L1 transaction is mined
+with, otherwise the Bridgehub rejects the deposit. The chain's server executes the priority transaction within a
+few minutes; the bridged token then shows up at
+
+```bash
+cast call 0x0000000000000000000000000000000000010004 "l2TokenAddress(address)(address)" $TOKEN --rpc-url $L2_RPC_URL
+cast call <l2 token> "balanceOf(address)(uint256)" <withdrawer> --rpc-url $L2_RPC_URL
+```
+
+### 4. Withdraw to L1 (repeat as often as you like)
+
+```bash
+WITHDRAWER=0x... L1_TOKEN=$TOKEN AMOUNT=10000000 L1_RECIPIENT=0x... \
+  forge script examples/sample-depositor/script/WithdrawToL1.s.sol --rpc-url $L2_RPC_URL --broadcast
+```
+
+`L1_TOKEN` is resolved to the bridged token through the `L2NativeTokenVault`; pass `L2_TOKEN` to name it directly.
+Every run sends a new bundle (fresh salt) and prints its hash.
+
+### 5. Finalize each withdrawal on L1
+
+Once the withdrawal's batch is executed on L1 and the chain's RPC serves the inclusion proof
+(`zks_getL2ToL1LogProof`), execute the bundle through the `L1InteropHandler`:
+
+```bash
+L2_WITHDRAWAL_TX_HASH=<tx hash of step 4> \
+  yarn ts-node examples/sample-depositor/scripts/finalize-withdrawal.ts
+```
+
+The script waits for the proof (up to `PROOF_TIMEOUT_MS`, default 60 min), simulates `executeBundle`, sends it,
+and checks that the bundle is `FullyExecuted`. The recipient then holds the tokens on L1.
+
+## Limitations
+
+- Only ZK chains whose base token is ETH are supported: the depositor pays the L2 gas with the ETH sent along.
+- If the L2 leg of a deposit fails, the tokens are claimable on L1 through `L1Nullifier.claimFailedDeposit` and
+  are returned to the depositor contract; `SampleDepositor.withdrawToken` lets the owner move them out.
+- The contracts are examples: single owner, no pausing, no accounting beyond the ERC20 balances.

--- a/l1-contracts/examples/sample-depositor/contracts/SampleDepositor.sol
+++ b/l1-contracts/examples/sample-depositor/contracts/SampleDepositor.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.28;
+
+import {Ownable} from "@openzeppelin/contracts-v4/access/Ownable.sol";
+import {IERC20} from "@openzeppelin/contracts-v4/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts-v4/token/ERC20/utils/SafeERC20.sol";
+
+import {IL1AssetRouter} from "contracts/bridge/asset-router/IL1AssetRouter.sol";
+import {INativeTokenVaultBase} from "contracts/bridge/ntv/INativeTokenVaultBase.sol";
+import {DataEncoding} from "contracts/common/libraries/DataEncoding.sol";
+import {IL1Bridgehub} from "contracts/core/bridgehub/IL1Bridgehub.sol";
+import {L2TransactionRequestTwoBridgesOuter} from "contracts/core/bridgehub/IBridgehubBase.sol";
+
+/// @title SampleDepositor
+/// @notice Example L1 contract that holds an ERC20 and bridges it to a contract on a ZK chain (e.g. a
+/// `SampleWithdrawer`, which can then withdraw the tokens back to L1).
+/// @dev The deposit is `Bridgehub.requestL2TransactionTwoBridges` with the L1AssetRouter as the second bridge:
+/// the L1NativeTokenVault pulls the tokens from this contract, and the L2 priority transaction mints the bridged
+/// token to `_l2Receiver`. Only destination chains whose base token is ETH are supported, because the L2 gas
+/// (`mintValue`) is paid with the ETH sent along with the call.
+/// See {protocol-docs/bridging.md#deposit-initiation-source-side}.
+contract SampleDepositor is Ownable {
+    using SafeERC20 for IERC20;
+
+    /// @notice The L1 Bridgehub of the ecosystem the tokens are bridged into.
+    IL1Bridgehub public immutable BRIDGEHUB;
+
+    /// @notice The ERC20 this contract holds and bridges.
+    IERC20 public immutable TOKEN;
+
+    /// @notice Emitted once a deposit has been requested on L1.
+    /// @param chainId The destination chain.
+    /// @param l2Receiver The address credited with the bridged token on the destination chain.
+    /// @param amount The bridged amount.
+    /// @param canonicalTxHash The hash of the L1 -> L2 priority transaction that finalizes the deposit.
+    event BridgedToL2(uint256 indexed chainId, address indexed l2Receiver, uint256 amount, bytes32 canonicalTxHash);
+
+    /// @notice The destination chain's base token is not ETH, so the L2 gas cannot be paid with `msg.value`.
+    error OnlyEthBaseTokenChains(uint256 chainId);
+
+    constructor(IL1Bridgehub _bridgehub, IERC20 _token) {
+        BRIDGEHUB = _bridgehub;
+        TOKEN = _token;
+    }
+
+    /// @notice Bridges `_amount` of `TOKEN` held by this contract to `_l2Receiver` on chain `_chainId`.
+    /// @dev `msg.value` becomes the deposit's `mintValue`. It must cover
+    /// `BRIDGEHUB.l2TransactionBaseCost(_chainId, tx.gasprice, _l2GasLimit, _l2GasPerPubdataByteLimit)`; the surplus
+    /// is refunded as ETH to `_refundRecipient` on the destination chain.
+    /// @param _chainId The destination chain id.
+    /// @param _l2Receiver The address credited with the bridged token on the destination chain.
+    /// @param _amount The amount of `TOKEN` to bridge.
+    /// @param _l2GasLimit The gas limit of the L2 transaction that finalizes the deposit.
+    /// @param _l2GasPerPubdataByteLimit The maximum L2 gas per pubdata byte the L2 transaction may pay.
+    /// @param _refundRecipient The L2 address receiving the ETH surplus (and the tokens, should the L2 transaction
+    /// fail); defaults to the caller. Pass an EOA: a contract address gets aliased on L2.
+    /// @return canonicalTxHash The hash of the resulting L1 -> L2 priority transaction.
+    function bridgeTo(
+        uint256 _chainId,
+        address _l2Receiver,
+        uint256 _amount,
+        uint256 _l2GasLimit,
+        uint256 _l2GasPerPubdataByteLimit,
+        address _refundRecipient
+    ) external payable onlyOwner returns (bytes32 canonicalTxHash) {
+        IL1AssetRouter assetRouter = IL1AssetRouter(address(BRIDGEHUB.assetRouter()));
+        if (BRIDGEHUB.baseTokenAssetId(_chainId) != assetRouter.ETH_TOKEN_ASSET_ID()) {
+            revert OnlyEthBaseTokenChains(_chainId);
+        }
+
+        canonicalTxHash = BRIDGEHUB.requestL2TransactionTwoBridges{value: msg.value}(
+            L2TransactionRequestTwoBridgesOuter({
+                chainId: _chainId,
+                mintValue: msg.value,
+                l2Value: 0,
+                l2GasLimit: _l2GasLimit,
+                l2GasPerPubdataByteLimit: _l2GasPerPubdataByteLimit,
+                refundRecipient: _refundRecipient == address(0) ? msg.sender : _refundRecipient,
+                secondBridgeAddress: address(assetRouter),
+                secondBridgeValue: 0,
+                secondBridgeCalldata: _prepareDeposit(assetRouter.nativeTokenVault(), _l2Receiver, _amount)
+            })
+        );
+
+        emit BridgedToL2(_chainId, _l2Receiver, _amount, canonicalTxHash);
+    }
+
+    /// @dev Registers `TOKEN` with the vault if needed, lets the vault pull `_amount` from this contract while the
+    /// deposit is processed, and returns the L1AssetRouter deposit calldata.
+    function _prepareDeposit(
+        INativeTokenVaultBase _nativeTokenVault,
+        address _l2Receiver,
+        uint256 _amount
+    ) internal returns (bytes memory secondBridgeCalldata) {
+        bytes32 assetId = _nativeTokenVault.ensureTokenIsRegistered(address(TOKEN));
+        TOKEN.forceApprove(address(_nativeTokenVault), _amount);
+        secondBridgeCalldata = DataEncoding.encodeAssetRouterBridgehubDepositData(
+            assetId,
+            DataEncoding.encodeBridgeBurnData(_amount, _l2Receiver, address(TOKEN))
+        );
+    }
+
+    /// @notice Moves `_amount` of `TOKEN` out of this contract without bridging (e.g. to recover funds).
+    /// @param _to The recipient.
+    /// @param _amount The amount to transfer.
+    function withdrawToken(address _to, uint256 _amount) external onlyOwner {
+        TOKEN.safeTransfer(_to, _amount);
+    }
+}

--- a/l1-contracts/examples/sample-depositor/contracts/SampleWithdrawer.sol
+++ b/l1-contracts/examples/sample-depositor/contracts/SampleWithdrawer.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.28;
+
+import {Ownable} from "@openzeppelin/contracts-v4/access/Ownable.sol";
+import {IERC20} from "@openzeppelin/contracts-v4/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts-v4/token/ERC20/utils/SafeERC20.sol";
+
+import {InteropCallStarter} from "contracts/common/Messaging.sol";
+import {DataEncoding} from "contracts/common/libraries/DataEncoding.sol";
+import {L2_NATIVE_TOKEN_VAULT_ADDR} from "contracts/common/l2-helpers/L2ContractAddresses.sol";
+import {L2_INTEROP_CENTER, L2_NATIVE_TOKEN_VAULT} from "contracts/common/l2-helpers/L2ContractInterfaces.sol";
+import {IERC7786Attributes} from "contracts/interop/IERC7786Attributes.sol";
+import {InteroperableAddress} from "contracts/vendor/draft-InteroperableAddress.sol";
+
+/// @title SampleWithdrawer
+/// @notice Example L2 contract that receives bridged ERC20s (e.g. deposited by a `SampleDepositor`) and withdraws
+/// them to arbitrary L1 recipients.
+/// @dev A withdrawal is a non-atomic interop bundle sent to the L1 chain id. Its single indirect call targets the
+/// L2AssetRouter, which burns the tokens from this contract; the bundle is executed on L1 by the L1InteropHandler
+/// once its message-inclusion proof is available (`executeBundle`). L2 -> L1 bundles carry no interop fee, so no
+/// base token is needed. The InteropCenter accepts each bundle salt only once per sender, hence the per-withdrawal
+/// salt. See {protocol-docs/bridging.md#deposit-initiation-source-side}.
+contract SampleWithdrawer is Ownable {
+    using SafeERC20 for IERC20;
+
+    /// @notice The number of withdrawals sent so far. Doubles as the salt of the next withdrawal bundle.
+    uint256 public withdrawalCount;
+
+    /// @notice Emitted once a withdrawal bundle has been sent.
+    /// @param l2Token The withdrawn token (its address on this chain).
+    /// @param l1Recipient The L1 address that receives the tokens once the bundle is executed on L1.
+    /// @param amount The withdrawn amount.
+    /// @param bundleHash The hash of the interop bundle to execute on L1.
+    event WithdrawalInitiated(address indexed l2Token, address indexed l1Recipient, uint256 amount, bytes32 bundleHash);
+
+    /// @notice The token is unknown to the L2NativeTokenVault, so it cannot be bridged.
+    error TokenNotRegistered(address l2Token);
+
+    /// @notice Withdraws `_amount` of `_l2Token` held by this contract to `_l1Recipient` on L1.
+    /// @param _l2Token The token on this chain. Every token bridged in from L1 is registered with the vault.
+    /// @param _amount The amount to withdraw.
+    /// @param _l1Recipient The L1 recipient.
+    /// @return bundleHash The hash of the interop bundle to execute on L1.
+    function withdraw(
+        address _l2Token,
+        uint256 _amount,
+        address _l1Recipient
+    ) external onlyOwner returns (bytes32 bundleHash) {
+        bytes32 assetId = L2_NATIVE_TOKEN_VAULT.assetId(_l2Token);
+        if (assetId == bytes32(0)) {
+            revert TokenNotRegistered(_l2Token);
+        }
+        // The vault burns a bridged token directly, but pulls a chain-native one via allowance.
+        IERC20(_l2Token).forceApprove(L2_NATIVE_TOKEN_VAULT_ADDR, _amount);
+
+        InteropCallStarter[] memory calls = DataEncoding.encodeInteropWithdrawalCallStarters(
+            assetId,
+            DataEncoding.encodeBridgeBurnData(_amount, _l1Recipient, _l2Token)
+        );
+        bytes[] memory bundleAttributes = new bytes[](1);
+        bundleAttributes[0] = abi.encodeCall(IERC7786Attributes.interopBundleSalt, (bytes32(++withdrawalCount)));
+
+        bundleHash = L2_INTEROP_CENTER.sendBundle(
+            InteroperableAddress.formatEvmV1(L2_INTEROP_CENTER.L1_CHAIN_ID()),
+            calls,
+            bundleAttributes
+        );
+
+        emit WithdrawalInitiated(_l2Token, _l1Recipient, _amount, bundleHash);
+    }
+}

--- a/l1-contracts/examples/sample-depositor/script/BridgeToL2.s.sol
+++ b/l1-contracts/examples/sample-depositor/script/BridgeToL2.s.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.28;
+
+// solhint-disable no-console
+
+import {Script} from "forge-std/Script.sol";
+import {console2} from "forge-std/console2.sol";
+
+import {REQUIRED_L2_GAS_PRICE_PER_PUBDATA} from "contracts/common/Config.sol";
+import {SampleDepositor} from "../contracts/SampleDepositor.sol";
+
+/// @notice Bridges tokens from a `SampleDepositor` (L1) to an address on a ZK chain.
+/// @dev Environment:
+/// - `PRIVATE_KEY`: the depositor's owner.
+/// - `DEPOSITOR`: the `SampleDepositor` address.
+/// - `L2_CHAIN_ID`, `L2_RECEIVER`, `AMOUNT`: destination chain, recipient on it (e.g. a `SampleWithdrawer`) and amount.
+/// - `L2_GAS_LIMIT` (optional, default 2,000,000): gas limit of the L2 transaction finalizing the deposit.
+/// - `L1_GAS_PRICE_WEI` (optional, default 50 gwei): L1 gas price the L2 gas is quoted at. The quote must not be
+///   below the gas price the transaction is mined with; the surplus is refunded on L2.
+/// - `REFUND_RECIPIENT` (optional, default: the owner): L2 address refunded the surplus.
+contract BridgeToL2 is Script {
+    uint256 internal constant DEFAULT_L2_GAS_LIMIT = 2_000_000;
+    uint256 internal constant DEFAULT_L1_GAS_PRICE_WEI = 50 gwei;
+
+    function run() external returns (bytes32 canonicalTxHash) {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        SampleDepositor depositor = SampleDepositor(vm.envAddress("DEPOSITOR"));
+        uint256 chainId = vm.envUint("L2_CHAIN_ID");
+        address l2Receiver = vm.envAddress("L2_RECEIVER");
+        uint256 amount = vm.envUint("AMOUNT");
+        uint256 l2GasLimit = vm.envOr("L2_GAS_LIMIT", DEFAULT_L2_GAS_LIMIT);
+        uint256 l1GasPrice = vm.envOr("L1_GAS_PRICE_WEI", DEFAULT_L1_GAS_PRICE_WEI);
+        address refundRecipient = vm.envOr("REFUND_RECIPIENT", vm.addr(privateKey));
+
+        uint256 mintValue = depositor.BRIDGEHUB().l2TransactionBaseCost({
+            _chainId: chainId,
+            _gasPrice: l1GasPrice,
+            _l2GasLimit: l2GasLimit,
+            _l2GasPerPubdataByteLimit: REQUIRED_L2_GAS_PRICE_PER_PUBDATA
+        });
+
+        vm.startBroadcast(privateKey);
+        canonicalTxHash = depositor.bridgeTo{value: mintValue}({
+            _chainId: chainId,
+            _l2Receiver: l2Receiver,
+            _amount: amount,
+            _l2GasLimit: l2GasLimit,
+            _l2GasPerPubdataByteLimit: REQUIRED_L2_GAS_PRICE_PER_PUBDATA,
+            _refundRecipient: refundRecipient
+        });
+        vm.stopBroadcast();
+
+        console2.log("L2 gas paid (wei):", mintValue);
+        console2.log("Canonical L1 -> L2 tx hash:");
+        console2.logBytes32(canonicalTxHash);
+    }
+}

--- a/l1-contracts/examples/sample-depositor/script/BridgeToL2.s.sol
+++ b/l1-contracts/examples/sample-depositor/script/BridgeToL2.s.sol
@@ -52,7 +52,9 @@ contract BridgeToL2 is Script {
         vm.stopBroadcast();
 
         console2.log("L2 gas paid (wei):", mintValue);
-        console2.log("Canonical L1 -> L2 tx hash:");
+        // Forge prints the hash of its *simulation*; the broadcast one differs (it commits to the priority
+        // queue position and the L1 gas price). Read it from the `NewPriorityRequest` event of the L1 receipt.
+        console2.log("Canonical L1 -> L2 tx hash (simulation):");
         console2.logBytes32(canonicalTxHash);
     }
 }

--- a/l1-contracts/examples/sample-depositor/script/DeploySampleDepositor.s.sol
+++ b/l1-contracts/examples/sample-depositor/script/DeploySampleDepositor.s.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.28;
+
+// solhint-disable no-console
+
+import {Script} from "forge-std/Script.sol";
+import {console2} from "forge-std/console2.sol";
+import {IERC20} from "@openzeppelin/contracts-v4/token/ERC20/IERC20.sol";
+
+import {IL1Bridgehub} from "contracts/core/bridgehub/IL1Bridgehub.sol";
+import {TestnetERC20Token} from "contracts/dev-contracts/TestnetERC20Token.sol";
+import {SampleDepositor} from "../contracts/SampleDepositor.sol";
+
+/// @notice Deploys a `SampleDepositor` on L1 and optionally funds it.
+/// @dev Environment:
+/// - `PRIVATE_KEY`: deployer (becomes the depositor's owner).
+/// - `BRIDGEHUB`: the ecosystem's L1 Bridgehub.
+/// - `TOKEN` (optional): the ERC20 to bridge, e.g. USDC. When unset a mintable `TestnetERC20Token` is deployed.
+/// - `FUND_AMOUNT` (optional): amount to put into the depositor; minted for a fresh test token, transferred from
+///   the deployer's balance for an existing one.
+contract DeploySampleDepositor is Script {
+    function run() external returns (SampleDepositor depositor, IERC20 token) {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        IL1Bridgehub bridgehub = IL1Bridgehub(vm.envAddress("BRIDGEHUB"));
+        token = IERC20(vm.envOr("TOKEN", address(0)));
+        uint256 fundAmount = vm.envOr("FUND_AMOUNT", uint256(0));
+
+        vm.startBroadcast(privateKey);
+        bool freshToken = address(token) == address(0);
+        if (freshToken) {
+            token = new TestnetERC20Token("Sample Token", "SMPL", 18);
+        }
+        depositor = new SampleDepositor(bridgehub, token);
+        if (fundAmount > 0) {
+            if (freshToken) {
+                TestnetERC20Token(address(token)).mint(address(depositor), fundAmount);
+            } else {
+                token.transfer(address(depositor), fundAmount);
+            }
+        }
+        vm.stopBroadcast();
+
+        console2.log("Token:", address(token));
+        console2.log("SampleDepositor:", address(depositor));
+    }
+}

--- a/l1-contracts/examples/sample-depositor/script/DeploySampleWithdrawer.s.sol
+++ b/l1-contracts/examples/sample-depositor/script/DeploySampleWithdrawer.s.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.28;
+
+// solhint-disable no-console
+
+import {Script} from "forge-std/Script.sol";
+import {console2} from "forge-std/console2.sol";
+
+import {SampleWithdrawer} from "../contracts/SampleWithdrawer.sol";
+
+/// @notice Deploys a `SampleWithdrawer` on a ZK chain.
+/// @dev Environment: `PRIVATE_KEY`, the deployer (becomes the withdrawer's owner).
+contract DeploySampleWithdrawer is Script {
+    function run() external returns (SampleWithdrawer withdrawer) {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+
+        vm.startBroadcast(privateKey);
+        withdrawer = new SampleWithdrawer();
+        vm.stopBroadcast();
+
+        console2.log("SampleWithdrawer:", address(withdrawer));
+    }
+}

--- a/l1-contracts/examples/sample-depositor/script/WithdrawToL1.s.sol
+++ b/l1-contracts/examples/sample-depositor/script/WithdrawToL1.s.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.28;
+
+// solhint-disable no-console
+
+import {Script} from "forge-std/Script.sol";
+import {console2} from "forge-std/console2.sol";
+
+import {L2_NATIVE_TOKEN_VAULT} from "contracts/common/l2-helpers/L2ContractInterfaces.sol";
+import {SampleWithdrawer} from "../contracts/SampleWithdrawer.sol";
+
+/// @notice Withdraws tokens from a `SampleWithdrawer` (ZK chain) to an L1 address.
+/// @dev Environment:
+/// - `PRIVATE_KEY`: the withdrawer's owner.
+/// - `WITHDRAWER`: the `SampleWithdrawer` address.
+/// - `AMOUNT`, `L1_RECIPIENT`: amount and L1 recipient.
+/// - `L2_TOKEN` or `L1_TOKEN`: the token to withdraw, either by its address on this chain or by its L1 address
+///   (resolved through the L2NativeTokenVault; the token must have been bridged in before).
+contract WithdrawToL1 is Script {
+    function run() external returns (bytes32 bundleHash) {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        SampleWithdrawer withdrawer = SampleWithdrawer(vm.envAddress("WITHDRAWER"));
+        uint256 amount = vm.envUint("AMOUNT");
+        address l1Recipient = vm.envAddress("L1_RECIPIENT");
+        address l2Token = vm.envOr("L2_TOKEN", address(0));
+        if (l2Token == address(0)) {
+            l2Token = L2_NATIVE_TOKEN_VAULT.l2TokenAddress(vm.envAddress("L1_TOKEN"));
+        }
+
+        vm.startBroadcast(privateKey);
+        bundleHash = withdrawer.withdraw(l2Token, amount, l1Recipient);
+        vm.stopBroadcast();
+
+        console2.log("L2 token:", l2Token);
+        console2.log("Withdrawal bundle hash:");
+        console2.logBytes32(bundleHash);
+    }
+}

--- a/l1-contracts/examples/sample-depositor/scripts/finalize-withdrawal.ts
+++ b/l1-contracts/examples/sample-depositor/scripts/finalize-withdrawal.ts
@@ -1,0 +1,89 @@
+/**
+ * Finalizes a `SampleWithdrawer` withdrawal on L1 against a real ZK chain (e.g. Sepolia + a testnet chain).
+ *
+ * Waits until the chain's server has published the message-inclusion proof for the withdrawal's L2 -> L1
+ * message, then executes the interop bundle through the ecosystem's `L1InteropHandler`.
+ *
+ * Environment:
+ *   L1_RPC_URL, L2_RPC_URL      RPC endpoints of L1 and the ZK chain
+ *   PRIVATE_KEY                 L1 account paying for the finalization (anyone may finalize)
+ *   BRIDGEHUB                   the ecosystem's L1 Bridgehub
+ *   L2_WITHDRAWAL_TX_HASH       the L2 transaction that called `SampleWithdrawer.withdraw` (`WithdrawToL1.s.sol`)
+ *   PROOF_TIMEOUT_MS            optional, how long to wait for the proof (default 60 min)
+ *
+ * Run from `l1-contracts/`:
+ *   yarn ts-node examples/sample-depositor/scripts/finalize-withdrawal.ts
+ */
+
+import { Contract, ethers, Wallet } from "ethers";
+import { BundleStatus, DEFAULT_TX_GAS_LIMIT } from "../../../test/anvil-interop/src/core/const";
+import { getAbi } from "../../../test/anvil-interop/src/core/contracts";
+import { createProvider } from "../../../test/anvil-interop/src/core/utils";
+import { waitForLiveFinalizeWithdrawalParams } from "../../../test/anvil-interop/src/helpers/temp-sdk";
+
+const DEFAULT_PROOF_TIMEOUT_MS = 60 * 60 * 1000;
+/** Every L2 -> L1 interop bundle message starts with this byte (`BUNDLE_IDENTIFIER`). */
+const BUNDLE_IDENTIFIER = "0x01";
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+async function main(): Promise<void> {
+  const l1Provider = createProvider(requiredEnv("L1_RPC_URL"));
+  const l2Provider = createProvider(requiredEnv("L2_RPC_URL"));
+  const l1Wallet = new Wallet(requiredEnv("PRIVATE_KEY"), l1Provider);
+  const bridgehubAddress = requiredEnv("BRIDGEHUB");
+  const withdrawalTxHash = requiredEnv("L2_WITHDRAWAL_TX_HASH");
+  const timeoutMs = Number(process.env.PROOF_TIMEOUT_MS ?? DEFAULT_PROOF_TIMEOUT_MS);
+
+  const l2ChainId = (await l2Provider.getNetwork()).chainId;
+  console.log(`Waiting for the inclusion proof of ${withdrawalTxHash} (chain ${l2ChainId})...`);
+  const params = await waitForLiveFinalizeWithdrawalParams(l2Provider, withdrawalTxHash, l2ChainId, 0, timeoutMs);
+
+  const message = ethers.utils.hexlify(params.message);
+  if (ethers.utils.hexDataSlice(message, 0, 1) !== BUNDLE_IDENTIFIER) {
+    throw new Error("The L2 -> L1 message is not an interop bundle");
+  }
+  const bundle = ethers.utils.hexDataSlice(message, 1);
+  const proof = {
+    chainId: l2ChainId,
+    l1BatchNumber: params.l2BatchNumber,
+    l2MessageIndex: params.l2MessageIndex,
+    message: { txNumberInBatch: params.l2TxNumberInBatch, sender: params.l2Sender, data: message },
+    proof: params.merkleProof,
+  };
+
+  // Bridgehub -> L1AssetRouter -> L1Nullifier -> L1InteropHandler: the bundle executor.
+  const bridgehub = new Contract(bridgehubAddress, getAbi("IL1Bridgehub"), l1Provider);
+  const assetRouter = new Contract(await bridgehub.assetRouter(), getAbi("L1AssetRouter"), l1Provider);
+  const nullifier = new Contract(await assetRouter.L1_NULLIFIER(), getAbi("L1Nullifier"), l1Provider);
+  const interopHandler = new Contract(await nullifier.l1InteropHandler(), getAbi("L1InteropHandler"), l1Wallet);
+
+  const bundleHash = ethers.utils.keccak256(bundle);
+  const statusBefore: number = await interopHandler.bundleStatus(bundleHash);
+  if (statusBefore === BundleStatus.FullyExecuted) {
+    console.log(`Bundle ${bundleHash} is already executed on L1`);
+    return;
+  }
+
+  await interopHandler.callStatic.executeBundle(bundle, proof, { gasLimit: DEFAULT_TX_GAS_LIMIT });
+  const tx = await interopHandler.executeBundle(bundle, proof, { gasLimit: DEFAULT_TX_GAS_LIMIT });
+  console.log(`L1 finalization tx: ${tx.hash}`);
+  await tx.wait();
+
+  const status: number = await interopHandler.bundleStatus(bundleHash);
+  if (status !== BundleStatus.FullyExecuted) {
+    throw new Error(`Unexpected bundle status ${status} after finalization`);
+  }
+  console.log(`Bundle ${bundleHash} executed on L1`);
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/l1-contracts/examples/sample-depositor/test/forge-broadcast.ts
+++ b/l1-contracts/examples/sample-depositor/test/forge-broadcast.ts
@@ -1,0 +1,53 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/** One entry of a forge `broadcast/<script>/<chainId>/run-latest.json` transaction list. */
+interface BroadcastTransaction {
+  hash: string;
+  transactionType: "CREATE" | "CREATE2" | "CALL";
+  contractName?: string | null;
+  contractAddress?: string | null;
+}
+
+export interface ForgeBroadcast {
+  transactions: BroadcastTransaction[];
+}
+
+/**
+ * Reads the latest broadcast forge wrote for `scriptFile` on `chainId`. Forge records every broadcast
+ * transaction there, so the tests learn deployed addresses and transaction hashes from the same source a
+ * manual `forge script --broadcast` run leaves behind.
+ */
+export function readLatestBroadcast(projectRoot: string, scriptFile: string, chainId: number): ForgeBroadcast {
+  const broadcastPath = path.join(
+    projectRoot,
+    "broadcast",
+    path.basename(scriptFile),
+    String(chainId),
+    "run-latest.json"
+  );
+  if (!fs.existsSync(broadcastPath)) {
+    throw new Error(`No forge broadcast found at ${broadcastPath}`);
+  }
+  return JSON.parse(fs.readFileSync(broadcastPath, "utf-8")) as ForgeBroadcast;
+}
+
+/** The address of the contract named `contractName` created by the broadcast. */
+export function createdContractAddress(broadcast: ForgeBroadcast, contractName: string): string {
+  const created = broadcast.transactions.find(
+    (tx) => tx.transactionType !== "CALL" && tx.contractName === contractName && tx.contractAddress
+  );
+  if (!created?.contractAddress) {
+    throw new Error(`The broadcast did not create a ${contractName}`);
+  }
+  return created.contractAddress;
+}
+
+/** The hash of the last transaction of the broadcast. */
+export function lastTransactionHash(broadcast: ForgeBroadcast): string {
+  const last = broadcast.transactions[broadcast.transactions.length - 1];
+  if (!last) {
+    throw new Error("The broadcast contains no transactions");
+  }
+  return last.hash;
+}

--- a/l1-contracts/examples/sample-depositor/test/sample-depositor.spec.ts
+++ b/l1-contracts/examples/sample-depositor/test/sample-depositor.spec.ts
@@ -1,0 +1,238 @@
+/**
+ * End-to-end run of the SampleDepositor / SampleWithdrawer example against the anvil-interop chains.
+ *
+ * The contracts are deployed and driven with the forge scripts from `../script` (exactly what a manual run
+ * against Sepolia uses); the pieces a real ZK chain's server would do are taken from the anvil-interop
+ * harness: relaying the L1 -> L2 priority transaction and supplying the (mocked) message-inclusion proof for
+ * the L1 finalization of each withdrawal bundle.
+ *
+ * Run from `l1-contracts/`:
+ *   yarn example:sample-depositor
+ * or, against chains kept running with `--keep-chains`:
+ *   ANVIL_INTEROP_SKIP_SETUP=1 ANVIL_INTEROP_SKIP_CLEANUP=1 \
+ *     yarn hardhat test examples/sample-depositor/test/sample-depositor.spec.ts --network hardhat --no-compile
+ */
+
+import { expect } from "chai";
+import type { BigNumber } from "ethers";
+import { Contract, ethers } from "ethers";
+import * as path from "path";
+import { DeploymentRunner } from "../../../test/anvil-interop/src/deployment-runner";
+import {
+  ANVIL_ACCOUNT2_ADDR,
+  ANVIL_DEFAULT_PRIVATE_KEY,
+  ANVIL_RECIPIENT_ADDR,
+  BundleStatus,
+  INTEROP_BUNDLE_TUPLE_TYPE,
+  L2_NATIVE_TOKEN_VAULT_ADDR,
+} from "../../../test/anvil-interop/src/core/const";
+import { getAbi } from "../../../test/anvil-interop/src/core/contracts";
+import { runForgeScript } from "../../../test/anvil-interop/src/core/forge";
+import type { DeploymentState } from "../../../test/anvil-interop/src/core/types";
+import {
+  createProvider,
+  extractAndRelayNewPriorityRequests,
+  getChainIdByRole,
+  getL2Chain,
+} from "../../../test/anvil-interop/src/core/utils";
+import { getL1BridgedOut } from "../../../test/anvil-interop/src/helpers/bridged-out-helper";
+import { finalizeWithdrawalOnL1 } from "../../../test/anvil-interop/src/helpers/l2-withdrawal-helper";
+import { createdContractAddress, lastTransactionHash, readLatestBroadcast } from "./forge-broadcast";
+
+const L1_CONTRACTS_DIR = path.resolve(__dirname, "../../..");
+const SCRIPT_DIR = "examples/sample-depositor/script";
+
+const TOKEN_DECIMALS = 18;
+/** What the depositor is funded with on L1. */
+const FUND_AMOUNT = ethers.utils.parseUnits("1500", TOKEN_DECIMALS);
+/** What the depositor bridges to the withdrawer. */
+const DEPOSIT_AMOUNT = ethers.utils.parseUnits("1000", TOKEN_DECIMALS);
+/** The withdrawals the withdrawer sends back to L1, in order; they must sum to less than `DEPOSIT_AMOUNT`. */
+const WITHDRAWALS = [
+  { amount: ethers.utils.parseUnits("100", TOKEN_DECIMALS), l1Recipient: ANVIL_RECIPIENT_ADDR },
+  { amount: ethers.utils.parseUnits("250", TOKEN_DECIMALS), l1Recipient: ANVIL_RECIPIENT_ADDR },
+  { amount: ethers.utils.parseUnits("400", TOKEN_DECIMALS), l1Recipient: ANVIL_ACCOUNT2_ADDR },
+];
+
+describe("Example - SampleDepositor (L1) -> SampleWithdrawer (L2) -> multiple withdrawals to L1", function () {
+  this.timeout(0);
+
+  const runner = new DeploymentRunner();
+  let state: DeploymentState;
+  let chainId: number;
+  let l1ChainId: number;
+  let l1RpcUrl: string;
+  let l2RpcUrl: string;
+  let gwRpcUrl: string | undefined;
+  let l1Provider: ethers.providers.JsonRpcProvider;
+  let l2Provider: ethers.providers.JsonRpcProvider;
+
+  let l1Token: Contract;
+  let depositor: string;
+  let withdrawer: string;
+  let l2Token: Contract;
+  let l1TokenAssetId: string;
+
+  async function runScript(scriptFile: string, rpcUrl: string, envVars: Record<string, string>): Promise<void> {
+    await runForgeScript({
+      scriptPath: `${SCRIPT_DIR}/${scriptFile}`,
+      envVars: { PRIVATE_KEY: ANVIL_DEFAULT_PRIVATE_KEY, ...envVars },
+      rpcUrl,
+      privateKey: ANVIL_DEFAULT_PRIVATE_KEY,
+      projectRoot: L1_CONTRACTS_DIR,
+      sig: "run()",
+    });
+  }
+
+  before(async () => {
+    state = runner.loadState();
+    if (!state.chains?.l1 || !state.l1Addresses || !state.chainAddresses) {
+      throw new Error("Deployment state incomplete. Run setup first.");
+    }
+    const config = state.chains.config;
+    chainId = Number(process.env.SAMPLE_L2_CHAIN_ID) || getChainIdByRole(config, "directSettled");
+    l1ChainId = state.chains.l1.chainId;
+    l1RpcUrl = state.chains.l1.rpcUrl;
+    l2RpcUrl = getL2Chain(state.chains, chainId).rpcUrl;
+    // A gateway-settled chain receives its priority transactions through the gateway.
+    if (config.find((c) => c.chainId === chainId)?.settlement === "gateway") {
+      gwRpcUrl = getL2Chain(state.chains, getChainIdByRole(config, "gateway")).rpcUrl;
+    }
+    l1Provider = createProvider(l1RpcUrl);
+    l2Provider = createProvider(l2RpcUrl);
+
+    console.log(`\n   Deploying the sample contracts (L1 chain ${l1ChainId}, L2 chain ${chainId})...`);
+    await runScript("DeploySampleDepositor.s.sol", l1RpcUrl, {
+      BRIDGEHUB: state.l1Addresses.bridgehub,
+      FUND_AMOUNT: FUND_AMOUNT.toString(),
+    });
+    const l1Broadcast = readLatestBroadcast(L1_CONTRACTS_DIR, "DeploySampleDepositor.s.sol", l1ChainId);
+    l1Token = new Contract(
+      createdContractAddress(l1Broadcast, "TestnetERC20Token"),
+      getAbi("TestnetERC20Token"),
+      l1Provider
+    );
+    depositor = createdContractAddress(l1Broadcast, "SampleDepositor");
+
+    await runScript("DeploySampleWithdrawer.s.sol", l2RpcUrl, {});
+    withdrawer = createdContractAddress(
+      readLatestBroadcast(L1_CONTRACTS_DIR, "DeploySampleWithdrawer.s.sol", chainId),
+      "SampleWithdrawer"
+    );
+    console.log(`   Token: ${l1Token.address}\n   SampleDepositor: ${depositor}\n   SampleWithdrawer: ${withdrawer}`);
+  });
+
+  it("bridges the ERC20 from the SampleDepositor to the SampleWithdrawer", async () => {
+    const l1Ntv = new Contract(state.l1Addresses!.l1NativeTokenVault, getAbi("L1NativeTokenVault"), l1Provider);
+    expect((await l1Token.balanceOf(depositor)).eq(FUND_AMOUNT), "depositor should hold the fund amount").to.equal(
+      true
+    );
+
+    await runScript("BridgeToL2.s.sol", l1RpcUrl, {
+      DEPOSITOR: depositor,
+      L2_CHAIN_ID: String(chainId),
+      L2_RECEIVER: withdrawer,
+      AMOUNT: DEPOSIT_AMOUNT.toString(),
+    });
+    const l1TxHash = lastTransactionHash(readLatestBroadcast(L1_CONTRACTS_DIR, "BridgeToL2.s.sol", l1ChainId));
+    const l1Receipt = await l1Provider.getTransactionReceipt(l1TxHash);
+    console.log(`   L1 deposit tx: cast run ${l1TxHash} -r ${l1RpcUrl}`);
+
+    // Stand-in for the chain's server: execute the priority transaction(s) the deposit emitted on L1.
+    const l2TxHashes = await extractAndRelayNewPriorityRequests(l1Receipt, {
+      l1RpcUrl,
+      bridgehubAddr: state.l1Addresses!.bridgehub,
+      chainId,
+      chainRpcUrl: l2RpcUrl,
+      gwRpcUrl,
+    });
+    expect(l2TxHashes.length, "the deposit should produce at least one L2 transaction").to.be.greaterThan(0);
+
+    // The bridged token is deployed by the L2 vault on first arrival.
+    const l2Ntv = new Contract(L2_NATIVE_TOKEN_VAULT_ADDR, getAbi("L2NativeTokenVault"), l2Provider);
+    const l2TokenAddress: string = await l2Ntv.l2TokenAddress(l1Token.address);
+    expect(l2TokenAddress, "the bridged token should exist on L2").to.not.equal(ethers.constants.AddressZero);
+    l2Token = new Contract(l2TokenAddress, getAbi("BridgedStandardERC20"), l2Provider);
+    console.log(`   Bridged token on L2: ${l2TokenAddress}`);
+
+    l1TokenAssetId = await l1Ntv.assetId(l1Token.address);
+    expectEqual(await l2Token.balanceOf(withdrawer), DEPOSIT_AMOUNT, "withdrawer L2 balance");
+    expectEqual(await l1Token.balanceOf(depositor), FUND_AMOUNT.sub(DEPOSIT_AMOUNT), "depositor L1 balance");
+    expectEqual(await getL1BridgedOut(l1RpcUrl, l1Ntv.address, l1TokenAssetId), DEPOSIT_AMOUNT, "bridgedOut");
+  });
+
+  it("withdraws to L1 several times from the SampleWithdrawer", async () => {
+    const interopCenter = new ethers.utils.Interface(getAbi("InteropCenter"));
+    const l1Nullifier = new Contract(state.l1Addresses!.l1NullifierProxy, getAbi("L1Nullifier"), l1Provider);
+    const l1InteropHandler = new Contract(await l1Nullifier.l1InteropHandler(), getAbi("L1InteropHandler"), l1Provider);
+    const bundleHashes = new Set<string>();
+    let withdrawnTotal = ethers.constants.Zero;
+
+    for (const [index, { amount, l1Recipient }] of WITHDRAWALS.entries()) {
+      console.log(
+        `\n   Withdrawal ${index + 1}/${WITHDRAWALS.length}: ${ethers.utils.formatUnits(amount)} -> ${l1Recipient}`
+      );
+      const recipientBefore: BigNumber = await l1Token.balanceOf(l1Recipient);
+
+      await runScript("WithdrawToL1.s.sol", l2RpcUrl, {
+        WITHDRAWER: withdrawer,
+        L1_TOKEN: l1Token.address,
+        AMOUNT: amount.toString(),
+        L1_RECIPIENT: l1Recipient,
+      });
+      const l2TxHash = lastTransactionHash(readLatestBroadcast(L1_CONTRACTS_DIR, "WithdrawToL1.s.sol", chainId));
+      console.log(`   L2 withdraw tx: cast run ${l2TxHash} -r ${l2RpcUrl}`);
+
+      // The bundle the InteropCenter emitted is what gets executed on L1, byte for byte.
+      const receipt = await l2Provider.getTransactionReceipt(l2TxHash);
+      const sent = receipt.logs
+        .map((log) => {
+          try {
+            return interopCenter.parseLog(log);
+          } catch {
+            return undefined;
+          }
+        })
+        .find((parsed) => parsed?.name === "InteropBundleSent");
+      if (!sent) {
+        throw new Error(`InteropBundleSent not found in ${l2TxHash}`);
+      }
+      const bundleHash: string = sent.args.interopBundleHash;
+      const bundleData = ethers.utils.defaultAbiCoder.encode([INTEROP_BUNDLE_TUPLE_TYPE], [sent.args.interopBundle]);
+      expect(bundleHashes.has(bundleHash), "each withdrawal should produce a distinct bundle").to.equal(false);
+      bundleHashes.add(bundleHash);
+
+      // Stand-in for the chain's server + the L1 finalizer: prove the bundle's inclusion and execute it on L1.
+      const result = await finalizeWithdrawalOnL1(l1RpcUrl, state.l1Addresses!, {
+        l2TxHash,
+        chainId,
+        amount,
+        l1Recipient,
+        tokenAddress: l1Token.address,
+        bundleData,
+      });
+      expect(result.success, `L1 finalization should succeed: ${result.errorMessage ?? ""}`).to.equal(true);
+
+      withdrawnTotal = withdrawnTotal.add(amount);
+      expectEqual((await l1Token.balanceOf(l1Recipient)).sub(recipientBefore), amount, "recipient L1 balance delta");
+      expect(await l1InteropHandler.bundleStatus(bundleHash), "bundle status").to.equal(BundleStatus.FullyExecuted);
+    }
+
+    const sampleWithdrawer = new Contract(
+      withdrawer,
+      ["function withdrawalCount() view returns (uint256)"],
+      l2Provider
+    );
+    expectEqual(await sampleWithdrawer.withdrawalCount(), ethers.BigNumber.from(WITHDRAWALS.length), "withdrawalCount");
+    expectEqual(await l2Token.balanceOf(withdrawer), DEPOSIT_AMOUNT.sub(withdrawnTotal), "withdrawer L2 balance");
+    expectEqual(
+      await getL1BridgedOut(l1RpcUrl, state.l1Addresses!.l1NativeTokenVault, l1TokenAssetId),
+      DEPOSIT_AMOUNT.sub(withdrawnTotal),
+      "bridgedOut"
+    );
+  });
+});
+
+function expectEqual(actual: BigNumber, expected: BigNumber, label: string): void {
+  expect(actual.eq(expected), `${label}: expected ${expected.toString()}, got ${actual.toString()}`).to.equal(true);
+}

--- a/l1-contracts/examples/sample-depositor/tsconfig.json
+++ b/l1-contracts/examples/sample-depositor/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "types": ["node", "mocha"]
+  },
+  "include": ["scripts/**/*", "test/**/*"]
+}

--- a/l1-contracts/package.json
+++ b/l1-contracts/package.json
@@ -65,6 +65,7 @@
     "test": "yarn workspace da-contracts build && hardhat test test/unit_tests/*.spec.ts --network hardhat",
     "test:hardhat": "yarn test:hardhat:interop",
     "test:hardhat:interop": "ts-node test/anvil-interop/run-hardhat-interop-test.ts",
+    "example:sample-depositor": "ts-node test/anvil-interop/run-hardhat-interop-test.ts --spec examples/sample-depositor/test/sample-depositor.spec.ts",
     "test:foundry": "forge test --threads 1 --ffi --match-path 'test/foundry/{l1,zksync-os}/*' --no-match-test 'test_DefaultUpgrade_MainnetFork' --no-match-contract 'ChainRegistrarTest'",
     "test:zkfoundry": "forge test --zksync --match-path 'test/foundry/l2/*' --gas-limit 20000000000 --skip 'test/foundry/l1/*' '*/L2BaseToken.sol' '*/Burner.sol' '*/L2GenesisUpgrade.t.sol'",
     "test:mainnet-upgrade-fork": "forge test --match-test test_DefaultUpgrade_MainnetFork --ffi --rpc-url $INFURA_MAINNET --gas-limit 2000000000",


### PR DESCRIPTION
## What

An example under `l1-contracts/examples/sample-depositor/` that exercises the v33 deposit and withdrawal paths end to end with two small contracts:

- **`SampleDepositor`** (L1): holds an ERC20 (e.g. USDC on Sepolia) and bridges a given amount to an address on a ZK chain via `Bridgehub.requestL2TransactionTwoBridges` + `L1AssetRouter` (the L1NativeTokenVault pulls the tokens from the contract).
- **`SampleWithdrawer`** (L2): receives the bridged token and withdraws a given amount to a given L1 address as a non-atomic interop bundle (`InteropCenter.sendBundle` to the L1 chain id, single indirect call into the `L2AssetRouter`). Each withdrawal uses a fresh `interopBundleSalt` (the withdrawal counter), since a salt is one-shot per sender.

Both contracts are deployed and driven with forge scripts (`script/*.s.sol`, env-var driven), so the same commands work against the local anvil-interop chains and against Sepolia + a live ZK chain. The pieces a chain's server does in production are covered in TypeScript:

- `test/sample-depositor.spec.ts` runs against anvil-interop (`yarn example:sample-depositor`): deploys via the forge scripts, bridges 1000 test tokens, then sends **three withdrawals** (100 / 250 / 400 to two L1 recipients), finalizing each on L1 through `L1InteropHandler.executeBundle` and checking balances, `bridgedOut` and bundle statuses. The harness relays the priority tx and mocks the inclusion proof.
- `scripts/finalize-withdrawal.ts` waits for the real inclusion proof (`zks_getL2ToL1LogProof`) and executes the bundle on a live L1.

The README walks through the local run and the Sepolia flow (deploy → bridge → withdraw N times → finalize each).

## Testing

- `yarn example:sample-depositor` (direct-settled chain 10): 2 passing.
- `SAMPLE_L2_CHAIN_ID=12` against the same chains (gateway-settled path, relay L1 → GW → L2): 2 passing.
- `forge build`, `solhint`, `eslint`, `prettier`, `markdownlint` clean on the new files.
- Not exercised against Sepolia: `scripts/finalize-withdrawal.ts` reuses the harness's live-proof helpers (`temp-sdk.ts`) but has only been run for its argument handling.

## Notes

- The spec lives outside `test/anvil-interop/test/hardhat/`, so it is not auto-discovered by the anvil-interop CI matrix; it is run explicitly with `--spec`.
- Only ETH-base-token destination chains are supported (the depositor pays the L2 gas with the ETH sent along).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
