### PR TITLE
ci: register remaining v31 dispatch workflows

### DIFF
--- a/.github/workflows/execute-deployer-safe-bundles.yaml
+++ b/.github/workflows/execute-deployer-safe-bundles.yaml
@@ -1,0 +1,15 @@
+name: "Execute Deployer Safe Bundles"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: List repository contents
+        run: ls -a

--- a/.github/workflows/generate-chain-add-validator-calldata.yaml
+++ b/.github/workflows/generate-chain-add-validator-calldata.yaml
@@ -1,0 +1,15 @@
+name: "Generate Chain Add Validator Calldata"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: List repository contents
+        run: ls -a

--- a/.github/workflows/generate-chain-init-calldata.yaml
+++ b/.github/workflows/generate-chain-init-calldata.yaml
@@ -1,0 +1,15 @@
+name: "Generate Chain Init Calldata"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: List repository contents
+        run: ls -a

--- a/.github/workflows/generate-chain-remove-validator-calldata.yaml
+++ b/.github/workflows/generate-chain-remove-validator-calldata.yaml
@@ -1,0 +1,15 @@
+name: "Generate Chain Remove Validator Calldata"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: List repository contents
+        run: ls -a

--- a/.github/workflows/generate-chain-set-upgrade-timestamp-calldata.yaml
+++ b/.github/workflows/generate-chain-set-upgrade-timestamp-calldata.yaml
@@ -1,0 +1,15 @@
+name: "Generate Chain Set Upgrade Timestamp Calldata"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: List repository contents
+        run: ls -a

--- a/.github/workflows/generate-chain-upgrade-calldata.yaml
+++ b/.github/workflows/generate-chain-upgrade-calldata.yaml
@@ -1,0 +1,15 @@
+name: "Generate Chain Upgrade Calldata"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: List repository contents
+        run: ls -a

--- a/.github/workflows/generate-gateway-convert-calldata.yaml
+++ b/.github/workflows/generate-gateway-convert-calldata.yaml
@@ -1,0 +1,15 @@
+name: "Generate Gateway Convert Calldata"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: List repository contents
+        run: ls -a

--- a/.github/workflows/generate-migrate-from-gw-phase0-pause.yaml
+++ b/.github/workflows/generate-migrate-from-gw-phase0-pause.yaml
@@ -1,0 +1,15 @@
+name: "Generate Migrate From Gateway Phase 0 Pause"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: List repository contents
+        run: ls -a

--- a/.github/workflows/generate-migrate-from-gw-phase1-submit.yaml
+++ b/.github/workflows/generate-migrate-from-gw-phase1-submit.yaml
@@ -1,0 +1,15 @@
+name: "Generate Migrate From Gateway Phase 1 Submit"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: List repository contents
+        run: ls -a

--- a/.github/workflows/generate-migrate-from-gw-phase2-finalize.yaml
+++ b/.github/workflows/generate-migrate-from-gw-phase2-finalize.yaml
@@ -1,0 +1,15 @@
+name: "Generate Migrate From Gateway Phase 2 Finalize"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: List repository contents
+        run: ls -a

--- a/.github/workflows/generate-migrate-from-gw-phase3-set-da.yaml
+++ b/.github/workflows/generate-migrate-from-gw-phase3-set-da.yaml
@@ -1,0 +1,15 @@
+name: "Generate Migrate From Gateway Phase 3 Set DA"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: List repository contents
+        run: ls -a

--- a/.github/workflows/generate-migrate-to-gw-phase0-pause.yaml
+++ b/.github/workflows/generate-migrate-to-gw-phase0-pause.yaml
@@ -1,0 +1,15 @@
+name: "Generate Migrate To Gateway Phase 0 Pause"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: List repository contents
+        run: ls -a

--- a/.github/workflows/generate-migrate-to-gw-phase1-submit.yaml
+++ b/.github/workflows/generate-migrate-to-gw-phase1-submit.yaml
@@ -1,0 +1,15 @@
+name: "Generate Migrate To Gateway Phase 1 Submit"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: List repository contents
+        run: ls -a

--- a/.github/workflows/generate-migrate-to-gw-phase2-finalize.yaml
+++ b/.github/workflows/generate-migrate-to-gw-phase2-finalize.yaml
@@ -1,0 +1,15 @@
+name: "Generate Migrate To Gateway Phase 2 Finalize"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: List repository contents
+        run: ls -a

--- a/.github/workflows/generate-migrate-to-gw-phase3-validators.yaml
+++ b/.github/workflows/generate-migrate-to-gw-phase3-validators.yaml
@@ -1,0 +1,15 @@
+name: "Generate Migrate To Gateway Phase 3 Validators"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: List repository contents
+        run: ls -a

--- a/.github/workflows/generate-upgrade-calldata-governance.yaml
+++ b/.github/workflows/generate-upgrade-calldata-governance.yaml
@@ -1,0 +1,15 @@
+name: "Generate Upgrade Calldata Governance"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: List repository contents
+        run: ls -a

--- a/.github/workflows/generate-upgrade-calldata-prepare.yaml
+++ b/.github/workflows/generate-upgrade-calldata-prepare.yaml
@@ -1,0 +1,15 @@
+name: "Generate Upgrade Calldata Prepare"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: List repository contents
+        run: ls -a


### PR DESCRIPTION
Adds the remaining v31 workflow paths to `main` as lightweight `workflow_dispatch` stubs.

This follows the same pattern already used in #2358. Since GitHub only exposes manually triggered workflows when the workflow file exists on the default branch, these stubs make the remaining v31 workflows available for dispatch without moving the full release-specific logic into `main`.

The real workflow implementations still live on the relevant v31 branches. This PR only adds the registration stubs for the remaining chain, validator, gateway, governance, and migration workflows.

No contract code or existing workflow logic is changed.